### PR TITLE
fix(provider): inject env explicitly into RuntimeProviderRegistry (#1050)

### DIFF
--- a/src/cli/commands/analytics.py
+++ b/src/cli/commands/analytics.py
@@ -313,11 +313,12 @@ def run(args: argparse.Namespace) -> None:
                 # branch above only lists existing verdicts; this is the single
                 # entry point that invokes ChannelAnalysisService.classify_channel.
                 from src.services.channel_analysis_service import ChannelAnalysisService
-                from src.services.provider_service import RuntimeProviderRegistry
+                from src.services.provider_service import build_provider_service
 
                 channel_id = args.channel_id
-                provider_service = RuntimeProviderRegistry(db, config)
-                await provider_service.load_db_providers()
+                # build_provider_service snapshots os.environ once and loads DB
+                # providers; the registry no longer reads env itself (#1050).
+                provider_service = await build_provider_service(db, config)
                 if not provider_service.has_providers():
                     print(
                         "LLM provider is not configured. Add one with `provider add`, in the web "

--- a/src/cli/commands/pipeline.py
+++ b/src/cli/commands/pipeline.py
@@ -387,11 +387,12 @@ def run(args: argparse.Namespace) -> None:
                     return
                 engine = SearchEngine(db)
 
-                from src.services.provider_service import RuntimeProviderRegistry
+                from src.services.provider_service import build_provider_service
                 from src.services.quality_scoring_service import QualityScoringService
 
-                provider_service = RuntimeProviderRegistry(db, config)
-                await provider_service.load_db_providers()
+                # build_provider_service snapshots os.environ once and loads DB
+                # providers; the registry no longer reads env itself (#1050).
+                provider_service = await build_provider_service(db, config)
                 if pipeline_needs_llm(pipeline) and not provider_service.has_providers():
                     print(
                         "LLM provider is not configured. Add one in /settings or set an API key "
@@ -439,11 +440,12 @@ def run(args: argparse.Namespace) -> None:
                     print(f"Pipeline id={args.id} not found")
                     return
                 engine = SearchEngine(db)
-                from src.services.provider_service import RuntimeProviderRegistry
+                from src.services.provider_service import build_provider_service
                 from src.services.quality_scoring_service import QualityScoringService
 
-                provider_svc = RuntimeProviderRegistry(db, config)
-                await provider_svc.load_db_providers()
+                # build_provider_service snapshots os.environ once and loads DB
+                # providers; the registry no longer reads env itself (#1050).
+                provider_svc = await build_provider_service(db, config)
                 if pipeline_needs_llm(pipeline) and not provider_svc.has_providers():
                     print(
                         "LLM provider is not configured. Add one in /settings or set an API key "
@@ -487,11 +489,12 @@ def run(args: argparse.Namespace) -> None:
                     return
 
                 from src.services.generation_service import GenerationService
-                from src.services.provider_service import RuntimeProviderRegistry
+                from src.services.provider_service import build_provider_service
                 from src.utils.json import safe_json_dumps
 
-                provider_service = RuntimeProviderRegistry(db, config)
-                await provider_service.load_db_providers()
+                # build_provider_service snapshots os.environ once and loads DB
+                # providers; the registry no longer reads env itself (#1050).
+                provider_service = await build_provider_service(db, config)
                 if pipeline_needs_llm(pipeline) and not provider_service.has_providers():
                     print(
                         "LLM provider is not configured. Add one in /settings or set an API key "

--- a/src/services/provider_service.py
+++ b/src/services/provider_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Awaitable, Callable, Dict, Optional
+from typing import Any, Awaitable, Callable, Dict, Mapping, Optional
 
 from src.agent.provider_registry import (
     ProviderRuntimeConfig,
@@ -18,9 +18,20 @@ logger = logging.getLogger(__name__)
 async def build_provider_service(
     db: object | None = None,
     config: object | None = None,
+    env: Mapping[str, str] | None = None,
 ) -> "RuntimeProviderRegistry":
-    """Create RuntimeProviderRegistry and eagerly load DB-backed providers when possible."""
-    svc = RuntimeProviderRegistry(db, config)
+    """Create RuntimeProviderRegistry and eagerly load DB-backed providers when possible.
+
+    ``env`` is the explicit environment mapping the registry registers env-based
+    providers from. The registry itself never reads ``os.environ`` (that global
+    process state coupling was the root cause of the #1050 parallel flake); this
+    factory snapshots ``os.environ`` exactly once when ``env`` is not supplied, so
+    production call-sites keep their env-based providers while tests can inject an
+    explicit (and isolated) mapping.
+    """
+    if env is None:
+        env = dict(os.environ)
+    svc = RuntimeProviderRegistry(db, config, env=env)
     if db is not None and config is not None:
         await svc.load_db_providers()
     return svc
@@ -47,9 +58,22 @@ class RuntimeProviderRegistry:
     env-based ones.
     """
 
-    def __init__(self, db: Optional[object] = None, config: Optional[object] = None) -> None:
+    def __init__(
+        self,
+        db: Optional[object] = None,
+        config: Optional[object] = None,
+        *,
+        env: Mapping[str, str] | None = None,
+    ) -> None:
         self.db = db
         self._config = config
+        # Env is injected explicitly. The registry NEVER reads the process
+        # environment: doing so coupled provider registration to shared process
+        # state, which under ``pytest -n auto`` let a neighbouring xdist worker's
+        # env mutations leak in and produce a non-deterministic provider set
+        # (#1050). ``env=None`` means "no env-based providers" — pulling env from
+        # the process is the caller's / factory's job (see build_provider_service).
+        self._env: dict[str, str] = dict(env) if env is not None else {}
         self._registry: Dict[str, Callable[..., Awaitable[str]]] = {}
         self._db_provider_names: set[str] = set()
         # register default provider
@@ -57,17 +81,17 @@ class RuntimeProviderRegistry:
         self._register_env_providers()
 
     def _register_env_providers(self) -> None:
-        """Register providers from environment variables (original behaviour)."""
+        """Register providers from the injected env mapping (``self._env``)."""
         # Optional OpenAI provider. Runtime calls go through LangChain so the
         # app uses the same model integration path as DeepAgents.
-        openai_key = os.environ.get("OPENAI_API_KEY")
+        openai_key = self._env.get("OPENAI_API_KEY")
         if openai_key:
             self.register_provider("openai", self._make_openai_provider(openai_key))
 
         # optional Z.AI provider. ZAI_BASE_URL is optional; empty value means
         # the subscription/Coding Plan endpoint.
-        zai_key = os.environ.get("ZAI_API_KEY")
-        zai_base = normalize_zai_base_url(os.environ.get("ZAI_BASE_URL") or "")
+        zai_key = self._env.get("ZAI_API_KEY")
+        zai_base = normalize_zai_base_url(self._env.get("ZAI_BASE_URL") or "")
         if zai_key and "zai" not in self._registry:
             try:
                 self.register_provider(
@@ -83,7 +107,7 @@ class RuntimeProviderRegistry:
                 logger.debug("Failed to register zai adapter", exc_info=True)
 
         # optional Context7 provider (user may supply CONTEXT7_API_KEY)
-        context7_key = os.environ.get("CONTEXT7_API_KEY") or os.environ.get("CTX7_API_KEY")
+        context7_key = self._env.get("CONTEXT7_API_KEY") or self._env.get("CTX7_API_KEY")
         if context7_key:
             try:
                 from src.services.provider_adapters import make_context7_adapter
@@ -95,7 +119,7 @@ class RuntimeProviderRegistry:
         # Register LangChain-backed adapters when env vars are present. Each
         # provider is isolated so one bad env config does not block the rest.
         env_adapters: list[tuple[str, Callable[[], Callable[..., Awaitable[str]]]]] = []
-        cohere_key = os.environ.get("COHERE_API_KEY")
+        cohere_key = self._env.get("COHERE_API_KEY")
         if cohere_key and "cohere" not in self._registry:
             env_adapters.append(
                 (
@@ -106,8 +130,8 @@ class RuntimeProviderRegistry:
                 )
             )
 
-        ollama_base = os.environ.get("OLLAMA_BASE") or os.environ.get("OLLAMA_URL")
-        ollama_key = os.environ.get("OLLAMA_API_KEY", "")
+        ollama_base = self._env.get("OLLAMA_BASE") or self._env.get("OLLAMA_URL")
+        ollama_key = self._env.get("OLLAMA_API_KEY", "")
         if (ollama_base or ollama_key) and "ollama" not in self._registry:
             env_adapters.append(
                 (
@@ -122,7 +146,7 @@ class RuntimeProviderRegistry:
                 )
             )
 
-        hf_key = os.environ.get("HUGGINGFACE_API_KEY") or os.environ.get("HUGGINGFACE_TOKEN")
+        hf_key = self._env.get("HUGGINGFACE_API_KEY") or self._env.get("HUGGINGFACE_TOKEN")
         if hf_key and "huggingface" not in self._registry:
             env_adapters.append(
                 (
@@ -136,18 +160,18 @@ class RuntimeProviderRegistry:
         openai_compatible_env = (
             (
                 "fireworks",
-                os.environ.get("FIREWORKS_BASE") or os.environ.get("FIREWORKS_API_BASE"),
-                os.environ.get("FIREWORKS_API_KEY"),
+                self._env.get("FIREWORKS_BASE") or self._env.get("FIREWORKS_API_BASE"),
+                self._env.get("FIREWORKS_API_KEY"),
             ),
             (
                 "deepseek",
-                os.environ.get("DEEPSEEK_BASE") or os.environ.get("DEEPSEEK_API_BASE"),
-                os.environ.get("DEEPSEEK_API_KEY"),
+                self._env.get("DEEPSEEK_BASE") or self._env.get("DEEPSEEK_API_BASE"),
+                self._env.get("DEEPSEEK_API_KEY"),
             ),
             (
                 "together",
-                os.environ.get("TOGETHER_BASE") or os.environ.get("TOGETHER_API_BASE"),
-                os.environ.get("TOGETHER_API_KEY"),
+                self._env.get("TOGETHER_BASE") or self._env.get("TOGETHER_API_BASE"),
+                self._env.get("TOGETHER_API_KEY"),
             ),
         )
         for provider_name, base_env, key_env in openai_compatible_env:
@@ -484,10 +508,10 @@ class RuntimeProviderRegistry:
 
     def _make_openai_provider(self, api_key: str) -> Callable[..., Awaitable[str]]:
         return self._make_openai_compat_provider(
-            os.environ.get("OPENAI_API_BASE", "https://api.openai.com/v1"),
+            self._env.get("OPENAI_API_BASE", "https://api.openai.com/v1"),
             api_key,
             provider_name="openai",
-            default_model=os.environ.get("OPENAI_DEFAULT_MODEL", "gpt-3.5-turbo"),
+            default_model=self._env.get("OPENAI_DEFAULT_MODEL", "gpt-3.5-turbo"),
         )
 
     async def _default_provider(self, **kwargs: Any) -> str:

--- a/src/web/bootstrap.py
+++ b/src/web/bootstrap.py
@@ -282,7 +282,9 @@ async def build_container_with_templates(
 
     from src.services.provider_service import RuntimeProviderRegistry
 
-    llm_provider_service = RuntimeProviderRegistry(db, config)
+    # Snapshot the process env once here and inject it: the registry no longer
+    # reads os.environ itself (root-cause fix for the #1050 parallel flake).
+    llm_provider_service = RuntimeProviderRegistry(db, config, env=dict(os.environ))
     await llm_provider_service.load_db_providers()
 
     if runtime_mode == "worker":

--- a/src/web/deps.py
+++ b/src/web/deps.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TypeVar
@@ -312,7 +313,7 @@ def get_llm_provider_service(request: Request) -> RuntimeProviderRegistry:
     svc = getattr(request.app.state, "llm_provider_service", None)
     if svc is not None:
         return svc
-    return get_container(request).llm_provider_service or RuntimeProviderRegistry()
+    return get_container(request).llm_provider_service or RuntimeProviderRegistry(env=dict(os.environ))
 
 
 def channel_service(request: Request) -> ChannelService:

--- a/tests/test_provider_runtime_integration.py
+++ b/tests/test_provider_runtime_integration.py
@@ -407,9 +407,11 @@ async def test_deepagents_chat_runs_real_init_chat_model_and_create_deep_agent(
     reason="Set RUN_REAL_PROVIDER_SMOKE=1 and ZAI_API_KEY to run live provider smoke.",
 )
 @pytest.mark.anyio
-async def test_live_zai_default_adapter_smoke(monkeypatch):
-    monkeypatch.setenv("ZAI_API_KEY", os.environ["ZAI_API_KEY"])
-    service = RuntimeProviderService()
+async def test_live_zai_default_adapter_smoke():
+    # Live smoke: inject the real key explicitly. The registry no longer reads
+    # os.environ itself (#1050), so the env arrives as an explicit mapping here
+    # — the gate above guarantees ZAI_API_KEY is present.
+    service = RuntimeProviderService(env={"ZAI_API_KEY": os.environ["ZAI_API_KEY"]})
     provider = service.get_provider_callable("zai")
 
     response = await provider(

--- a/tests/test_provider_service.py
+++ b/tests/test_provider_service.py
@@ -3,42 +3,12 @@
 from __future__ import annotations
 
 import asyncio
-import os
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from src.services.provider_service import RuntimeProviderRegistry
-
-
-@pytest.fixture(autouse=True)
-def clean_env():
-    """Clean environment variables before each test."""
-    # Save original values
-    saved = {}
-    env_vars = [
-        "OPENAI_API_KEY", "COHERE_API_KEY", "OLLAMA_BASE", "OLLAMA_URL",
-        "HUGGINGFACE_API_KEY", "HUGGINGFACE_TOKEN", "FIREWORKS_BASE",
-        "FIREWORKS_API_BASE", "FIREWORKS_API_KEY", "DEEPSEEK_BASE",
-        "DEEPSEEK_API_BASE", "DEEPSEEK_API_KEY", "TOGETHER_BASE",
-        "TOGETHER_API_BASE", "TOGETHER_API_KEY", "CONTEXT7_API_KEY",
-        "CTX7_API_KEY",
-    ]
-    for var in env_vars:
-        saved[var] = os.environ.get(var)
-        if var in os.environ:
-            del os.environ[var]
-
-    yield
-
-    # Restore original values
-    for var, val in saved.items():
-        if val is None:
-            os.environ.pop(var, None)
-        else:
-            os.environ[var] = val
-
 
 # === Default provider tests ===
 
@@ -137,15 +107,14 @@ def test_resolve_provider_callable_no_name_uses_first_real():
 # === OpenAI provider tests ===
 
 
-def test_openai_provider_registered_with_api_key(clean_env):
+def test_openai_provider_registered_with_api_key():
     """OpenAI provider registered when API key present."""
-    os.environ["OPENAI_API_KEY"] = "test_key"
-    svc = RuntimeProviderRegistry()
+    svc = RuntimeProviderRegistry(env={"OPENAI_API_KEY": "test_key"})
     provider = svc.get_provider_callable("openai")
     assert provider is not None
 
 
-def test_openai_provider_not_registered_without_key(clean_env):
+def test_openai_provider_not_registered_without_key():
     """OpenAI provider not registered without API key."""
     svc = RuntimeProviderRegistry()
     # openai shouldn't be in registry
@@ -153,9 +122,8 @@ def test_openai_provider_not_registered_without_key(clean_env):
 
 
 @pytest.mark.anyio
-async def test_openai_provider_calls_api(clean_env):
+async def test_openai_provider_calls_api():
     """OpenAI provider calls LangChain chat runtime with expected options."""
-    os.environ["OPENAI_API_KEY"] = "test_key"
     captured = {}
 
     class FakeChatModel:
@@ -168,7 +136,7 @@ async def test_openai_provider_calls_api(clean_env):
         return FakeChatModel()
 
     with patch("langchain.chat_models.init_chat_model", fake_init_chat_model):
-        svc = RuntimeProviderRegistry()
+        svc = RuntimeProviderRegistry(env={"OPENAI_API_KEY": "test_key"})
         provider = svc.get_provider_callable("openai")
         result = await provider(prompt="hi")
 
@@ -180,12 +148,10 @@ async def test_openai_provider_calls_api(clean_env):
 
 
 @pytest.mark.anyio
-async def test_openai_provider_error_status(clean_env):
+async def test_openai_provider_error_status():
     """OpenAI provider propagates LangChain runtime errors."""
-    os.environ["OPENAI_API_KEY"] = "test_key"
-
     with patch("langchain.chat_models.init_chat_model", side_effect=RuntimeError("OpenAI error 401")):
-        svc = RuntimeProviderRegistry()
+        svc = RuntimeProviderRegistry(env={"OPENAI_API_KEY": "test_key"})
         provider = svc.get_provider_callable("openai")
 
         with pytest.raises(RuntimeError) as exc_info:
@@ -196,17 +162,16 @@ async def test_openai_provider_error_status(clean_env):
 # === GPT model routing tests ===
 
 
-def test_gpt_model_routes_to_openai(clean_env):
+def test_gpt_model_routes_to_openai():
     """GPT model names route to OpenAI provider."""
-    os.environ["OPENAI_API_KEY"] = "test_key"
-    svc = RuntimeProviderRegistry()
+    svc = RuntimeProviderRegistry(env={"OPENAI_API_KEY": "test_key"})
 
     # gpt-4 should create a wrapper that uses openai provider
     provider = svc.get_provider_callable("gpt-4")
     assert provider is not None
 
 
-def test_gpt_model_without_openai_key_falls_back(clean_env):
+def test_gpt_model_without_openai_key_falls_back():
     """GPT model without OpenAI key falls back to default."""
     svc = RuntimeProviderRegistry()
     provider = svc.get_provider_callable("gpt-4-turbo")
@@ -219,76 +184,69 @@ def test_gpt_model_without_openai_key_falls_back(clean_env):
 # === Other provider registration tests ===
 
 
-def test_cohere_registered_with_api_key(clean_env):
+def test_cohere_registered_with_api_key():
     """Cohere provider registered when API key present."""
-    os.environ["COHERE_API_KEY"] = "cohere_key"
-    svc = RuntimeProviderRegistry()
+    svc = RuntimeProviderRegistry(env={"COHERE_API_KEY": "cohere_key"})
     assert "cohere" in svc._registry
 
 
-def test_ollama_registered_with_base_url(clean_env):
+def test_ollama_registered_with_base_url():
     """Ollama provider registered when base URL present."""
-    os.environ["OLLAMA_BASE"] = "http://localhost:11434"
-    svc = RuntimeProviderRegistry()
+    svc = RuntimeProviderRegistry(env={"OLLAMA_BASE": "http://localhost:11434"})
     assert "ollama" in svc._registry
 
 
-def test_ollama_registered_with_ollama_url(clean_env):
+def test_ollama_registered_with_ollama_url():
     """Ollama provider registered with OLLAMA_URL fallback."""
-    os.environ["OLLAMA_URL"] = "http://ollama.local"
-    svc = RuntimeProviderRegistry()
+    svc = RuntimeProviderRegistry(env={"OLLAMA_URL": "http://ollama.local"})
     assert "ollama" in svc._registry
 
 
-def test_huggingface_registered_with_api_key(clean_env):
+def test_huggingface_registered_with_api_key():
     """HuggingFace provider registered when API key present."""
-    os.environ["HUGGINGFACE_API_KEY"] = "hf_key"
-    svc = RuntimeProviderRegistry()
+    svc = RuntimeProviderRegistry(env={"HUGGINGFACE_API_KEY": "hf_key"})
     assert "huggingface" in svc._registry
 
 
-def test_huggingface_registered_with_token(clean_env):
+def test_huggingface_registered_with_token():
     """HuggingFace provider registered with HUGGINGFACE_TOKEN fallback."""
-    os.environ["HUGGINGFACE_TOKEN"] = "hf_token"
-    svc = RuntimeProviderRegistry()
+    svc = RuntimeProviderRegistry(env={"HUGGINGFACE_TOKEN": "hf_token"})
     assert "huggingface" in svc._registry
 
 
-def test_fireworks_registered(clean_env):
+def test_fireworks_registered():
     """Fireworks provider registered with base URL and key."""
-    os.environ["FIREWORKS_BASE"] = "https://fireworks.api"
-    os.environ["FIREWORKS_API_KEY"] = "fw_key"
-    svc = RuntimeProviderRegistry()
+    svc = RuntimeProviderRegistry(
+        env={"FIREWORKS_BASE": "https://fireworks.api", "FIREWORKS_API_KEY": "fw_key"}
+    )
     assert "fireworks" in svc._registry
 
 
-def test_deepseek_registered(clean_env):
+def test_deepseek_registered():
     """DeepSeek provider registered with base URL and key."""
-    os.environ["DEEPSEEK_BASE"] = "https://deepseek.api"
-    os.environ["DEEPSEEK_API_KEY"] = "ds_key"
-    svc = RuntimeProviderRegistry()
+    svc = RuntimeProviderRegistry(
+        env={"DEEPSEEK_BASE": "https://deepseek.api", "DEEPSEEK_API_KEY": "ds_key"}
+    )
     assert "deepseek" in svc._registry
 
 
-def test_together_registered(clean_env):
+def test_together_registered():
     """Together provider registered with base URL and key."""
-    os.environ["TOGETHER_BASE"] = "https://together.api"
-    os.environ["TOGETHER_API_KEY"] = "tg_key"
-    svc = RuntimeProviderRegistry()
+    svc = RuntimeProviderRegistry(
+        env={"TOGETHER_BASE": "https://together.api", "TOGETHER_API_KEY": "tg_key"}
+    )
     assert "together" in svc._registry
 
 
-def test_context7_registered_with_api_key(clean_env):
+def test_context7_registered_with_api_key():
     """Context7 provider registered when API key present."""
-    os.environ["CONTEXT7_API_KEY"] = "c7_key"
-    svc = RuntimeProviderRegistry()
+    svc = RuntimeProviderRegistry(env={"CONTEXT7_API_KEY": "c7_key"})
     assert "context7" in svc._registry
 
 
-def test_context7_registered_with_ctx7_fallback(clean_env):
+def test_context7_registered_with_ctx7_fallback():
     """Context7 provider registered with CTX7_API_KEY fallback."""
-    os.environ["CTX7_API_KEY"] = "ctx7_key"
-    svc = RuntimeProviderRegistry()
+    svc = RuntimeProviderRegistry(env={"CTX7_API_KEY": "ctx7_key"})
     assert "context7" in svc._registry
 
 
@@ -303,7 +261,7 @@ def test_provider_service_with_db():
     assert svc.db is mock_db
 
 
-def test_multiple_providers_same_type(clean_env):
+def test_multiple_providers_same_type():
     """Can register multiple providers of same type with different names."""
     svc = RuntimeProviderRegistry()
 
@@ -323,7 +281,7 @@ def test_multiple_providers_same_type(clean_env):
     assert result2 == "Provider 2"
 
 
-def test_provider_override(clean_env):
+def test_provider_override():
     """Can override existing provider."""
     svc = RuntimeProviderRegistry()
 
@@ -336,19 +294,17 @@ def test_provider_override(clean_env):
     assert result == "New default"
 
 
-def test_gpt_lowercase_routing(clean_env):
+def test_gpt_lowercase_routing():
     """Lowercase gpt model names route to OpenAI."""
-    os.environ["OPENAI_API_KEY"] = "test_key"
-    svc = RuntimeProviderRegistry()
+    svc = RuntimeProviderRegistry(env={"OPENAI_API_KEY": "test_key"})
 
     provider = svc.get_provider_callable("gpt-3.5-turbo")
     assert provider is not None
 
 
-def test_gpt_uppercase_routing(clean_env):
+def test_gpt_uppercase_routing():
     """Uppercase GPT model names route to OpenAI."""
-    os.environ["OPENAI_API_KEY"] = "test_key"
-    svc = RuntimeProviderRegistry()
+    svc = RuntimeProviderRegistry(env={"OPENAI_API_KEY": "test_key"})
 
     provider = svc.get_provider_callable("GPT-4")
     assert provider is not None

--- a/tests/test_provider_service_adapters.py
+++ b/tests/test_provider_service_adapters.py
@@ -1,7 +1,6 @@
 """Tests for provider service adapter registration and failure paths."""
 from __future__ import annotations
 
-import os
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -9,81 +8,56 @@ import pytest
 
 from src.services.provider_service import RuntimeProviderRegistry
 
-
-@pytest.fixture(autouse=True)
-def clean_env():
-    saved = {}
-    for var in [
-        "OPENAI_API_KEY", "COHERE_API_KEY", "OLLAMA_BASE", "OLLAMA_URL",
-        "HUGGINGFACE_API_KEY", "HUGGINGFACE_TOKEN", "FIREWORKS_BASE",
-        "FIREWORKS_API_BASE", "FIREWORKS_API_KEY", "DEEPSEEK_BASE",
-        "DEEPSEEK_API_BASE", "DEEPSEEK_API_KEY", "TOGETHER_BASE",
-        "TOGETHER_API_BASE", "TOGETHER_API_KEY", "CONTEXT7_API_KEY",
-        "CTX7_API_KEY", "ZAI_API_KEY", "ZAI_BASE_URL",
-    ]:
-        saved[var] = os.environ.get(var)
-        if var in os.environ:
-            del os.environ[var]
-    yield
-    for var, val in saved.items():
-        if val is None:
-            os.environ.pop(var, None)
-        else:
-            os.environ[var] = val
-
-
 # === Z.AI registration failure ===
 
 
-def test_zai_registration_failure_path(clean_env):
+def test_zai_registration_failure_path():
     """Z.AI adapter registration failure is caught gracefully."""
-    os.environ["ZAI_API_KEY"] = "zai-test-key"
-    os.environ["ZAI_BASE_URL"] = "https://api.z.ai/api/coding/paas/v4"
     with patch.object(
         RuntimeProviderRegistry,
         "_make_openai_compat_provider",
         side_effect=RuntimeError("no openai"),
     ):
-        svc = RuntimeProviderRegistry()
+        svc = RuntimeProviderRegistry(
+            env={
+                "ZAI_API_KEY": "zai-test-key",
+                "ZAI_BASE_URL": "https://api.z.ai/api/coding/paas/v4",
+            }
+        )
     assert "zai" not in svc._registry
 
 
-def test_zai_env_registration_defaults_without_base_url(clean_env):
+def test_zai_env_registration_defaults_without_base_url():
     """ZAI_API_KEY without ZAI_BASE_URL uses the subscription endpoint."""
-    os.environ["ZAI_API_KEY"] = "zai-test-key"
-    svc = RuntimeProviderRegistry()
+    svc = RuntimeProviderRegistry(env={"ZAI_API_KEY": "zai-test-key"})
     assert "zai" in svc._registry
 
 
 # === Context7 registration failure ===
 
 
-def test_context7_registration_failure_path(clean_env):
+def test_context7_registration_failure_path():
     """Context7 adapter registration failure is caught gracefully."""
-    os.environ["CONTEXT7_API_KEY"] = "ctx7-test-key"
     with patch("src.services.provider_adapters.make_context7_adapter", side_effect=ImportError("no ctx7")):
-        svc = RuntimeProviderRegistry()
+        svc = RuntimeProviderRegistry(env={"CONTEXT7_API_KEY": "ctx7-test-key"})
     assert "context7" not in svc._registry
 
 
 # === Env LangChain adapters ===
 
 
-def test_env_langchain_adapter_registration_does_not_depend_on_provider_adapters(clean_env):
+def test_env_langchain_adapter_registration_does_not_depend_on_provider_adapters():
     """LLM env adapters no longer depend on custom provider_adapters."""
-    os.environ["COHERE_API_KEY"] = "cohere-test"
     with patch.dict("sys.modules", {"src.services.provider_adapters": None}):
-        svc = RuntimeProviderRegistry()
+        svc = RuntimeProviderRegistry(env={"COHERE_API_KEY": "cohere-test"})
     assert "cohere" in svc._registry
 
 
 # === Exception during individual env adapter registration ===
 
 
-def test_env_adapter_registration_exception(clean_env):
+def test_env_adapter_registration_exception():
     """Single adapter failure doesn't prevent others from registering."""
-    os.environ["COHERE_API_KEY"] = "cohere-key"
-    os.environ["OLLAMA_BASE"] = "http://localhost:11434"
 
     async def fallback_provider(**kwargs):
         return "ok"
@@ -93,7 +67,12 @@ def test_env_adapter_registration_exception(clean_env):
         "_make_provider_for_runtime_config",
         side_effect=[ValueError("bad adapter"), fallback_provider],
     ):
-        svc = RuntimeProviderRegistry()
+        svc = RuntimeProviderRegistry(
+            env={
+                "COHERE_API_KEY": "cohere-key",
+                "OLLAMA_BASE": "http://localhost:11434",
+            }
+        )
 
     assert "cohere" not in svc._registry
     assert "ollama" in svc._registry
@@ -182,9 +161,8 @@ async def test_openai_compat_provider_extracts_langchain_content_blocks():
 
 
 @pytest.mark.anyio
-async def test_openai_provider_unknown_response_fallback(clean_env):
+async def test_openai_provider_unknown_response_fallback():
     """OpenAI provider returns stringified response when no text/content is exposed."""
-    os.environ["OPENAI_API_KEY"] = "test-key"
 
     class WeirdResponse:
         def __str__(self):
@@ -195,7 +173,7 @@ async def test_openai_provider_unknown_response_fallback(clean_env):
             return WeirdResponse()
 
     with patch("langchain.chat_models.init_chat_model", return_value=FakeChatModel()):
-        svc = RuntimeProviderRegistry()
+        svc = RuntimeProviderRegistry(env={"OPENAI_API_KEY": "test-key"})
         provider = svc.get_provider_callable("openai")
         result = await provider(prompt="test")
     assert "unexpected" in result

--- a/tests/test_provider_service_db_load.py
+++ b/tests/test_provider_service_db_load.py
@@ -1,7 +1,6 @@
 """Tests for RuntimeProviderRegistry.load_db_providers (env-only service)."""
 from __future__ import annotations
 
-import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -432,13 +431,9 @@ async def test_get_provider_status_list_no_db():
 def test_env_provider_makes_has_providers_true():
     """When env provider exists, has_providers() is True even if DB load fails."""
     env_key = "OPENAI_API_KEY"
-    original = os.environ.get(env_key)
-    try:
-        os.environ[env_key] = "test-key-for-banner-test"
-        svc = RuntimeProviderRegistry(db=MagicMock(), config=MagicMock())
-        assert svc.has_providers()
-    finally:
-        if original is None:
-            os.environ.pop(env_key, None)
-        else:
-            os.environ[env_key] = original
+    svc = RuntimeProviderRegistry(
+        db=MagicMock(),
+        config=MagicMock(),
+        env={env_key: "test-key-for-banner-test"},
+    )
+    assert svc.has_providers()

--- a/tests/test_provider_service_env_injection.py
+++ b/tests/test_provider_service_env_injection.py
@@ -90,13 +90,17 @@ async def test_build_provider_service_explicit_env_overrides_process(monkeypatch
 
 
 def test_registry_body_has_no_os_environ_reads():
-    """Guard: the registry source must not read os.environ in its body.
+    """Guard: the registry source must not read the process env in its body.
 
     Reading the process environment inside the registry is exactly the global
     state coupling that caused the #1050 flake. This static guard parses the
-    registry's AST and fails if any ``os.environ`` *access* (attribute, call, or
-    subscript) is reintroduced — comments/docstrings that merely mention the name
-    are ignored.
+    registry's AST and fails if any process-env *access* is reintroduced —
+    comments/docstrings that merely mention the name are ignored. It covers all
+    spellings:
+
+    * ``os.environ`` (attribute/subscript, any nesting depth),
+    * ``os.getenv(...)``,
+    * the ``from os import environ, getenv`` bare forms (``environ`` / ``getenv``).
     """
     import ast
     import inspect
@@ -105,16 +109,19 @@ def test_registry_body_has_no_os_environ_reads():
     tree = ast.parse(textwrap.dedent(inspect.getsource(RuntimeProviderRegistry)))
     offenders: list[int] = []
     for node in ast.walk(tree):
-        # match `os.environ` attribute access regardless of how it's used
+        # `os.environ` / `os.getenv` attribute access regardless of how it's used
         if (
             isinstance(node, ast.Attribute)
-            and node.attr == "environ"
+            and node.attr in ("environ", "getenv")
             and isinstance(node.value, ast.Name)
             and node.value.id == "os"
         ):
             offenders.append(node.lineno)
+        # bare `environ` / `getenv` from a `from os import ...` form
+        elif isinstance(node, ast.Name) and node.id in ("environ", "getenv"):
+            offenders.append(node.lineno)
     assert not offenders, (
-        "RuntimeProviderRegistry must not access os.environ directly "
+        "RuntimeProviderRegistry must not access the process env directly "
         f"(found at relative lines {offenders}); inject env explicitly (see #1050)."
     )
 

--- a/tests/test_provider_service_env_injection.py
+++ b/tests/test_provider_service_env_injection.py
@@ -1,0 +1,127 @@
+"""Env injection isolation for RuntimeProviderRegistry (#1050).
+
+Root-cause fix for the provider parallel flake under ``-n auto``: the registry
+used to read the real ``os.environ`` directly inside ``_register_env_providers``,
+so a neighbouring xdist worker mutating ``OPENAI_API_KEY`` (and friends) could
+"infect" an unrelated test's provider set non-deterministically (one such test
+even reached the live OpenAI API).
+
+These tests prove the registry is isolated *by design*: env arrives explicitly
+and the registry NEVER touches the process environment. They must stay green
+under ``-n auto`` without any autouse env-cleaner fixture, because the registry
+no longer depends on global process state.
+"""
+
+from __future__ import annotations
+
+import os
+
+from src.services.provider_service import RuntimeProviderRegistry, build_provider_service
+
+
+def test_explicit_env_registers_openai_provider():
+    """env={OPENAI_API_KEY: ...} → openai provider is registered."""
+    svc = RuntimeProviderRegistry(env={"OPENAI_API_KEY": "sk-explicit"})
+    assert "openai" in svc._registry
+    assert svc.has_providers()
+
+
+def test_empty_env_yields_clean_registry():
+    """env={} → only the 'default' stub, regardless of the real os.environ.
+
+    This is the crux of the isolation fix: even if a neighbouring xdist worker
+    has set OPENAI_API_KEY in the shared process env, an explicitly empty env
+    must produce a clean registry.
+    """
+    svc = RuntimeProviderRegistry(env={})
+    assert svc._registry == {"default": svc._registry["default"]}
+    assert not svc.has_providers()
+
+
+def test_default_env_none_does_not_read_os_environ(monkeypatch):
+    """env=None (default) → registry ignores os.environ entirely.
+
+    The registry must be clean by design; reading the process environment is the
+    factory/call-site's job, not the registry's.
+    """
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-from-process-env")
+    svc = RuntimeProviderRegistry()
+    assert "openai" not in svc._registry
+    assert not svc.has_providers()
+
+
+def test_explicit_env_does_not_leak_real_keys(monkeypatch):
+    """An explicit env mapping fully overrides the real os.environ.
+
+    Real OPENAI_API_KEY present in the process, but the explicit env supplies a
+    *different* provider only → no openai provider leaks in.
+    """
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-leak-attempt")
+    svc = RuntimeProviderRegistry(env={"COHERE_API_KEY": "co-explicit"})
+    assert "openai" not in svc._registry
+    assert "cohere" in svc._registry
+
+
+def test_openai_compat_env_provider_via_explicit_env():
+    """OpenAI-compatible providers (together/deepseek/fireworks) come from env."""
+    svc = RuntimeProviderRegistry(
+        env={"TOGETHER_API_KEY": "tk", "TOGETHER_BASE": "https://api.together.xyz/v1"}
+    )
+    assert "together" in svc._registry
+
+
+async def test_build_provider_service_snapshots_os_environ(monkeypatch):
+    """build_provider_service(env=None) snapshots the *real* os.environ once.
+
+    Prod call-sites rely on the factory to pull env from the process; this keeps
+    env-based providers working in production while the registry stays pure.
+    """
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-prod-snapshot")
+    svc = await build_provider_service()
+    assert "openai" in svc._registry
+
+
+async def test_build_provider_service_explicit_env_overrides_process(monkeypatch):
+    """build_provider_service(env=...) uses the explicit env, not os.environ."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-should-be-ignored")
+    svc = await build_provider_service(env={})
+    assert "openai" not in svc._registry
+    assert not svc.has_providers()
+
+
+def test_registry_body_has_no_os_environ_reads():
+    """Guard: the registry source must not read os.environ in its body.
+
+    Reading the process environment inside the registry is exactly the global
+    state coupling that caused the #1050 flake. This static guard parses the
+    registry's AST and fails if any ``os.environ`` *access* (attribute, call, or
+    subscript) is reintroduced — comments/docstrings that merely mention the name
+    are ignored.
+    """
+    import ast
+    import inspect
+    import textwrap
+
+    tree = ast.parse(textwrap.dedent(inspect.getsource(RuntimeProviderRegistry)))
+    offenders: list[int] = []
+    for node in ast.walk(tree):
+        # match `os.environ` attribute access regardless of how it's used
+        if (
+            isinstance(node, ast.Attribute)
+            and node.attr == "environ"
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "os"
+        ):
+            offenders.append(node.lineno)
+    assert not offenders, (
+        "RuntimeProviderRegistry must not access os.environ directly "
+        f"(found at relative lines {offenders}); inject env explicitly (see #1050)."
+    )
+
+
+def test_make_service_module_keeps_os_import_for_factory():
+    """Sanity: the factory still imports os to snapshot the process env."""
+    import src.services.provider_service as mod
+
+    assert hasattr(mod, "os")
+    assert mod.os is os

--- a/tests/test_provider_service_registration.py
+++ b/tests/test_provider_service_registration.py
@@ -1,15 +1,12 @@
 from __future__ import annotations
 
-import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from src.services.provider_service import RuntimeProviderRegistry
 
 
 def _make_service(**env_vars):
-    with patch.dict(os.environ, env_vars, clear=False):
-        svc = RuntimeProviderRegistry(db=None, config=None)
-    return svc
+    return RuntimeProviderRegistry(db=None, config=None, env=dict(env_vars))
 
 
 def test_default_provider_registered():


### PR DESCRIPTION
## Что и зачем

Provider/quality/pipeline тесты недетерминированно падали под `pytest -n auto`, но изолированно были зелёными. **Корень:** `RuntimeProviderRegistry.__init__` → `_register_env_providers()` читал реальный `os.environ` напрямую при конструировании. Под xdist `--dist=loadfile` один воркер крутит несколько файлов подряд в одном процессе → соседний файл, оставивший провайдер-ключ (`OPENAI_API_KEY` и др.) в общем env, «заражал» набор провайдеров несвязанного теста. Один тест даже бил в живой OpenAI/ZAI API.

## Подход: корневой фикс, не симптом

Предыдущая попытка (отклонена владельцем) добавляла autouse-фикстуру «уборщик env». Это лечение симптома. Здесь убрано **само** глобальное process-state coupling: **registry больше не читает `os.environ` вообще** — env приходит явно.

- `RuntimeProviderRegistry(db, config, *, env=None)` — keyword-only `env`. `env=None` → чистый реестр by design. Все `os.environ.get` в теле → `self._env.get`.
- `build_provider_service(db, config, env=None)` — фабрика снимает `os.environ` один раз снаружи, когда `env` не передан. Прод env-провайдеров не теряет.
- Прямые прод-call-sites передают env явно: `bootstrap.py` и `deps.py` инжектят `dict(os.environ)`; 4 CLI call-site (`analytics.py`, `pipeline.py` ×3) переведены на фабрику `build_provider_service`.
- Тесты дают env явно: убрано 24 мутации `os.environ`, удалены обе autouse `clean_env`-фикстуры, `_make_service` инжектит env напрямую. Gated live-smoke `test_live_zai_default_adapter_smoke` передаёт реальный ключ явно (`env={"ZAI_API_KEY": os.environ[...]}`) — не сломан.
- НЕ трогает: image-адаптеры (#958 retry/billing) и live opt-in тесты — они читают os.environ независимо.

## TDD / верификация

- 🔴→🟢 Новый `tests/test_provider_service_env_injection.py` (9 тестов): явный env→провайдер; `env={}`→чисто; `env=None` игнорирует `os.environ`; AST-guard падает, если `os.environ` вернут в тело registry.
- Стабильность: 6× прогон затронутых классов под `-n 8` — зелёные.
- Полный CI-эквивалент: **8492 passed / 138 skipped** (parallel `-n auto`) + **899 passed** (serial `aiosqlite_serial`). `ruff check` чист. mypy без новых ошибок (остаётся pre-existing `object→Database` / `init_chat_model` шум).

Closes #1050

🤖 Generated with [Claude Code](https://claude.com/claude-code)