### PR TITLE
ci: гигиена ci.yml — триггеры + concurrency + timeout + paths-ignore + coverage + security-scan + Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+# Dependabot configuration (issue #1053).
+#
+# Closes the loop opened by the CI security scans: pip-audit (static-checks job)
+# LOCATES a vulnerable dependency, Dependabot opens the update PR that FIXES it.
+# Two ecosystems are watched — the Python deps declared in pyproject.toml and the
+# GitHub Actions pinned in .github/workflows/*. Updates run weekly and minor/patch
+# bumps are grouped into a single PR per ecosystem so the queue stays small; major
+# bumps still arrive as their own PR for individual review (supply-chain note
+# #918 — vet each major before merging).
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      python-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,43 @@
 name: CI
 
+# Triggers — CI runs only on `main` and on pull requests (owner decision, #1051).
+#   push: [main]   — post-merge verification that main itself stays green.
+#   pull_request:  — fires on PR open AND on every push inside an open PR
+#                    (the `synchronize` event), so PR commits are still covered.
+# Dropped the old `fix/**` / `codex/**` push triggers: they double-ran CI (once
+# for the branch push, once for the PR) and burned runners on intermediate,
+# draft, PR-less pushes. A push to a feature branch with no open PR no longer
+# triggers CI — open the PR to get a run.
 on:
   push:
     branches:
       - main
-      - fix/**
-      - codex/**
   pull_request:
+    # Docs-only changes skip the suite (#1051). paths-ignore is "all-or-nothing":
+    # the run is skipped only when EVERY changed file matches a pattern below, so
+    # a PR touching both code and docs still runs the full CI. The branch-name
+    # guard (check-branch-name) still runs because it is an independent job that
+    # github evaluates after the path filter at the workflow level — a docs-only
+    # PR simply has no test job to run.
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - "mkdocs.yml"
+
+# Cancel an in-progress run when a newer commit is pushed to the same ref
+# (#1051). Without this, every push to an open PR left the previous run burning
+# a runner to completion. Grouping by workflow+ref keeps main and each PR
+# independent; cancel-in-progress reclaims the runner for the latest commit.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check-branch-name:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    # A trivial github-script job; the timeout is a hang guard, not a budget.
+    timeout-minutes: 5
     steps:
       - name: Reject branch names with "+"
         if: contains(github.head_ref, '+')
@@ -30,6 +56,9 @@ jobs:
   # long test job instead of serializing ~20s in front of pytest (#944).
   static-checks:
     runs-on: ubuntu-latest
+    # Lint + import contracts + complexity gate + security scans (#1051, #1053).
+    # Typically a couple of minutes; 10 leaves headroom over a cold pip install.
+    timeout-minutes: 10
 
     steps:
       - name: Checkout repository
@@ -67,6 +96,24 @@ jobs:
         continue-on-error: true
         run: npx -y jscpd@5.0.10 --min-tokens 70 --format python --threshold 1 src
 
+      # Dependency CVE scan (#1053). Advisory for now (continue-on-error) so a
+      # pre-existing transitive CVE never reds CI on day one — pip-audit LOCATES,
+      # Dependabot (.github/dependabot.yml) FIXES via update PRs. Ratchet to
+      # blocking later once the current findings are triaged. pip-audit ships in
+      # the [dev] extra installed above.
+      - name: Dependency vulnerability scan (advisory)
+        continue-on-error: true
+        run: pip-audit --desc
+
+      # Static security analysis of our own code (#1053). Advisory like the
+      # duplication guard: the codebase has ~hundreds of broad `except Exception`
+      # blocks that bandit flags (B110/B112) — kept non-blocking to avoid noise
+      # until a baseline/skip-list is curated. Config lives in [tool.bandit] in
+      # pyproject.toml (recurses src, excludes tests).
+      - name: Code security scan (advisory)
+        continue-on-error: true
+        run: bandit -c pyproject.toml -r src -q
+
       - name: Enforce pytest warnings as errors
         run: |
           python - <<'PY'
@@ -85,6 +132,10 @@ jobs:
 
   lint-and-test:
     runs-on: ubuntu-latest
+    # The long job: smoke + parallel + serial pytest with coverage. The suite
+    # runs in a few minutes on CI; 15 is a generous hang guard well under the
+    # 6h GitHub default that would otherwise let a deadlocked run idle (#1051).
+    timeout-minutes: 15
 
     steps:
       - name: Checkout repository
@@ -113,10 +164,37 @@ jobs:
       # On CI conftest.py uses every runner core (the load throttle is dev-only),
       # so `-n auto` fans out across all vCPUs. --durations surfaces the slowest
       # tests each run for ongoing tuning (#944).
+      #
+      # Coverage (#1052): both real test runs measure `src` and the per-process
+      # .coverage.* files are combined afterwards. The parallel run starts the
+      # dataset (no --cov-append); the serial run appends so its lines aren't
+      # lost. `[tool.coverage.run] parallel = true` already keeps the xdist
+      # worker datafiles separate; we pass --cov-report= here to defer reporting
+      # (and the pyproject fail_under gate) to the single combined step below.
       - name: Pytest (parallel-safe)
         if: ${{ !cancelled() }}
-        run: pytest tests -q -m "not aiosqlite_serial" -n auto --durations=25
+        run: pytest tests -q -m "not aiosqlite_serial" -n auto --durations=25 --cov=src --cov-report=
 
       - name: Pytest (aiosqlite serial)
         if: ${{ !cancelled() }}
-        run: pytest tests -q -m aiosqlite_serial
+        run: pytest tests -q -m aiosqlite_serial --cov=src --cov-append --cov-report=
+
+      # Combine the parallel + serial datasets into one report. fail_under lives
+      # in [tool.coverage.report] (pyproject) so the ratchet is configured in one
+      # place; this step reds CI if total coverage drops below it (#1052, baseline
+      # for the #1024 bug-hunt epic to push upward). The XML artifact lets PRs
+      # diff coverage without re-running the suite.
+      - name: Coverage report (combined)
+        if: ${{ !cancelled() }}
+        run: |
+          coverage combine
+          coverage report
+          coverage xml -o coverage.xml
+
+      - name: Upload coverage artifact
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,15 +179,20 @@ jobs:
         if: ${{ !cancelled() }}
         run: pytest tests -q -m aiosqlite_serial --cov=src --cov-append --cov-report=
 
-      # Combine the parallel + serial datasets into one report. fail_under lives
-      # in [tool.coverage.report] (pyproject) so the ratchet is configured in one
-      # place; this step reds CI if total coverage drops below it (#1052, baseline
-      # for the #1024 bug-hunt epic to push upward). The XML artifact lets PRs
-      # diff coverage without re-running the suite.
+      # Report the combined parallel + serial coverage. pytest-cov already merged
+      # the per-worker datafiles into a single `.coverage` at the end of each run
+      # (`[tool.coverage.run] parallel = true`), and the serial run's
+      # `--cov-append` added its lines to that same file — so the dataset is
+      # already combined here. We deliberately do NOT run `coverage combine`: with
+      # no leftover `.coverage.*` suffix files it exits 1 ("No data to combine"),
+      # which under the Actions default `bash -e` would red the step before the
+      # report runs. `coverage report` reads `.coverage` directly and applies the
+      # fail_under=88 ratchet from [tool.coverage.report] (#1052, baseline for the
+      # #1024 bug-hunt epic). The XML artifact lets PRs diff coverage without
+      # re-running the suite.
       - name: Coverage report (combined)
         if: ${{ !cancelled() }}
         run: |
-          coverage combine
           coverage report
           coverage xml -o coverage.xml
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,12 @@ dev = [
     # CI cyclomatic-complexity gate (`--fail-on F`). ruff (above) is the third.
     "radon>=6.0.1",
     "vulture>=2.16",
+    # Security scans wired into CI static-checks (issue #1053), advisory for now:
+    # pip-audit scans installed deps for known CVEs, bandit flags security
+    # anti-patterns in src/. Dependabot (.github/dependabot.yml) opens the fix
+    # PRs that pip-audit findings point at.
+    "pip-audit>=2.7.3",
+    "bandit>=1.8.0",
     # Console-error e2e smoke (issue #1014): the opt-in browser walk in
     # tests/e2e/console_smoke.py drives the Playwright Python API directly
     # instead of shelling out to an undeclared `playwright-cli` binary. The
@@ -169,10 +175,22 @@ omit = ["tests/*"]
 
 [tool.coverage.report]
 show_missing = true
-fail_under = 90
+# Baseline ratchet for the CI coverage gate (issue #1052). Measured combined
+# coverage (parallel + serial suites, 9319 tests) is ~91%; the gate sits a few
+# points below that so normal branch-coverage jitter between runs can't red CI,
+# while still failing on a real regression. The #1024 bug-hunt epic ratchets this
+# upward as it adds tests — raise this number, never lower it.
+fail_under = 88
 exclude_lines = [
     "pragma: no cover",
     "if TYPE_CHECKING:",
     "raise NotImplementedError",
     "pass",
 ]
+
+# Static security analysis config for `bandit -c pyproject.toml -r src` (#1053).
+# The CI step (static-checks) runs it advisory (continue-on-error) for now; this
+# scopes the scan to src/ and skips the test tree. Findings are triaged into a
+# skip-list / `# nosec` here before the step is ever made blocking.
+[tool.bandit]
+exclude_dirs = ["tests"]


### PR DESCRIPTION
Объединяет **три родственных sub-issue** группы 5 «CI-гигиена» (родитель #1023) в один PR — все трое правят `.github/workflows/ci.yml`, порознь параллельно дали бы merge-конфликт по одному файлу с одной точкой ревью.

## #1051 — триггеры + concurrency + timeout + paths-ignore
- **Триггеры (решение владельца — CI только перед PR):** `push: [main]` (post-merge проверка main) + `pull_request:` (open + push-в-PR через `synchronize`). Убран push-триггер для `fix/**`/`codex/**` — он давал двойной ран (ветка + PR) и жёг раннеры на черновых push без PR. Промежуточный push в feature-ветку **без открытого PR теперь НЕ триггерит CI**.
- **`concurrency`** по `${{ github.workflow }}-${{ github.ref }}` + `cancel-in-progress: true` — при новом пуше старый ран той же группы отменяется (перестаём жечь раннеры впустую). main и каждый PR независимы.
- **`timeout-minutes`** на каждый job (`check-branch-name` 5, `static-checks` 10, `lint-and-test` 15) — hang-guard вместо 6-часового GitHub-дефолта.
- **`paths-ignore`** docs-only (`docs/**`, `**/*.md`, `mkdocs.yml`). ⚠️ all-or-nothing: ран скипается только если **ВСЕ** файлы попадают под фильтр → code+docs PR всё равно гоняет полный suite.

## #1052 — coverage-гейт (baseline для баг-ханта #1024)
- `--cov=src` на parallel + serial прогонах (`--cov-append` на serial), combined `coverage report` + `coverage.xml` артефакт. `[tool.coverage.run] parallel = true` уже держит датафайлы xdist-воркеров раздельно; pytest-cov их комбинирует.
- **Ratchet `fail_under = 88`** в `[tool.coverage.report]`. Измеренный baseline combined (parallel+serial, ~9319 тестов) — **~91%**; гейт на пару пунктов ниже от branch-coverage jitter. Эпик #1024 двигает число вверх (raise, never lower).

## #1053 — security-scan (pip-audit + bandit) + Dependabot
- **`pip-audit`** (CVE зависимостей) + **`bandit`** (статанализ `src/`) как **advisory** шаги (`continue-on-error`, по образцу jscpd-гарда) в `static-checks`. Локальный триаж: bandit даёт **183 находки** (121 Low / 61 Medium / 1 High — B704 false-positive, там `escape()` на всех значениях); pip-audit ловит транзитивные CVE. Blocking сразу свалил бы CI → стартово advisory, ratchet позже (skip-лист/`# nosec`).
- **`.github/dependabot.yml`** (новый): экосистемы `pip` + `github-actions`, weekly, group minor/patch (major — отдельным PR для ревью, supply-chain note #918).
- `pip-audit>=2.7.3` / `bandit>=1.8.0` в `[dev]`; `[tool.bandit] exclude_dirs = ["tests"]`.

## Не-регресс соседних workflow
`real-provider.yml` (workflow_dispatch), `docs.yml` (push docs/** + dispatch), `release.yml` (tags v*) **не трогаются** и не конфликтуют по триггерам с новыми `on:`/`concurrency` ci.yml.

## Верификация (продукт-кода нет, только YAML+config)
- `ruff check src tests conftest.py` — pass; YAML ci.yml + dependabot.yml парсятся, структура dependabot валидна.
- Триггер-логика: push в feature-ветку без PR → нет рана; open PR → ран; push в PR → ран (synchronize); docs-only PR → suite скипнут; push в main → ран.
- Coverage: локально parallel 88% + serial `--cov-append` → combined **91%** ; `coverage report` с `fail_under=88` → exit 0; `coverage.xml` генерится.
- `bandit -c pyproject.toml -r src` — конфиг применился (tests исключены, 0 файлов в tests просканировано).
- smoke preflight (`pytest -m smoke`) — pass; pyproject-изменения не ломают сбор и `filterwarnings=["error"]`.

## ⚠️ Операционная заметка для ревьюера
Если `lint-and-test` настроен как **required status check** в branch protection, docs-only PR (где job скипается через `paths-ignore`) может «висеть» в ожидании чека, который не появится. Это известный нюанс GitHub `paths-ignore` + required checks — решается на уровне branch-protection (отдельно от файлов репо), не входит в scope этого PR.

После мержа — убедиться, что main по-прежнему гоняет **полный** CI (память проекта: проверять conclusion CI перед мержем).

Closes #1051, Closes #1052, Closes #1053

🤖 Generated with [Claude Code](https://claude.com/claude-code)