### PR TITLE
refactor(dispatcher): разнести TelegramCommandDispatcher по доменам команд (#1047)

### DIFF
--- a/src/services/dispatcher/__init__.py
+++ b/src/services/dispatcher/__init__.py
@@ -1,0 +1,9 @@
+"""Per-domain command handlers for :class:`TelegramCommandDispatcher` (#1047).
+
+The dispatcher used to be a single 1162-line module. Handlers are now grouped
+by command domain into mixin classes here; the facade in
+``src.services.telegram_command_dispatcher`` composes them and keeps the loop
+machinery, the public class, and every patch-sensitive symbol in one place.
+"""
+
+from __future__ import annotations

--- a/src/services/dispatcher/_base.py
+++ b/src/services/dispatcher/_base.py
@@ -1,0 +1,65 @@
+"""Shared attribute/method surface for the dispatcher mixins (#1047).
+
+The per-domain mixins read collaborators (``self._db``, ``self._pool``, …) that
+are assigned in :class:`TelegramCommandDispatcher.__init__`, and a few call
+handlers that live on a *different* mixin (e.g. auth.verify_code chains into
+accounts.connect). To keep type-checkers honest without a runtime base class,
+each mixin inherits from :class:`_DispatcherProtocol` only under
+``TYPE_CHECKING``; at runtime the mixins are plain classes composed by the
+facade, exactly as before.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from src.config import AppConfig
+    from src.database import Database
+    from src.live_runtime_pause import LiveRuntimePauseGate
+    from src.scheduler.service import SchedulerManager
+    from src.search.engine import SearchEngine
+    from src.telegram.auth import TelegramAuth
+    from src.telegram.client_pool import ClientPool
+    from src.telegram.collector import Collector
+    from src.telegram.notifier import Notifier
+
+
+class _DispatcherProtocol(Protocol):
+    """The collaborator surface every mixin can assume the dispatcher provides.
+
+    Used only for static typing — never instantiated, never inherited at
+    runtime. Mirrors :meth:`TelegramCommandDispatcher.__init__`.
+    """
+
+    _db: "Database"
+    _pool: "ClientPool"
+    _config: "AppConfig | None"
+    _collector: "Collector | None"
+    _scheduler: "SchedulerManager | None"
+    _auth: "TelegramAuth | None"
+    _search_engine: "SearchEngine | None"
+    _collection_queue: Any
+    _live_runtime_pause_gate: "LiveRuntimePauseGate | None"
+    _notifier: "Notifier | None"
+    _last_reaction_at_monotonic: dict[str, float]
+
+    # Cross-mixin / facade helpers a handler may delegate to.
+    async def _handle_accounts_connect(self, payload: dict[str, Any]) -> dict[str, Any]: ...
+
+    def _pool_method(self, name: str) -> Any | None: ...
+
+    async def _account_flood_until(self, phone: str) -> datetime | None: ...
+
+    async def _reaction_min_interval(self) -> float: ...
+
+    async def _ensure_reaction_can_run(self, phone: str) -> None: ...
+
+    def _notification_service(self) -> Any: ...
+
+    def _notification_target_service(self) -> Any: ...
+
+    def _photo_task_service(self) -> Any: ...
+
+    def _photo_auto_upload_service(self) -> Any: ...

--- a/src/services/dispatcher/_constants.py
+++ b/src/services/dispatcher/_constants.py
@@ -1,0 +1,21 @@
+"""Shared constants for the Telegram command dispatcher and its mixins (#1047).
+
+These live in their own module so both the facade
+(``src.services.telegram_command_dispatcher``) and the per-domain mixins can
+import them without a circular dependency. The facade re-exports them at module
+level so historical patch points like ``mod.REACTION_MIN_INTERVAL_FLOOR_SEC``
+keep resolving.
+"""
+
+from __future__ import annotations
+
+COMMAND_STATUS_UPDATE_BUSY_RETRY_INITIAL_SEC = 0.1
+COMMAND_STATUS_UPDATE_BUSY_RETRY_MAX_SEC = 1.0
+
+# Minimum spacing between reactions on the same phone. Configurable live via the
+# DB setting below; a non-zero floor is enforced because Telegram rate-limits
+# reactions server-side and zero spacing risks FLOOD_WAIT / account limiting.
+REACTION_MIN_INTERVAL_SETTING = "reaction_min_interval_sec"
+DEFAULT_REACTION_MIN_INTERVAL_SEC = 30.0
+REACTION_MIN_INTERVAL_FLOOR_SEC = 1.0
+REACTION_MIN_INTERVAL_CEILING_SEC = 300.0

--- a/src/services/dispatcher/_errors.py
+++ b/src/services/dispatcher/_errors.py
@@ -1,0 +1,30 @@
+"""Dispatcher control-flow exceptions (#1047).
+
+Lives in the subpackage so both the facade and the mixins can raise/catch it
+without a circular import. The facade re-exports
+:class:`TelegramCommandRetryLaterError` so existing
+``from src.services.telegram_command_dispatcher import TelegramCommandRetryLaterError``
+imports keep working.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+
+@dataclass(slots=True)
+class TelegramCommandRetryLaterError(RuntimeError):
+    """Raised by a handler to requeue its command for a later run.
+
+    The dispatcher loop catches this, resets the command to PENDING with the
+    given ``run_after`` and ``result_payload``, and does not mark it failed.
+    """
+
+    run_after: datetime
+    reason: str
+    result_payload: dict[str, Any] | None = None
+
+    def __str__(self) -> str:
+        return self.reason

--- a/src/services/dispatcher/accounts_mixin.py
+++ b/src/services/dispatcher/accounts_mixin.py
@@ -1,0 +1,105 @@
+"""Account connection lifecycle command handlers (#1047).
+
+Domain: ``accounts.*`` — connect (materialize session into the pool), toggle
+active, delete. ``accounts.connect`` is also chained from ``auth.verify_code``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from src.database.live_accounts import load_live_usable_accounts
+from src.models import Account
+
+if TYPE_CHECKING:
+    from src.services.dispatcher._base import _DispatcherProtocol
+
+    _Base = _DispatcherProtocol
+else:
+    _Base = object
+
+logger = logging.getLogger(__name__)
+
+
+class AccountsCommandsMixin(_Base):
+    """``accounts.*`` command handlers."""
+
+    async def _handle_accounts_connect(self, payload: dict[str, Any]) -> dict[str, Any]:
+        phone = str(payload["phone"])
+        accounts = await load_live_usable_accounts(self._db, active_only=False)
+        account = next((a for a in accounts if a.phone == phone), None)
+        if account is None:
+            summaries = await self._db.get_account_summaries(active_only=False)
+            summary = next((a for a in summaries if a.phone == phone), None)
+            if summary is not None:
+                status = getattr(summary, "session_status", "unavailable")
+                raise RuntimeError(f"account_session_unavailable:{phone}:{status}")
+            raise RuntimeError(f"account_not_found:{phone}")
+        await self._pool.add_client(phone, account.session_string)
+        result = await self._pool.get_client_by_phone(phone)
+        is_premium = False
+        if result is not None:
+            session, acquired_phone = result
+            try:
+                me = await session.fetch_me()
+                is_premium = bool(getattr(me, "premium", False))
+            finally:
+                await self._pool.release_client(acquired_phone)
+        await self._db.update_account_premium(phone, is_premium)
+        return {"phone": phone, "is_premium": is_premium}
+
+    async def _handle_accounts_toggle(self, payload: dict[str, Any]) -> dict[str, Any]:
+        account_id = int(payload["account_id"])
+        summaries = await self._db.get_account_summaries(active_only=False)
+        account_summary = next((a for a in summaries if a.id == account_id), None)
+        live_account: Account | None = None
+        if account_summary is None:
+            accounts = await load_live_usable_accounts(self._db, active_only=False)
+            live_account = next((a for a in accounts if a.id == account_id), None)
+            account_summary = live_account
+        if account_summary is None:
+            raise RuntimeError(f"account_not_found:{account_id}")
+        new_active = not account_summary.is_active
+        await self._db.set_account_active(account_id, new_active)
+        if new_active:
+            try:
+                if live_account is None:
+                    accounts = await load_live_usable_accounts(self._db, active_only=False)
+                    live_account = next((a for a in accounts if a.id == account_id), None)
+                if live_account is None:
+                    logger.warning(
+                        "accounts.toggle: account session unavailable for %s",
+                        account_summary.phone,
+                    )
+                else:
+                    await self._pool.add_client(live_account.phone, live_account.session_string)
+            except Exception as exc:
+                logger.warning("accounts.toggle: failed to add client %s: %s", account_summary.phone, exc)
+        else:
+            try:
+                await self._pool.remove_client(account_summary.phone)
+            except Exception as exc:
+                logger.warning("accounts.toggle: failed to remove client %s: %s", account_summary.phone, exc)
+        return {"account_id": account_id, "is_active": new_active}
+
+    async def _handle_accounts_delete(self, payload: dict[str, Any]) -> dict[str, Any]:
+        account_id = int(payload["account_id"])
+        phone = str(payload.get("phone") or "").strip()
+        delete_from_db = not phone
+        if not phone:
+            accounts = await self._db.get_account_summaries(active_only=False)
+            account = next((a for a in accounts if a.id == account_id), None)
+            phone = account.phone if account is not None else ""
+        if phone:
+            try:
+                await self._pool.remove_client(phone)
+            except Exception as exc:
+                logger.warning("accounts.delete: failed to remove client %s: %s", phone, exc)
+        if delete_from_db:
+            await self._db.delete_account(account_id)
+        return {
+            "account_id": account_id,
+            "deleted": delete_from_db,
+            "client_removed": bool(phone),
+        }

--- a/src/services/dispatcher/auth_mixin.py
+++ b/src/services/dispatcher/auth_mixin.py
@@ -1,0 +1,63 @@
+"""Auth command handlers for :class:`TelegramCommandDispatcher` (#1047).
+
+Domain: ``auth.*`` — phone-code send/resend/verify and account materialization.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from src.models import Account
+
+if TYPE_CHECKING:
+    from src.services.dispatcher._base import _DispatcherProtocol
+
+    _Base = _DispatcherProtocol
+else:
+    _Base = object
+
+
+class AuthCommandsMixin(_Base):
+    """``auth.*`` command handlers.
+
+    Relies on the facade for ``self._auth`` (TelegramAuth) and ``self._db``;
+    ``_handle_auth_verify_code`` chains into ``self._handle_accounts_connect``
+    which lives on the accounts side of the dispatcher.
+    """
+
+    async def _handle_auth_send_code(self, payload: dict[str, Any]) -> dict[str, Any]:
+        if self._auth is None or not self._auth.is_configured:
+            raise RuntimeError("auth_not_configured")
+        phone = str(payload["phone"]).strip()
+        result = await self._auth.send_code(phone)
+        return {"result": {"phone": phone, **result}}
+
+    async def _handle_auth_resend_code(self, payload: dict[str, Any]) -> dict[str, Any]:
+        if self._auth is None or not self._auth.is_configured:
+            raise RuntimeError("auth_not_configured")
+        phone = str(payload["phone"]).strip()
+        result = await self._auth.resend_code(phone)
+        return {"result": {"phone": phone, **result}}
+
+    async def _handle_auth_verify_code(self, payload: dict[str, Any]) -> dict[str, Any]:
+        if self._auth is None or not self._auth.is_configured:
+            raise RuntimeError("auth_not_configured")
+        phone = str(payload["phone"]).strip()
+        password_2fa = str(payload.get("password_2fa", "")).strip() or None
+        payload["password_2fa"] = ""
+        session_string = await self._auth.verify_code(
+            phone,
+            str(payload["code"]),
+            str(payload["phone_code_hash"]),
+            password_2fa,
+        )
+        existing = await self._db.get_account_summaries(active_only=False)
+        account = Account(
+            phone=phone,
+            session_string=session_string,
+            is_primary=not any(acc.phone == phone for acc in existing) and len(existing) == 0,
+            is_premium=False,
+        )
+        await self._db.add_account(account)
+        connect_result = await self._handle_accounts_connect({"phone": phone})
+        return {"result": {"phone": phone, **connect_result}, "payload_update": {**payload}}

--- a/src/services/dispatcher/channels_mixin.py
+++ b/src/services/dispatcher/channels_mixin.py
@@ -1,0 +1,176 @@
+"""Channel ingest and refresh command handlers (#1047).
+
+Domains: ``channels.*`` (add / collect_stats / refresh_types / refresh_meta /
+import_batch) and ``agent.forum_topics_refresh``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from src.services.channel_onboarding import (
+    channel_from_resolved_info,
+    enqueue_stats_for_new_channels,
+    fetch_channel_meta,
+    get_existing_channel,
+)
+
+if TYPE_CHECKING:
+    from src.services.dispatcher._base import _DispatcherProtocol
+
+    _Base = _DispatcherProtocol
+else:
+    _Base = object
+
+
+class ChannelsCommandsMixin(_Base):
+    """``channels.*`` and ``agent.forum_topics_refresh`` command handlers."""
+
+    async def _handle_agent_forum_topics_refresh(self, payload: dict[str, Any]) -> dict[str, Any]:
+        channel_id = int(payload["channel_id"])
+        topics = await self._pool.get_forum_topics(channel_id)
+        if topics:
+            await self._db.upsert_forum_topics(channel_id, topics)
+            await self._db.set_channel_type(channel_id, "forum")
+        return {"channel_id": channel_id, "count": len(topics)}
+
+    async def _handle_channels_add_identifier(self, payload: dict[str, Any]) -> dict[str, Any]:
+        identifier = str(payload["identifier"]).strip()
+        info = await self._pool.resolve_channel(identifier)
+        if not info:
+            raise RuntimeError(f"resolve failed: {identifier!r} not found")
+        existing = await get_existing_channel(self._db, int(info["channel_id"]))
+        meta = await fetch_channel_meta(
+            self._pool, int(info["channel_id"]), info.get("channel_type")
+        )
+        channel = channel_from_resolved_info(info, meta)
+        await self._db.add_channel(channel)
+        stats_task_id = None
+        if existing is None and channel.is_active:
+            stats_task_id = await enqueue_stats_for_new_channels(
+                self._db.create_stats_task,
+                [channel.channel_id],
+                context="channels.add_identifier",
+            )
+        return {"channel_id": info["channel_id"], "stats_task_id": stats_task_id}
+
+    async def _handle_channels_collect_stats(self, payload: dict[str, Any]) -> dict[str, Any]:
+        if self._collector is None:
+            raise RuntimeError("collector_unavailable")
+        channel_pk = int(payload["channel_pk"])
+        channel = await self._db.get_channel_by_pk(channel_pk)
+        if channel is None:
+            raise RuntimeError("channel_not_found")
+        result = await self._collector.collect_channel_stats(channel)
+        return {"channel_id": channel.channel_id, "collected": bool(result)}
+
+    async def _handle_channels_refresh_types(self, payload: dict[str, Any]) -> dict[str, Any]:
+        channels = await self._db.get_channels(active_only=True)
+        updated = 0
+        failed = 0
+        deactivated = 0
+        quarantined = 0
+        for ch in channels:
+            identifier = ch.username or str(ch.channel_id)
+            try:
+                # numeric_fallback so a stale @username doesn't deactivate a live
+                # channel — gone is retried by numeric id first (#858 review).
+                info = await self._pool.resolve_channel(
+                    identifier, signal_gone=True, numeric_fallback=str(ch.channel_id)
+                )
+            except Exception:
+                info = None
+            # Uncertain (cache-miss vs deleted, owner unknown/unavailable) → quarantine
+            # for human review. This runs in the background worker with no interactive
+            # user, so flagging for review is the only safe move (#875 redesign).
+            if info and info.get("review"):
+                await self._db.repos.channels.set_channel_review(ch.id, info.get("reason", "uncertain"))
+                quarantined += 1
+                continue
+            # Definitive not-found → deactivate; transient None → skip and leave
+            # active (audit #835/8; old `if info is False` was unreachable).
+            if info and info.get("gone"):
+                await self._db.set_channel_active(ch.id, False)
+                await self._db.set_channel_type(ch.channel_id, "unavailable")
+                deactivated += 1
+                continue
+            if not info or info.get("channel_type") is None:
+                failed += 1
+                continue
+            # Resolved live: clear any stale quarantine flag (channel recovered).
+            if getattr(ch, "needs_review", False):
+                await self._db.repos.channels.clear_channel_review(ch.id)
+            await self._db.set_channel_type(ch.channel_id, info["channel_type"])
+            updated += 1
+        return {
+            "updated": updated,
+            "failed": failed,
+            "deactivated": deactivated,
+            "quarantined": quarantined,
+        }
+
+    async def _handle_channels_refresh_meta(self, payload: dict[str, Any]) -> dict[str, Any]:
+        channels = await self._db.get_channels(active_only=True)
+        updated = 0
+        failed = 0
+        for ch in channels:
+            try:
+                meta = await self._pool.fetch_channel_meta(ch.channel_id, ch.channel_type)
+            except Exception:
+                meta = None
+            if not meta:
+                failed += 1
+                continue
+            await self._db.update_channel_full_meta(
+                ch.channel_id,
+                about=meta["about"],
+                linked_chat_id=meta["linked_chat_id"],
+                has_comments=meta["has_comments"],
+            )
+            updated += 1
+        return {"updated": updated, "failed": failed}
+
+    async def _handle_channels_import_batch(self, payload: dict[str, Any]) -> dict[str, Any]:
+        identifiers = [str(item).strip() for item in payload.get("identifiers", []) if str(item).strip()]
+        existing = await self._db.get_channels()
+        existing_ids = {channel.channel_id for channel in existing}
+        added = 0
+        skipped = 0
+        failed = 0
+        stats_channel_ids: list[int] = []
+        details: list[dict[str, Any]] = []
+        for ident in identifiers:
+            try:
+                info = await self._pool.resolve_channel(ident)
+            except Exception:
+                info = None
+            if not info:
+                failed += 1
+                details.append({"identifier": ident, "status": "failed"})
+                continue
+            if info["channel_id"] in existing_ids:
+                skipped += 1
+                details.append({"identifier": ident, "status": "skipped"})
+                continue
+            meta = await fetch_channel_meta(
+                self._pool, int(info["channel_id"]), info.get("channel_type")
+            )
+            channel = channel_from_resolved_info(info, meta)
+            await self._db.add_channel(channel)
+            existing_ids.add(info["channel_id"])
+            if channel.is_active:
+                stats_channel_ids.append(channel.channel_id)
+            added += 1
+            details.append({"identifier": ident, "status": "added"})
+        stats_task_id = await enqueue_stats_for_new_channels(
+            self._db.create_stats_task,
+            stats_channel_ids,
+            context="channels.import_batch",
+        )
+        return {
+            "added": added,
+            "skipped": skipped,
+            "failed": failed,
+            "details": details,
+            "stats_task_id": stats_task_id,
+        }

--- a/src/services/dispatcher/dialogs_mixin.py
+++ b/src/services/dispatcher/dialogs_mixin.py
@@ -1,0 +1,379 @@
+"""Dialog action command handlers (#1047).
+
+Domain: ``dialogs.*`` — message send/edit/delete/forward, pin/unpin, reactions
+(with the per-phone rate-limit gate), participants, broadcast stats, admin and
+permission edits, kick, archive/unarchive, mark-read, channel creation, cache
+refresh/clear, leave, and resolve.
+
+Two ``dialogs.*`` handlers deliberately stay on the facade class, not here:
+``dialogs.join`` (the suite patches ``TelegramActionService`` through the facade
+module namespace) and ``dialogs.download_media`` (it reads ``mod.__file__`` to
+locate ``data/downloads`` and the suite monkeypatches that). Keeping them on the
+facade is the only way those patches reach the call site.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import datetime, timedelta, timezone
+from inspect import isawaitable
+from typing import TYPE_CHECKING, Any
+
+from src.models import RuntimeSnapshot
+from src.services.dispatcher._constants import (
+    DEFAULT_REACTION_MIN_INTERVAL_SEC,
+    REACTION_MIN_INTERVAL_CEILING_SEC,
+    REACTION_MIN_INTERVAL_FLOOR_SEC,
+    REACTION_MIN_INTERVAL_SETTING,
+)
+from src.services.dispatcher._errors import TelegramCommandRetryLaterError
+from src.services.telegram_actions import TelegramActionService
+from src.settings_utils import parse_float_setting
+from src.telegram.reactions import normalize_outgoing_reaction_emoji
+from src.telegram.utils import normalize_utc
+from src.utils.datetime import parse_required_datetime
+
+if TYPE_CHECKING:
+    from src.services.dispatcher._base import _DispatcherProtocol
+
+    _Base = _DispatcherProtocol
+else:
+    _Base = object
+
+logger = logging.getLogger(__name__)
+
+
+class DialogsCommandsMixin(_Base):
+    """``dialogs.*`` command handlers and the reaction rate-limit machinery."""
+
+    async def _handle_dialogs_refresh(self, payload: dict[str, Any]) -> dict[str, Any]:
+        phone = str(payload["phone"])
+        dialogs = await self._pool.get_dialogs_for_phone(phone, include_dm=True, mode="full", refresh=True)
+        await self._db.repos.dialog_cache.replace_dialogs(phone, dialogs)
+        return {"phone": phone, "dialogs_count": len(dialogs)}
+
+    async def _handle_dialogs_cache_clear(self, payload: dict[str, Any]) -> dict[str, Any]:
+        phone = str(payload.get("phone") or "").strip()
+        invalidate = getattr(self._pool, "invalidate_dialogs_cache", None)
+        if phone:
+            if callable(invalidate):
+                invalidate(phone)
+            await self._db.repos.dialog_cache.clear_dialogs(phone)
+        else:
+            if callable(invalidate):
+                invalidate()
+            await self._db.repos.dialog_cache.clear_all_dialogs()
+        return {"phone": phone}
+
+    async def _handle_dialogs_leave(self, payload: dict[str, Any]) -> dict[str, Any]:
+        phone = str(payload["phone"])
+        dialogs = [(int(item["dialog_id"]), str(item["title"])) for item in payload.get("dialogs", [])]
+        result = await TelegramActionService(self._pool).leave_dialogs(phone=phone, dialogs=dialogs)
+        return {"left": result.success_count, "failed": result.failed_count}
+
+    async def _handle_dialogs_send(self, payload: dict[str, Any]) -> dict[str, Any]:
+        result = await TelegramActionService(self._pool).send_message(
+            phone=str(payload["phone"]),
+            recipient=payload["recipient"],
+            text=payload["text"],
+        )
+        return {"phone": result.phone, "message_id": result.message_id}
+
+    async def _handle_dialogs_resolve(self, payload: dict[str, Any]) -> dict[str, Any]:
+        identifier = str(payload["identifier"])
+        entity = await self._pool.resolve_any_entity(
+            identifier, phone=str(payload.get("phone") or "") or None
+        )
+        if not entity:
+            raise RuntimeError(f"resolve failed: {identifier!r} not found")
+        return {"entity": entity}
+
+    async def _handle_dialogs_edit_message(self, payload: dict[str, Any]) -> dict[str, Any]:
+        result = await TelegramActionService(self._pool).edit_message(
+            phone=str(payload["phone"]),
+            chat_id=payload["chat_id"],
+            message_id=int(payload["message_id"]),
+            text=payload["text"],
+        )
+        return {"phone": result.phone}
+
+    async def _handle_dialogs_delete_message(self, payload: dict[str, Any]) -> dict[str, Any]:
+        result = await TelegramActionService(self._pool).delete_messages(
+            phone=str(payload["phone"]),
+            chat_id=payload["chat_id"],
+            message_ids=[int(value) for value in payload["message_ids"]],
+        )
+        return {"phone": result.phone, "deleted": result.count}
+
+    async def _handle_dialogs_forward_messages(self, payload: dict[str, Any]) -> dict[str, Any]:
+        result = await TelegramActionService(self._pool).forward_messages(
+            phone=str(payload["phone"]),
+            from_chat=payload["from_chat"],
+            to_chat=payload["to_chat"],
+            message_ids=[int(value) for value in payload["message_ids"]],
+        )
+        return {"phone": result.phone, "forwarded": result.count}
+
+    async def _account_flood_until(self, phone: str) -> datetime | None:
+        accounts: list[Any] = []
+        for getter_name in ("get_account_summaries", "get_accounts"):
+            getter = getattr(self._db, getter_name, None)
+            if not callable(getter):
+                continue
+            try:
+                result = getter(active_only=True)
+            except TypeError:
+                result = getter()
+            if isawaitable(result):
+                result = await result
+            if isinstance(result, (list, tuple)):
+                accounts = list(result)
+                break
+        now = datetime.now(timezone.utc)
+        for account in accounts:
+            if str(getattr(account, "phone", "")) != phone:
+                continue
+            flood_until = normalize_utc(getattr(account, "flood_wait_until", None))
+            if flood_until is not None and flood_until > now:
+                return flood_until
+        return None
+
+    async def _reaction_min_interval(self) -> float:
+        """Per-phone minimum seconds between reactions, read live from DB settings.
+
+        Clamped to a non-zero floor because Telegram rate-limits reactions
+        server-side; values outside the range or unparseable fall back to the
+        default.
+        """
+        raw = await self._db.get_setting(REACTION_MIN_INTERVAL_SETTING)
+        value = parse_float_setting(
+            raw,
+            setting_name=REACTION_MIN_INTERVAL_SETTING,
+            default=DEFAULT_REACTION_MIN_INTERVAL_SEC,
+            logger=logger,
+        )
+        return max(REACTION_MIN_INTERVAL_FLOOR_SEC, min(REACTION_MIN_INTERVAL_CEILING_SEC, value))
+
+    async def _ensure_reaction_can_run(self, phone: str) -> None:
+        is_warming = self._pool_method("is_warming")
+        if callable(is_warming):
+            try:
+                warming = bool(is_warming())
+            except Exception:
+                warming = False
+            if warming:
+                run_after = datetime.now(timezone.utc) + timedelta(seconds=5)
+                raise TelegramCommandRetryLaterError(
+                    run_after=run_after,
+                    reason="account dialog warm-up is still running",
+                    result_payload={
+                        "state": "waiting_warmup",
+                        "phone": phone,
+                        "next_available_at_utc": run_after.isoformat(),
+                    },
+                )
+
+        flood_until = await self._account_flood_until(phone)
+        if flood_until is not None:
+            raise TelegramCommandRetryLaterError(
+                run_after=flood_until + timedelta(seconds=1),
+                reason=f"account {phone} is flood-waited until {flood_until.isoformat()}",
+                result_payload={
+                    "state": "waiting_flood_wait",
+                    "phone": phone,
+                    "next_available_at_utc": flood_until.isoformat(),
+                },
+            )
+
+        last = self._last_reaction_at_monotonic.get(phone)
+        if last is None:
+            return
+        min_interval = await self._reaction_min_interval()
+        elapsed = time.monotonic() - last
+        remaining = min_interval - elapsed
+        if remaining > 0:
+            run_after = datetime.now(timezone.utc) + timedelta(seconds=remaining)
+            raise TelegramCommandRetryLaterError(
+                run_after=run_after,
+                reason=f"reaction rate limit for {phone}; waiting {int(remaining) + 1}s",
+                result_payload={
+                    "state": "waiting_rate_limit",
+                    "phone": phone,
+                    "retry_after_sec": int(remaining) + 1,
+                    "next_available_at_utc": run_after.isoformat(),
+                },
+            )
+
+    async def _handle_dialogs_pin_message(self, payload: dict[str, Any]) -> dict[str, Any]:
+        result = await TelegramActionService(self._pool).pin_message(
+            phone=str(payload["phone"]),
+            chat_id=payload["chat_id"],
+            message_id=int(payload["message_id"]),
+            notify=bool(payload.get("notify", False)),
+        )
+        return {"phone": result.phone}
+
+    async def _handle_dialogs_react(self, payload: dict[str, Any]) -> dict[str, Any]:
+        phone = str(payload["phone"])
+        await self._ensure_reaction_can_run(phone)
+        emoji = normalize_outgoing_reaction_emoji(str(payload.get("emoji") or ""))
+        result = await TelegramActionService(self._pool).send_reaction(
+            phone=phone,
+            chat_id=payload["chat_id"],
+            message_id=int(payload["message_id"]),
+            emoji=emoji,
+            native=True,
+            resolve_entity=True,
+        )
+        self._last_reaction_at_monotonic[result.phone] = time.monotonic()
+        return {"phone": result.phone}
+
+    async def _handle_dialogs_unpin_message(self, payload: dict[str, Any]) -> dict[str, Any]:
+        message_id = payload.get("message_id")
+        result = await TelegramActionService(self._pool).unpin_message(
+            phone=str(payload["phone"]),
+            chat_id=payload["chat_id"],
+            message_id=int(message_id) if message_id is not None else None,
+        )
+        return {"phone": result.phone}
+
+    async def _handle_dialogs_participants(self, payload: dict[str, Any]) -> dict[str, Any]:
+        action_result = await TelegramActionService(self._pool).get_participants(
+            phone=str(payload["phone"]),
+            chat_id=payload["chat_id"],
+            limit=int(payload.get("limit", 200)),
+            search=str(payload.get("search", "")),
+        )
+        data = [
+            {
+                "id": p.id,
+                "first_name": getattr(p, "first_name", None) or "",
+                "last_name": getattr(p, "last_name", None) or "",
+                "username": getattr(p, "username", None) or "",
+            }
+            for p in action_result.participants
+        ]
+        scope = f"dialogs_participants:{action_result.phone}:{payload['chat_id']}"
+        search_value = str(payload.get("search", ""))
+        # Only cache unfiltered (full) participant lists. A search-filtered
+        # result would otherwise overwrite the shared snapshot, so later
+        # no-search GETs would return only the filtered subset.
+        if not search_value:
+            await self._db.repos.runtime_snapshots.upsert_snapshot(
+                RuntimeSnapshot(
+                    snapshot_type="dialogs_participants",
+                    scope=scope,
+                    payload={"participants": data, "total": len(data)},
+                )
+            )
+        result = {"phone": action_result.phone, "scope": scope, "total": len(data)}
+        if search_value:
+            # Search results are intentionally not cached; return them
+            # inline so the client can read them via GET /telegram-commands/{id}.
+            result["participants"] = data
+        return result
+
+    async def _handle_dialogs_broadcast_stats(self, payload: dict[str, Any]) -> dict[str, Any]:
+        action_result = await TelegramActionService(self._pool).get_broadcast_stats(
+            phone=str(payload["phone"]),
+            chat_id=payload["chat_id"],
+        )
+        stats = action_result.stats
+        fields: dict[str, Any] = {}
+        for attr in ("followers", "views_per_post", "shares_per_post", "reactions_per_post", "forwards_per_post"):
+            val = getattr(stats, attr, None)
+            if val is not None:
+                current = getattr(val, "current", None)
+                previous = getattr(val, "previous", None)
+                if current is not None:
+                    fields[attr] = {"current": current, "previous": previous}
+                else:
+                    fields[attr] = str(val)
+        period = getattr(stats, "period", None)
+        if period is not None:
+            fields["period"] = {
+                "min_date": period.min_date.isoformat() if getattr(period, "min_date", None) else None,
+                "max_date": period.max_date.isoformat() if getattr(period, "max_date", None) else None,
+            }
+        enabled_notifications = getattr(stats, "enabled_notifications", None)
+        if enabled_notifications is not None:
+            fields["enabled_notifications"] = enabled_notifications
+        if not fields:
+            fields["raw"] = str(stats)
+        scope = f"dialogs_broadcast_stats:{action_result.phone}:{payload['chat_id']}"
+        await self._db.repos.runtime_snapshots.upsert_snapshot(
+            RuntimeSnapshot(
+                snapshot_type="dialogs_broadcast_stats",
+                scope=scope,
+                payload={"stats": fields},
+            )
+        )
+        return {"phone": action_result.phone, "scope": scope}
+
+    async def _handle_dialogs_archive(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return await self._set_dialog_folder(payload, folder_id=1)
+
+    async def _handle_dialogs_unarchive(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return await self._set_dialog_folder(payload, folder_id=0)
+
+    async def _set_dialog_folder(self, payload: dict[str, Any], *, folder_id: int) -> dict[str, Any]:
+        result = await TelegramActionService(self._pool).set_dialog_folder(
+            phone=str(payload["phone"]),
+            chat_id=payload["chat_id"],
+            folder_id=folder_id,
+        )
+        return {"phone": result.phone, "folder_id": folder_id}
+
+    async def _handle_dialogs_mark_read(self, payload: dict[str, Any]) -> dict[str, Any]:
+        max_id = payload.get("max_id")
+        result = await TelegramActionService(self._pool).mark_read(
+            phone=str(payload["phone"]),
+            chat_id=payload["chat_id"],
+            max_id=int(max_id) if max_id is not None else None,
+        )
+        return {"phone": result.phone}
+
+    async def _handle_dialogs_edit_admin(self, payload: dict[str, Any]) -> dict[str, Any]:
+        result = await TelegramActionService(self._pool).edit_admin(
+            phone=str(payload["phone"]),
+            chat_id=payload["chat_id"],
+            user_id=payload["user_id"],
+            is_admin=bool(payload.get("is_admin", False)),
+            title=payload.get("title") or None,
+        )
+        return {"phone": result.phone}
+
+    async def _handle_dialogs_edit_permissions(self, payload: dict[str, Any]) -> dict[str, Any]:
+        result = await TelegramActionService(self._pool).edit_permissions(
+            phone=str(payload["phone"]),
+            chat_id=payload["chat_id"],
+            user_id=payload["user_id"],
+            until_date=parse_required_datetime(str(payload["until_date"])) if payload.get("until_date") else None,
+            send_messages=bool(payload["send_messages"]) if "send_messages" in payload else None,
+            send_media=bool(payload["send_media"]) if "send_media" in payload else None,
+        )
+        return {"phone": result.phone}
+
+    async def _handle_dialogs_kick(self, payload: dict[str, Any]) -> dict[str, Any]:
+        result = await TelegramActionService(self._pool).kick_participant(
+            phone=str(payload["phone"]),
+            chat_id=payload["chat_id"],
+            user_id=payload["user_id"],
+        )
+        return {"phone": result.phone}
+
+    async def _handle_dialogs_create_channel(self, payload: dict[str, Any]) -> dict[str, Any]:
+        result = await TelegramActionService(self._pool).create_channel(
+            phone=str(payload["phone"]),
+            title=str(payload["title"]).strip(),
+            about=str(payload.get("about", "")).strip(),
+            username=str(payload.get("username", "")).strip(),
+        )
+        return {
+            "phone": result.phone,
+            "channel_id": result.channel_id,
+            "channel_title": result.channel_title,
+            "channel_username": result.channel_username,
+            "invite_link": result.invite_link,
+        }

--- a/src/services/dispatcher/moderation_mixin.py
+++ b/src/services/dispatcher/moderation_mixin.py
@@ -1,0 +1,36 @@
+"""Moderation publish command handler (#1047).
+
+Domain: ``moderation.publish_run`` — publishes a moderated generation run to its
+pipeline target.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from src.services.dispatcher._base import _DispatcherProtocol
+
+    _Base = _DispatcherProtocol
+else:
+    _Base = object
+
+
+class ModerationCommandsMixin(_Base):
+    """``moderation.*`` command handlers."""
+
+    async def _handle_moderation_publish_run(self, payload: dict[str, Any]) -> dict[str, Any]:
+        from src.services.pipeline_service import PipelineService
+        from src.services.publish_service import PublishService
+
+        run_id = int(payload["run_id"])
+        run = await self._db.repos.generation_runs.get(run_id)
+        if run is None:
+            raise RuntimeError("run_not_found")
+        pipeline = await PipelineService(self._db).get(int(payload["pipeline_id"]))
+        if pipeline is None:
+            raise RuntimeError("pipeline_invalid")
+        results = await PublishService(self._db, self._pool).publish_run(run, pipeline)
+        if not results or not all(result.success for result in results):
+            raise RuntimeError("pipeline_run_failed")
+        return {"run_id": run_id, "published": len(results)}

--- a/src/services/dispatcher/notifications_mixin.py
+++ b/src/services/dispatcher/notifications_mixin.py
@@ -1,0 +1,56 @@
+"""Notification bot command handlers (#1047).
+
+Domain: ``notifications.*`` — setup / teardown of the personal notification bot
+and worker me-cache invalidation.
+
+``notifications.test`` and the ``_notification_target_service`` factory stay on
+the facade class: the existing suite patches ``Notifier`` /
+``NotificationTargetService`` through the facade module namespace, so their call
+sites must resolve those names from there.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from src.services.notification_service import NotificationService
+from src.services.notification_target_service import NotificationTargetService
+
+if TYPE_CHECKING:
+    from src.services.dispatcher._base import _DispatcherProtocol
+
+    _Base = _DispatcherProtocol
+else:
+    _Base = object
+
+
+class NotificationsCommandsMixin(_Base):
+    """``notifications.*`` command handlers (except the patch-sensitive test)."""
+
+    def _notification_service(self) -> NotificationService:
+        from src.database.bundles import NotificationBundle
+
+        target_service = NotificationTargetService(NotificationBundle.from_database(self._db), self._pool)
+        kwargs: dict[str, Any] = {}
+        if self._config is not None:
+            kwargs["bot_name_prefix"] = self._config.notifications.bot_name_prefix
+            kwargs["bot_username_prefix"] = self._config.notifications.bot_username_prefix
+        return NotificationService(self._db, target_service, **kwargs)
+
+    async def _handle_notifications_setup_bot(self, payload: dict[str, Any]) -> dict[str, Any]:
+        bot = await self._notification_service().setup_bot()
+        return {"bot_username": bot.bot_username, "bot_id": bot.bot_id}
+
+    async def _handle_notifications_delete_bot(self, payload: dict[str, Any]) -> dict[str, Any]:
+        await self._notification_service().teardown_bot()
+        return {"deleted": True}
+
+    async def _handle_notifications_invalidate_cache(self, payload: dict[str, Any]) -> dict[str, Any]:
+        # The web process calls notifier.invalidate_me_cache(), but its container's
+        # notifier is None — the live Notifier lives only in the worker. So a
+        # notification-account change must reach the worker over the command queue
+        # and invalidate the SHARED worker Notifier here, or it keeps sending from
+        # the old account's me.id until the worker restarts (#832).
+        if self._notifier is not None:
+            self._notifier.invalidate_me_cache()
+        return {"invalidated": True}

--- a/src/services/dispatcher/photo_mixin.py
+++ b/src/services/dispatcher/photo_mixin.py
@@ -1,0 +1,89 @@
+"""Photo send/schedule command handlers (#1047).
+
+Domain: ``photo.*`` — immediate send, scheduled send, and the due-runner that
+drains both scheduled items and auto-upload jobs.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from src.services.photo_auto_upload_service import PhotoAutoUploadService
+from src.services.photo_task_service import PhotoTarget, PhotoTaskService
+from src.utils.datetime import parse_required_schedule_datetime
+
+if TYPE_CHECKING:
+    from src.services.dispatcher._base import _DispatcherProtocol
+
+    _Base = _DispatcherProtocol
+else:
+    _Base = object
+
+
+class PhotoCommandsMixin(_Base):
+    """``photo.*`` command handlers and their service factories."""
+
+    def _photo_task_service(self) -> PhotoTaskService:
+        from src.database.bundles import PhotoLoaderBundle
+        from src.services.photo_publish_service import PhotoPublishService
+
+        return PhotoTaskService(PhotoLoaderBundle.from_database(self._db), PhotoPublishService(self._pool))
+
+    def _photo_auto_upload_service(self) -> PhotoAutoUploadService:
+        from src.database.bundles import PhotoLoaderBundle
+        from src.services.photo_publish_service import PhotoPublishService
+
+        return PhotoAutoUploadService(PhotoLoaderBundle.from_database(self._db), PhotoPublishService(self._pool))
+
+    async def _handle_photo_send_now(self, payload: dict[str, Any]) -> dict[str, Any]:
+        item = await self._photo_task_service().send_now(
+            phone=str(payload["phone"]),
+            target=PhotoTarget(
+                dialog_id=int(payload["target_dialog_id"]),
+                title=payload.get("target_title"),
+                target_type=payload.get("target_type"),
+            ),
+            file_paths=[str(path) for path in payload.get("file_paths", [])],
+            mode=str(payload.get("mode", "separate")),
+            caption=payload.get("caption"),
+        )
+        return {"item_id": item.id, "batch_id": item.batch_id}
+
+    async def _handle_photo_schedule_send(self, payload: dict[str, Any]) -> dict[str, Any]:
+        item = await self._photo_task_service().schedule_send(
+            phone=str(payload["phone"]),
+            target=PhotoTarget(
+                dialog_id=int(payload["target_dialog_id"]),
+                title=payload.get("target_title"),
+                target_type=payload.get("target_type"),
+            ),
+            file_paths=[str(path) for path in payload.get("file_paths", [])],
+            mode=str(payload.get("mode", "separate")),
+            schedule_at=parse_required_schedule_datetime(str(payload["schedule_at"])),
+            caption=payload.get("caption"),
+        )
+        return {"item_id": item.id, "batch_id": item.batch_id}
+
+    async def _handle_photo_run_due(self, payload: dict[str, Any]) -> dict[str, Any]:
+        if payload.get("dry_run"):
+            # Preview only: skip the photo-item path (no dry-run there) and ask the
+            # auto-upload service for a plan without sending, marking, or advancing state.
+            previews = await self._photo_auto_upload_service().run_due(dry_run=True)
+            assert isinstance(previews, list)  # narrow run_due's int|list return
+            return {
+                "dry_run": True,
+                "jobs": [
+                    {
+                        "job_id": preview.job_id,
+                        "target_dialog_id": preview.target_dialog_id,
+                        "target_title": preview.target_title,
+                        "target_type": preview.target_type,
+                        "send_mode": preview.send_mode.value,
+                        "files": list(preview.files),
+                    }
+                    for preview in previews
+                ],
+            }
+        items = await self._photo_task_service().run_due()
+        jobs = await self._photo_auto_upload_service().run_due()
+        return {"processed_items": items, "processed_jobs": jobs}

--- a/src/services/dispatcher/scheduler_mixin.py
+++ b/src/services/dispatcher/scheduler_mixin.py
@@ -1,0 +1,53 @@
+"""Scheduler and collection-queue command handlers (#1047).
+
+Domains: ``scheduler.*`` (reconcile / warm trigger) and ``collection.*``
+(pause / resume) — process-control commands that don't touch Telegram.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from src.services.dispatcher._base import _DispatcherProtocol
+
+    _Base = _DispatcherProtocol
+else:
+    _Base = object
+
+
+class SchedulerCommandsMixin(_Base):
+    """``scheduler.*`` and ``collection.*`` command handlers."""
+
+    async def _handle_scheduler_reconcile(self, payload: dict[str, Any]) -> dict[str, Any]:
+        if self._scheduler is None:
+            raise RuntimeError("scheduler_unavailable")
+        autostart = await self._db.get_setting("scheduler_autostart")
+        desired_running = autostart == "1"
+        if not desired_running:
+            await self._scheduler.stop()
+            await self._scheduler.load_settings()
+            return {"running": False}
+        if self._scheduler.is_running:
+            await self._scheduler.stop()
+        await self._scheduler.load_settings()
+        await self._scheduler.start()
+        return {"running": True, "interval_minutes": self._scheduler.interval_minutes}
+
+    async def _handle_scheduler_trigger_warm(self, payload: dict[str, Any]) -> dict[str, Any]:
+        if self._scheduler is None:
+            raise RuntimeError("scheduler_unavailable")
+        await self._scheduler.trigger_warm_background()
+        return {"started": True}
+
+    async def _handle_collection_pause(self, payload: dict[str, Any]) -> dict[str, Any]:
+        await self._db.set_setting("collection_queue_paused", "1")
+        if self._collection_queue is not None:
+            self._collection_queue.pause()
+        return {"paused": True}
+
+    async def _handle_collection_resume(self, payload: dict[str, Any]) -> dict[str, Any]:
+        await self._db.set_setting("collection_queue_paused", "0")
+        if self._collection_queue is not None:
+            self._collection_queue.resume()
+        return {"paused": False}

--- a/src/services/dispatcher/search_mixin.py
+++ b/src/services/dispatcher/search_mixin.py
@@ -1,0 +1,43 @@
+"""Live Telegram search command handler (#1047).
+
+Domain: ``search.telegram`` — proxies premium / my_chats / in-channel search to
+the worker's real ClientPool (#643), since the web container has no live pool.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from src.services.dispatcher._base import _DispatcherProtocol
+
+    _Base = _DispatcherProtocol
+else:
+    _Base = object
+
+
+class SearchCommandsMixin(_Base):
+    """``search.telegram`` command handler."""
+
+    async def _handle_search_telegram(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Run a live Telegram-backed search on the worker's real pool.
+
+        The web container has no live ClientPool (runtime_mode="web"), so it
+        proxies premium/my_chats/in-channel search here and reads the serialized
+        SearchResult back from ``result_payload`` (#643).
+        """
+        if self._search_engine is None:
+            raise RuntimeError("Search engine unavailable in worker")
+        query = str(payload.get("query", ""))
+        mode = str(payload.get("mode", "telegram"))
+        limit = int(payload.get("limit", 50))
+        if mode == "my_chats":
+            result = await self._search_engine.search_my_chats(query, limit=limit)
+        elif mode == "channel":
+            channel_id = payload.get("channel_id")
+            result = await self._search_engine.search_in_channel(
+                int(channel_id) if channel_id is not None else None, query, limit=limit
+            )
+        else:
+            result = await self._search_engine.search_telegram(query, limit=limit)
+        return {"result": result.model_dump(mode="json")}

--- a/src/services/telegram_command_dispatcher.py
+++ b/src/services/telegram_command_dispatcher.py
@@ -3,43 +3,46 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
-from inspect import isawaitable
+from datetime import timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from src.config import AppConfig
 from src.database import Database, DatabaseBusyError
-from src.database.live_accounts import load_live_usable_accounts
 from src.live_runtime_pause import LiveRuntimePauseGate
-from src.models import Account, RuntimeSnapshot, TelegramCommandStatus
+from src.models import RuntimeSnapshot, TelegramCommandStatus  # noqa: F401  (RuntimeSnapshot re-exported for tests)
 from src.scheduler.service import SchedulerManager
-from src.services.channel_onboarding import (
-    channel_from_resolved_info,
-    enqueue_stats_for_new_channels,
-    fetch_channel_meta,
-    get_existing_channel,
+from src.services.dispatcher._constants import (
+    COMMAND_STATUS_UPDATE_BUSY_RETRY_INITIAL_SEC,
+    COMMAND_STATUS_UPDATE_BUSY_RETRY_MAX_SEC,
+    DEFAULT_REACTION_MIN_INTERVAL_SEC,
+    REACTION_MIN_INTERVAL_CEILING_SEC,
+    REACTION_MIN_INTERVAL_FLOOR_SEC,
+    REACTION_MIN_INTERVAL_SETTING,
 )
-from src.services.notification_service import NotificationService
+from src.services.dispatcher._errors import TelegramCommandRetryLaterError
+from src.services.dispatcher.accounts_mixin import AccountsCommandsMixin
+from src.services.dispatcher.auth_mixin import AuthCommandsMixin
+from src.services.dispatcher.channels_mixin import ChannelsCommandsMixin
+from src.services.dispatcher.dialogs_mixin import DialogsCommandsMixin
+from src.services.dispatcher.moderation_mixin import ModerationCommandsMixin
+from src.services.dispatcher.notifications_mixin import NotificationsCommandsMixin
+from src.services.dispatcher.photo_mixin import PhotoCommandsMixin
+from src.services.dispatcher.scheduler_mixin import SchedulerCommandsMixin
+from src.services.dispatcher.search_mixin import SearchCommandsMixin
 from src.services.notification_target_service import NotificationTargetService
-from src.services.photo_auto_upload_service import PhotoAutoUploadService
-from src.services.photo_task_service import PhotoTarget, PhotoTaskService
 from src.services.telegram_actions import (
     TelegramActionMessageNotFoundError,
     TelegramActionNoMediaError,
     TelegramActionPathEscapeError,
     TelegramActionService,
 )
-from src.settings_utils import parse_float_setting
 from src.telegram.auth import TelegramAuth
 from src.telegram.client_pool import ClientPool
 from src.telegram.collector import Collector
 from src.telegram.flood_wait import HandledFloodWaitError
 from src.telegram.notifier import Notifier
-from src.telegram.reactions import TelegramReactionInvalidError, normalize_outgoing_reaction_emoji
-from src.telegram.utils import normalize_utc
-from src.utils.datetime import parse_required_datetime, parse_required_schedule_datetime
+from src.telegram.reactions import TelegramReactionInvalidError
 from src.utils.safe_logging import elapsed_ms, query_log_fields
 
 try:  # telethon is an optional dependency at test-time
@@ -53,29 +56,43 @@ if TYPE_CHECKING:
     from src.search.engine import SearchEngine
 
 logger = logging.getLogger(__name__)
-COMMAND_STATUS_UPDATE_BUSY_RETRY_INITIAL_SEC = 0.1
-COMMAND_STATUS_UPDATE_BUSY_RETRY_MAX_SEC = 1.0
 
-# Minimum spacing between reactions on the same phone. Configurable live via the
-# DB setting below; a non-zero floor is enforced because Telegram rate-limits
-# reactions server-side and zero spacing risks FLOOD_WAIT / account limiting.
-REACTION_MIN_INTERVAL_SETTING = "reaction_min_interval_sec"
-DEFAULT_REACTION_MIN_INTERVAL_SEC = 30.0
-REACTION_MIN_INTERVAL_FLOOR_SEC = 1.0
-REACTION_MIN_INTERVAL_CEILING_SEC = 300.0
-
-
-@dataclass(slots=True)
-class TelegramCommandRetryLaterError(RuntimeError):
-    run_after: datetime
-    reason: str
-    result_payload: dict[str, Any] | None = None
-
-    def __str__(self) -> str:
-        return self.reason
+# Re-exported so existing patch points keep working:
+#   - constants accessed/patched as ``mod.<NAME>`` by the test suite;
+#   - TelegramCommandRetryLaterError imported from this module by external code.
+__all__ = [
+    "TelegramCommandDispatcher",
+    "TelegramCommandRetryLaterError",
+    "REACTION_MIN_INTERVAL_SETTING",
+    "DEFAULT_REACTION_MIN_INTERVAL_SEC",
+    "REACTION_MIN_INTERVAL_FLOOR_SEC",
+    "REACTION_MIN_INTERVAL_CEILING_SEC",
+    "COMMAND_STATUS_UPDATE_BUSY_RETRY_INITIAL_SEC",
+    "COMMAND_STATUS_UPDATE_BUSY_RETRY_MAX_SEC",
+]
 
 
-class TelegramCommandDispatcher:
+class TelegramCommandDispatcher(
+    AuthCommandsMixin,
+    AccountsCommandsMixin,
+    SchedulerCommandsMixin,
+    DialogsCommandsMixin,
+    ChannelsCommandsMixin,
+    NotificationsCommandsMixin,
+    PhotoCommandsMixin,
+    SearchCommandsMixin,
+    ModerationCommandsMixin,
+):
+    """Worker-side command queue dispatcher.
+
+    Owns the claim/dispatch/update loop and the command-status machinery; the
+    per-domain ``_handle_*`` handlers live in the mixins above. A handful of
+    handlers stay on this class because the test suite patches symbols
+    (``TelegramActionService``, ``Notifier``, ``NotificationTargetService``) or
+    ``__file__`` through *this* module's namespace, so their call sites must
+    resolve those names here (#1047).
+    """
+
     def __init__(
         self,
         db: Database,
@@ -364,33 +381,6 @@ class TelegramCommandDispatcher:
             raise RuntimeError("client unavailable")
         return result
 
-    def _photo_task_service(self) -> PhotoTaskService:
-        from src.database.bundles import PhotoLoaderBundle
-        from src.services.photo_publish_service import PhotoPublishService
-
-        return PhotoTaskService(PhotoLoaderBundle.from_database(self._db), PhotoPublishService(self._pool))
-
-    def _photo_auto_upload_service(self) -> PhotoAutoUploadService:
-        from src.database.bundles import PhotoLoaderBundle
-        from src.services.photo_publish_service import PhotoPublishService
-
-        return PhotoAutoUploadService(PhotoLoaderBundle.from_database(self._db), PhotoPublishService(self._pool))
-
-    def _notification_service(self) -> NotificationService:
-        from src.database.bundles import NotificationBundle
-
-        target_service = NotificationTargetService(NotificationBundle.from_database(self._db), self._pool)
-        kwargs: dict[str, Any] = {}
-        if self._config is not None:
-            kwargs["bot_name_prefix"] = self._config.notifications.bot_name_prefix
-            kwargs["bot_username_prefix"] = self._config.notifications.bot_username_prefix
-        return NotificationService(self._db, target_service, **kwargs)
-
-    def _notification_target_service(self) -> NotificationTargetService:
-        from src.database.bundles import NotificationBundle
-
-        return NotificationTargetService(NotificationBundle.from_database(self._db), self._pool)
-
     def _pool_method(self, name: str) -> Any | None:
         instance_attrs = getattr(self._pool, "__dict__", {})
         if isinstance(instance_attrs, dict) and name in instance_attrs:
@@ -401,108 +391,10 @@ class TelegramCommandDispatcher:
             return None
         return candidate if callable(candidate) else None
 
-    async def _handle_auth_send_code(self, payload: dict[str, Any]) -> dict[str, Any]:
-        if self._auth is None or not self._auth.is_configured:
-            raise RuntimeError("auth_not_configured")
-        phone = str(payload["phone"]).strip()
-        result = await self._auth.send_code(phone)
-        return {"result": {"phone": phone, **result}}
+    def _notification_target_service(self) -> NotificationTargetService:
+        from src.database.bundles import NotificationBundle
 
-    async def _handle_auth_resend_code(self, payload: dict[str, Any]) -> dict[str, Any]:
-        if self._auth is None or not self._auth.is_configured:
-            raise RuntimeError("auth_not_configured")
-        phone = str(payload["phone"]).strip()
-        result = await self._auth.resend_code(phone)
-        return {"result": {"phone": phone, **result}}
-
-    async def _handle_auth_verify_code(self, payload: dict[str, Any]) -> dict[str, Any]:
-        if self._auth is None or not self._auth.is_configured:
-            raise RuntimeError("auth_not_configured")
-        phone = str(payload["phone"]).strip()
-        password_2fa = str(payload.get("password_2fa", "")).strip() or None
-        payload["password_2fa"] = ""
-        session_string = await self._auth.verify_code(
-            phone,
-            str(payload["code"]),
-            str(payload["phone_code_hash"]),
-            password_2fa,
-        )
-        existing = await self._db.get_account_summaries(active_only=False)
-        account = Account(
-            phone=phone,
-            session_string=session_string,
-            is_primary=not any(acc.phone == phone for acc in existing) and len(existing) == 0,
-            is_premium=False,
-        )
-        await self._db.add_account(account)
-        connect_result = await self._handle_accounts_connect({"phone": phone})
-        return {"result": {"phone": phone, **connect_result}, "payload_update": {**payload}}
-
-    async def _handle_scheduler_reconcile(self, payload: dict[str, Any]) -> dict[str, Any]:
-        if self._scheduler is None:
-            raise RuntimeError("scheduler_unavailable")
-        autostart = await self._db.get_setting("scheduler_autostart")
-        desired_running = autostart == "1"
-        if not desired_running:
-            await self._scheduler.stop()
-            await self._scheduler.load_settings()
-            return {"running": False}
-        if self._scheduler.is_running:
-            await self._scheduler.stop()
-        await self._scheduler.load_settings()
-        await self._scheduler.start()
-        return {"running": True, "interval_minutes": self._scheduler.interval_minutes}
-
-    async def _handle_scheduler_trigger_warm(self, payload: dict[str, Any]) -> dict[str, Any]:
-        if self._scheduler is None:
-            raise RuntimeError("scheduler_unavailable")
-        await self._scheduler.trigger_warm_background()
-        return {"started": True}
-
-    async def _handle_collection_pause(self, payload: dict[str, Any]) -> dict[str, Any]:
-        await self._db.set_setting("collection_queue_paused", "1")
-        if self._collection_queue is not None:
-            self._collection_queue.pause()
-        return {"paused": True}
-
-    async def _handle_collection_resume(self, payload: dict[str, Any]) -> dict[str, Any]:
-        await self._db.set_setting("collection_queue_paused", "0")
-        if self._collection_queue is not None:
-            self._collection_queue.resume()
-        return {"paused": False}
-
-    async def _handle_dialogs_refresh(self, payload: dict[str, Any]) -> dict[str, Any]:
-        phone = str(payload["phone"])
-        dialogs = await self._pool.get_dialogs_for_phone(phone, include_dm=True, mode="full", refresh=True)
-        await self._db.repos.dialog_cache.replace_dialogs(phone, dialogs)
-        return {"phone": phone, "dialogs_count": len(dialogs)}
-
-    async def _handle_dialogs_cache_clear(self, payload: dict[str, Any]) -> dict[str, Any]:
-        phone = str(payload.get("phone") or "").strip()
-        invalidate = getattr(self._pool, "invalidate_dialogs_cache", None)
-        if phone:
-            if callable(invalidate):
-                invalidate(phone)
-            await self._db.repos.dialog_cache.clear_dialogs(phone)
-        else:
-            if callable(invalidate):
-                invalidate()
-            await self._db.repos.dialog_cache.clear_all_dialogs()
-        return {"phone": phone}
-
-    async def _handle_dialogs_leave(self, payload: dict[str, Any]) -> dict[str, Any]:
-        phone = str(payload["phone"])
-        dialogs = [(int(item["dialog_id"]), str(item["title"])) for item in payload.get("dialogs", [])]
-        result = await TelegramActionService(self._pool).leave_dialogs(phone=phone, dialogs=dialogs)
-        return {"left": result.success_count, "failed": result.failed_count}
-
-    async def _handle_dialogs_send(self, payload: dict[str, Any]) -> dict[str, Any]:
-        result = await TelegramActionService(self._pool).send_message(
-            phone=str(payload["phone"]),
-            recipient=payload["recipient"],
-            text=payload["text"],
-        )
-        return {"phone": result.phone, "message_id": result.message_id}
+        return NotificationTargetService(NotificationBundle.from_database(self._db), self._pool)
 
     async def _handle_dialogs_join(self, payload: dict[str, Any]) -> dict[str, Any]:
         result = await TelegramActionService(self._pool).join_dialog(
@@ -510,476 +402,6 @@ class TelegramCommandDispatcher:
             target=payload["target"],
         )
         return {"phone": result.phone, "target": result.target, "via_invite": result.via_invite}
-
-    async def _handle_dialogs_resolve(self, payload: dict[str, Any]) -> dict[str, Any]:
-        identifier = str(payload["identifier"])
-        entity = await self._pool.resolve_any_entity(
-            identifier, phone=str(payload.get("phone") or "") or None
-        )
-        if not entity:
-            raise RuntimeError(f"resolve failed: {identifier!r} not found")
-        return {"entity": entity}
-
-    async def _handle_dialogs_edit_message(self, payload: dict[str, Any]) -> dict[str, Any]:
-        result = await TelegramActionService(self._pool).edit_message(
-            phone=str(payload["phone"]),
-            chat_id=payload["chat_id"],
-            message_id=int(payload["message_id"]),
-            text=payload["text"],
-        )
-        return {"phone": result.phone}
-
-    async def _handle_dialogs_delete_message(self, payload: dict[str, Any]) -> dict[str, Any]:
-        result = await TelegramActionService(self._pool).delete_messages(
-            phone=str(payload["phone"]),
-            chat_id=payload["chat_id"],
-            message_ids=[int(value) for value in payload["message_ids"]],
-        )
-        return {"phone": result.phone, "deleted": result.count}
-
-    async def _handle_dialogs_forward_messages(self, payload: dict[str, Any]) -> dict[str, Any]:
-        result = await TelegramActionService(self._pool).forward_messages(
-            phone=str(payload["phone"]),
-            from_chat=payload["from_chat"],
-            to_chat=payload["to_chat"],
-            message_ids=[int(value) for value in payload["message_ids"]],
-        )
-        return {"phone": result.phone, "forwarded": result.count}
-
-    async def _account_flood_until(self, phone: str) -> datetime | None:
-        accounts: list[Any] = []
-        for getter_name in ("get_account_summaries", "get_accounts"):
-            getter = getattr(self._db, getter_name, None)
-            if not callable(getter):
-                continue
-            try:
-                result = getter(active_only=True)
-            except TypeError:
-                result = getter()
-            if isawaitable(result):
-                result = await result
-            if isinstance(result, (list, tuple)):
-                accounts = list(result)
-                break
-        now = datetime.now(timezone.utc)
-        for account in accounts:
-            if str(getattr(account, "phone", "")) != phone:
-                continue
-            flood_until = normalize_utc(getattr(account, "flood_wait_until", None))
-            if flood_until is not None and flood_until > now:
-                return flood_until
-        return None
-
-    async def _reaction_min_interval(self) -> float:
-        """Per-phone minimum seconds between reactions, read live from DB settings.
-
-        Clamped to a non-zero floor because Telegram rate-limits reactions
-        server-side; values outside the range or unparseable fall back to the
-        default.
-        """
-        raw = await self._db.get_setting(REACTION_MIN_INTERVAL_SETTING)
-        value = parse_float_setting(
-            raw,
-            setting_name=REACTION_MIN_INTERVAL_SETTING,
-            default=DEFAULT_REACTION_MIN_INTERVAL_SEC,
-            logger=logger,
-        )
-        return max(REACTION_MIN_INTERVAL_FLOOR_SEC, min(REACTION_MIN_INTERVAL_CEILING_SEC, value))
-
-    async def _ensure_reaction_can_run(self, phone: str) -> None:
-        is_warming = self._pool_method("is_warming")
-        if callable(is_warming):
-            try:
-                warming = bool(is_warming())
-            except Exception:
-                warming = False
-            if warming:
-                run_after = datetime.now(timezone.utc) + timedelta(seconds=5)
-                raise TelegramCommandRetryLaterError(
-                    run_after=run_after,
-                    reason="account dialog warm-up is still running",
-                    result_payload={
-                        "state": "waiting_warmup",
-                        "phone": phone,
-                        "next_available_at_utc": run_after.isoformat(),
-                    },
-                )
-
-        flood_until = await self._account_flood_until(phone)
-        if flood_until is not None:
-            raise TelegramCommandRetryLaterError(
-                run_after=flood_until + timedelta(seconds=1),
-                reason=f"account {phone} is flood-waited until {flood_until.isoformat()}",
-                result_payload={
-                    "state": "waiting_flood_wait",
-                    "phone": phone,
-                    "next_available_at_utc": flood_until.isoformat(),
-                },
-            )
-
-        last = self._last_reaction_at_monotonic.get(phone)
-        if last is None:
-            return
-        min_interval = await self._reaction_min_interval()
-        elapsed = time.monotonic() - last
-        remaining = min_interval - elapsed
-        if remaining > 0:
-            run_after = datetime.now(timezone.utc) + timedelta(seconds=remaining)
-            raise TelegramCommandRetryLaterError(
-                run_after=run_after,
-                reason=f"reaction rate limit for {phone}; waiting {int(remaining) + 1}s",
-                result_payload={
-                    "state": "waiting_rate_limit",
-                    "phone": phone,
-                    "retry_after_sec": int(remaining) + 1,
-                    "next_available_at_utc": run_after.isoformat(),
-                },
-            )
-
-    async def _handle_dialogs_pin_message(self, payload: dict[str, Any]) -> dict[str, Any]:
-        result = await TelegramActionService(self._pool).pin_message(
-            phone=str(payload["phone"]),
-            chat_id=payload["chat_id"],
-            message_id=int(payload["message_id"]),
-            notify=bool(payload.get("notify", False)),
-        )
-        return {"phone": result.phone}
-
-    async def _handle_dialogs_react(self, payload: dict[str, Any]) -> dict[str, Any]:
-        phone = str(payload["phone"])
-        await self._ensure_reaction_can_run(phone)
-        emoji = normalize_outgoing_reaction_emoji(str(payload.get("emoji") or ""))
-        result = await TelegramActionService(self._pool).send_reaction(
-            phone=phone,
-            chat_id=payload["chat_id"],
-            message_id=int(payload["message_id"]),
-            emoji=emoji,
-            native=True,
-            resolve_entity=True,
-        )
-        self._last_reaction_at_monotonic[result.phone] = time.monotonic()
-        return {"phone": result.phone}
-
-    async def _handle_dialogs_unpin_message(self, payload: dict[str, Any]) -> dict[str, Any]:
-        message_id = payload.get("message_id")
-        result = await TelegramActionService(self._pool).unpin_message(
-            phone=str(payload["phone"]),
-            chat_id=payload["chat_id"],
-            message_id=int(message_id) if message_id is not None else None,
-        )
-        return {"phone": result.phone}
-
-    async def _handle_dialogs_participants(self, payload: dict[str, Any]) -> dict[str, Any]:
-        action_result = await TelegramActionService(self._pool).get_participants(
-            phone=str(payload["phone"]),
-            chat_id=payload["chat_id"],
-            limit=int(payload.get("limit", 200)),
-            search=str(payload.get("search", "")),
-        )
-        data = [
-            {
-                "id": p.id,
-                "first_name": getattr(p, "first_name", None) or "",
-                "last_name": getattr(p, "last_name", None) or "",
-                "username": getattr(p, "username", None) or "",
-            }
-            for p in action_result.participants
-        ]
-        scope = f"dialogs_participants:{action_result.phone}:{payload['chat_id']}"
-        search_value = str(payload.get("search", ""))
-        # Only cache unfiltered (full) participant lists. A search-filtered
-        # result would otherwise overwrite the shared snapshot, so later
-        # no-search GETs would return only the filtered subset.
-        if not search_value:
-            await self._db.repos.runtime_snapshots.upsert_snapshot(
-                RuntimeSnapshot(
-                    snapshot_type="dialogs_participants",
-                    scope=scope,
-                    payload={"participants": data, "total": len(data)},
-                )
-            )
-        result = {"phone": action_result.phone, "scope": scope, "total": len(data)}
-        if search_value:
-            # Search results are intentionally not cached; return them
-            # inline so the client can read them via GET /telegram-commands/{id}.
-            result["participants"] = data
-        return result
-
-    async def _handle_dialogs_broadcast_stats(self, payload: dict[str, Any]) -> dict[str, Any]:
-        action_result = await TelegramActionService(self._pool).get_broadcast_stats(
-            phone=str(payload["phone"]),
-            chat_id=payload["chat_id"],
-        )
-        stats = action_result.stats
-        fields: dict[str, Any] = {}
-        for attr in ("followers", "views_per_post", "shares_per_post", "reactions_per_post", "forwards_per_post"):
-            val = getattr(stats, attr, None)
-            if val is not None:
-                current = getattr(val, "current", None)
-                previous = getattr(val, "previous", None)
-                if current is not None:
-                    fields[attr] = {"current": current, "previous": previous}
-                else:
-                    fields[attr] = str(val)
-        period = getattr(stats, "period", None)
-        if period is not None:
-            fields["period"] = {
-                "min_date": period.min_date.isoformat() if getattr(period, "min_date", None) else None,
-                "max_date": period.max_date.isoformat() if getattr(period, "max_date", None) else None,
-            }
-        enabled_notifications = getattr(stats, "enabled_notifications", None)
-        if enabled_notifications is not None:
-            fields["enabled_notifications"] = enabled_notifications
-        if not fields:
-            fields["raw"] = str(stats)
-        scope = f"dialogs_broadcast_stats:{action_result.phone}:{payload['chat_id']}"
-        await self._db.repos.runtime_snapshots.upsert_snapshot(
-            RuntimeSnapshot(
-                snapshot_type="dialogs_broadcast_stats",
-                scope=scope,
-                payload={"stats": fields},
-            )
-        )
-        return {"phone": action_result.phone, "scope": scope}
-
-    async def _handle_dialogs_archive(self, payload: dict[str, Any]) -> dict[str, Any]:
-        return await self._set_dialog_folder(payload, folder_id=1)
-
-    async def _handle_dialogs_unarchive(self, payload: dict[str, Any]) -> dict[str, Any]:
-        return await self._set_dialog_folder(payload, folder_id=0)
-
-    async def _set_dialog_folder(self, payload: dict[str, Any], *, folder_id: int) -> dict[str, Any]:
-        result = await TelegramActionService(self._pool).set_dialog_folder(
-            phone=str(payload["phone"]),
-            chat_id=payload["chat_id"],
-            folder_id=folder_id,
-        )
-        return {"phone": result.phone, "folder_id": folder_id}
-
-    async def _handle_dialogs_mark_read(self, payload: dict[str, Any]) -> dict[str, Any]:
-        max_id = payload.get("max_id")
-        result = await TelegramActionService(self._pool).mark_read(
-            phone=str(payload["phone"]),
-            chat_id=payload["chat_id"],
-            max_id=int(max_id) if max_id is not None else None,
-        )
-        return {"phone": result.phone}
-
-    async def _handle_dialogs_edit_admin(self, payload: dict[str, Any]) -> dict[str, Any]:
-        result = await TelegramActionService(self._pool).edit_admin(
-            phone=str(payload["phone"]),
-            chat_id=payload["chat_id"],
-            user_id=payload["user_id"],
-            is_admin=bool(payload.get("is_admin", False)),
-            title=payload.get("title") or None,
-        )
-        return {"phone": result.phone}
-
-    async def _handle_dialogs_edit_permissions(self, payload: dict[str, Any]) -> dict[str, Any]:
-        result = await TelegramActionService(self._pool).edit_permissions(
-            phone=str(payload["phone"]),
-            chat_id=payload["chat_id"],
-            user_id=payload["user_id"],
-            until_date=parse_required_datetime(str(payload["until_date"])) if payload.get("until_date") else None,
-            send_messages=bool(payload["send_messages"]) if "send_messages" in payload else None,
-            send_media=bool(payload["send_media"]) if "send_media" in payload else None,
-        )
-        return {"phone": result.phone}
-
-    async def _handle_dialogs_kick(self, payload: dict[str, Any]) -> dict[str, Any]:
-        result = await TelegramActionService(self._pool).kick_participant(
-            phone=str(payload["phone"]),
-            chat_id=payload["chat_id"],
-            user_id=payload["user_id"],
-        )
-        return {"phone": result.phone}
-
-    async def _handle_dialogs_create_channel(self, payload: dict[str, Any]) -> dict[str, Any]:
-        result = await TelegramActionService(self._pool).create_channel(
-            phone=str(payload["phone"]),
-            title=str(payload["title"]).strip(),
-            about=str(payload.get("about", "")).strip(),
-            username=str(payload.get("username", "")).strip(),
-        )
-        return {
-            "phone": result.phone,
-            "channel_id": result.channel_id,
-            "channel_title": result.channel_title,
-            "channel_username": result.channel_username,
-            "invite_link": result.invite_link,
-        }
-
-    async def _handle_search_telegram(self, payload: dict[str, Any]) -> dict[str, Any]:
-        """Run a live Telegram-backed search on the worker's real pool.
-
-        The web container has no live ClientPool (runtime_mode="web"), so it
-        proxies premium/my_chats/in-channel search here and reads the serialized
-        SearchResult back from ``result_payload`` (#643).
-        """
-        if self._search_engine is None:
-            raise RuntimeError("Search engine unavailable in worker")
-        query = str(payload.get("query", ""))
-        mode = str(payload.get("mode", "telegram"))
-        limit = int(payload.get("limit", 50))
-        if mode == "my_chats":
-            result = await self._search_engine.search_my_chats(query, limit=limit)
-        elif mode == "channel":
-            channel_id = payload.get("channel_id")
-            result = await self._search_engine.search_in_channel(
-                int(channel_id) if channel_id is not None else None, query, limit=limit
-            )
-        else:
-            result = await self._search_engine.search_telegram(query, limit=limit)
-        return {"result": result.model_dump(mode="json")}
-
-    async def _handle_agent_forum_topics_refresh(self, payload: dict[str, Any]) -> dict[str, Any]:
-        channel_id = int(payload["channel_id"])
-        topics = await self._pool.get_forum_topics(channel_id)
-        if topics:
-            await self._db.upsert_forum_topics(channel_id, topics)
-            await self._db.set_channel_type(channel_id, "forum")
-        return {"channel_id": channel_id, "count": len(topics)}
-
-    async def _handle_channels_add_identifier(self, payload: dict[str, Any]) -> dict[str, Any]:
-        identifier = str(payload["identifier"]).strip()
-        info = await self._pool.resolve_channel(identifier)
-        if not info:
-            raise RuntimeError(f"resolve failed: {identifier!r} not found")
-        existing = await get_existing_channel(self._db, int(info["channel_id"]))
-        meta = await fetch_channel_meta(
-            self._pool, int(info["channel_id"]), info.get("channel_type")
-        )
-        channel = channel_from_resolved_info(info, meta)
-        await self._db.add_channel(channel)
-        stats_task_id = None
-        if existing is None and channel.is_active:
-            stats_task_id = await enqueue_stats_for_new_channels(
-                self._db.create_stats_task,
-                [channel.channel_id],
-                context="channels.add_identifier",
-            )
-        return {"channel_id": info["channel_id"], "stats_task_id": stats_task_id}
-
-    async def _handle_channels_collect_stats(self, payload: dict[str, Any]) -> dict[str, Any]:
-        if self._collector is None:
-            raise RuntimeError("collector_unavailable")
-        channel_pk = int(payload["channel_pk"])
-        channel = await self._db.get_channel_by_pk(channel_pk)
-        if channel is None:
-            raise RuntimeError("channel_not_found")
-        result = await self._collector.collect_channel_stats(channel)
-        return {"channel_id": channel.channel_id, "collected": bool(result)}
-
-    async def _handle_channels_refresh_types(self, payload: dict[str, Any]) -> dict[str, Any]:
-        channels = await self._db.get_channels(active_only=True)
-        updated = 0
-        failed = 0
-        deactivated = 0
-        quarantined = 0
-        for ch in channels:
-            identifier = ch.username or str(ch.channel_id)
-            try:
-                # numeric_fallback so a stale @username doesn't deactivate a live
-                # channel — gone is retried by numeric id first (#858 review).
-                info = await self._pool.resolve_channel(
-                    identifier, signal_gone=True, numeric_fallback=str(ch.channel_id)
-                )
-            except Exception:
-                info = None
-            # Uncertain (cache-miss vs deleted, owner unknown/unavailable) → quarantine
-            # for human review. This runs in the background worker with no interactive
-            # user, so flagging for review is the only safe move (#875 redesign).
-            if info and info.get("review"):
-                await self._db.repos.channels.set_channel_review(ch.id, info.get("reason", "uncertain"))
-                quarantined += 1
-                continue
-            # Definitive not-found → deactivate; transient None → skip and leave
-            # active (audit #835/8; old `if info is False` was unreachable).
-            if info and info.get("gone"):
-                await self._db.set_channel_active(ch.id, False)
-                await self._db.set_channel_type(ch.channel_id, "unavailable")
-                deactivated += 1
-                continue
-            if not info or info.get("channel_type") is None:
-                failed += 1
-                continue
-            # Resolved live: clear any stale quarantine flag (channel recovered).
-            if getattr(ch, "needs_review", False):
-                await self._db.repos.channels.clear_channel_review(ch.id)
-            await self._db.set_channel_type(ch.channel_id, info["channel_type"])
-            updated += 1
-        return {
-            "updated": updated,
-            "failed": failed,
-            "deactivated": deactivated,
-            "quarantined": quarantined,
-        }
-
-    async def _handle_channels_refresh_meta(self, payload: dict[str, Any]) -> dict[str, Any]:
-        channels = await self._db.get_channels(active_only=True)
-        updated = 0
-        failed = 0
-        for ch in channels:
-            try:
-                meta = await self._pool.fetch_channel_meta(ch.channel_id, ch.channel_type)
-            except Exception:
-                meta = None
-            if not meta:
-                failed += 1
-                continue
-            await self._db.update_channel_full_meta(
-                ch.channel_id,
-                about=meta["about"],
-                linked_chat_id=meta["linked_chat_id"],
-                has_comments=meta["has_comments"],
-            )
-            updated += 1
-        return {"updated": updated, "failed": failed}
-
-    async def _handle_channels_import_batch(self, payload: dict[str, Any]) -> dict[str, Any]:
-        identifiers = [str(item).strip() for item in payload.get("identifiers", []) if str(item).strip()]
-        existing = await self._db.get_channels()
-        existing_ids = {channel.channel_id for channel in existing}
-        added = 0
-        skipped = 0
-        failed = 0
-        stats_channel_ids: list[int] = []
-        details: list[dict[str, Any]] = []
-        for ident in identifiers:
-            try:
-                info = await self._pool.resolve_channel(ident)
-            except Exception:
-                info = None
-            if not info:
-                failed += 1
-                details.append({"identifier": ident, "status": "failed"})
-                continue
-            if info["channel_id"] in existing_ids:
-                skipped += 1
-                details.append({"identifier": ident, "status": "skipped"})
-                continue
-            meta = await fetch_channel_meta(
-                self._pool, int(info["channel_id"]), info.get("channel_type")
-            )
-            channel = channel_from_resolved_info(info, meta)
-            await self._db.add_channel(channel)
-            existing_ids.add(info["channel_id"])
-            if channel.is_active:
-                stats_channel_ids.append(channel.channel_id)
-            added += 1
-            details.append({"identifier": ident, "status": "added"})
-        stats_task_id = await enqueue_stats_for_new_channels(
-            self._db.create_stats_task,
-            stats_channel_ids,
-            context="channels.import_batch",
-        )
-        return {
-            "added": added,
-            "skipped": skipped,
-            "failed": failed,
-            "details": details,
-            "stats_task_id": stats_task_id,
-        }
 
     async def _handle_dialogs_download_media(self, payload: dict[str, Any]) -> dict[str, Any]:
         phone = str(payload["phone"])
@@ -1002,103 +424,6 @@ class TelegramCommandDispatcher:
         except TelegramActionPathEscapeError as exc:
             raise RuntimeError("path_escape") from exc
 
-    async def _handle_accounts_connect(self, payload: dict[str, Any]) -> dict[str, Any]:
-        phone = str(payload["phone"])
-        accounts = await load_live_usable_accounts(self._db, active_only=False)
-        account = next((a for a in accounts if a.phone == phone), None)
-        if account is None:
-            summaries = await self._db.get_account_summaries(active_only=False)
-            summary = next((a for a in summaries if a.phone == phone), None)
-            if summary is not None:
-                status = getattr(summary, "session_status", "unavailable")
-                raise RuntimeError(f"account_session_unavailable:{phone}:{status}")
-            raise RuntimeError(f"account_not_found:{phone}")
-        await self._pool.add_client(phone, account.session_string)
-        result = await self._pool.get_client_by_phone(phone)
-        is_premium = False
-        if result is not None:
-            session, acquired_phone = result
-            try:
-                me = await session.fetch_me()
-                is_premium = bool(getattr(me, "premium", False))
-            finally:
-                await self._pool.release_client(acquired_phone)
-        await self._db.update_account_premium(phone, is_premium)
-        return {"phone": phone, "is_premium": is_premium}
-
-    async def _handle_accounts_toggle(self, payload: dict[str, Any]) -> dict[str, Any]:
-        account_id = int(payload["account_id"])
-        summaries = await self._db.get_account_summaries(active_only=False)
-        account_summary = next((a for a in summaries if a.id == account_id), None)
-        live_account: Account | None = None
-        if account_summary is None:
-            accounts = await load_live_usable_accounts(self._db, active_only=False)
-            live_account = next((a for a in accounts if a.id == account_id), None)
-            account_summary = live_account
-        if account_summary is None:
-            raise RuntimeError(f"account_not_found:{account_id}")
-        new_active = not account_summary.is_active
-        await self._db.set_account_active(account_id, new_active)
-        if new_active:
-            try:
-                if live_account is None:
-                    accounts = await load_live_usable_accounts(self._db, active_only=False)
-                    live_account = next((a for a in accounts if a.id == account_id), None)
-                if live_account is None:
-                    logger.warning(
-                        "accounts.toggle: account session unavailable for %s",
-                        account_summary.phone,
-                    )
-                else:
-                    await self._pool.add_client(live_account.phone, live_account.session_string)
-            except Exception as exc:
-                logger.warning("accounts.toggle: failed to add client %s: %s", account_summary.phone, exc)
-        else:
-            try:
-                await self._pool.remove_client(account_summary.phone)
-            except Exception as exc:
-                logger.warning("accounts.toggle: failed to remove client %s: %s", account_summary.phone, exc)
-        return {"account_id": account_id, "is_active": new_active}
-
-    async def _handle_accounts_delete(self, payload: dict[str, Any]) -> dict[str, Any]:
-        account_id = int(payload["account_id"])
-        phone = str(payload.get("phone") or "").strip()
-        delete_from_db = not phone
-        if not phone:
-            accounts = await self._db.get_account_summaries(active_only=False)
-            account = next((a for a in accounts if a.id == account_id), None)
-            phone = account.phone if account is not None else ""
-        if phone:
-            try:
-                await self._pool.remove_client(phone)
-            except Exception as exc:
-                logger.warning("accounts.delete: failed to remove client %s: %s", phone, exc)
-        if delete_from_db:
-            await self._db.delete_account(account_id)
-        return {
-            "account_id": account_id,
-            "deleted": delete_from_db,
-            "client_removed": bool(phone),
-        }
-
-    async def _handle_notifications_setup_bot(self, payload: dict[str, Any]) -> dict[str, Any]:
-        bot = await self._notification_service().setup_bot()
-        return {"bot_username": bot.bot_username, "bot_id": bot.bot_id}
-
-    async def _handle_notifications_delete_bot(self, payload: dict[str, Any]) -> dict[str, Any]:
-        await self._notification_service().teardown_bot()
-        return {"deleted": True}
-
-    async def _handle_notifications_invalidate_cache(self, payload: dict[str, Any]) -> dict[str, Any]:
-        # The web process calls notifier.invalidate_me_cache(), but its container's
-        # notifier is None — the live Notifier lives only in the worker. So a
-        # notification-account change must reach the worker over the command queue
-        # and invalidate the SHARED worker Notifier here, or it keeps sending from
-        # the old account's me.id until the worker restarts (#832).
-        if self._notifier is not None:
-            self._notifier.invalidate_me_cache()
-        return {"invalidated": True}
-
     async def _handle_notifications_test(self, payload: dict[str, Any]) -> dict[str, Any]:
         from src.database.bundles import NotificationBundle
 
@@ -1109,72 +434,3 @@ class TelegramCommandDispatcher:
         if not ok:
             raise RuntimeError("notification_test_failed")
         return {"sent": True}
-
-    async def _handle_photo_send_now(self, payload: dict[str, Any]) -> dict[str, Any]:
-        item = await self._photo_task_service().send_now(
-            phone=str(payload["phone"]),
-            target=PhotoTarget(
-                dialog_id=int(payload["target_dialog_id"]),
-                title=payload.get("target_title"),
-                target_type=payload.get("target_type"),
-            ),
-            file_paths=[str(path) for path in payload.get("file_paths", [])],
-            mode=str(payload.get("mode", "separate")),
-            caption=payload.get("caption"),
-        )
-        return {"item_id": item.id, "batch_id": item.batch_id}
-
-    async def _handle_photo_schedule_send(self, payload: dict[str, Any]) -> dict[str, Any]:
-        item = await self._photo_task_service().schedule_send(
-            phone=str(payload["phone"]),
-            target=PhotoTarget(
-                dialog_id=int(payload["target_dialog_id"]),
-                title=payload.get("target_title"),
-                target_type=payload.get("target_type"),
-            ),
-            file_paths=[str(path) for path in payload.get("file_paths", [])],
-            mode=str(payload.get("mode", "separate")),
-            schedule_at=parse_required_schedule_datetime(str(payload["schedule_at"])),
-            caption=payload.get("caption"),
-        )
-        return {"item_id": item.id, "batch_id": item.batch_id}
-
-    async def _handle_photo_run_due(self, payload: dict[str, Any]) -> dict[str, Any]:
-        if payload.get("dry_run"):
-            # Preview only: skip the photo-item path (no dry-run there) and ask the
-            # auto-upload service for a plan without sending, marking, or advancing state.
-            previews = await self._photo_auto_upload_service().run_due(dry_run=True)
-            assert isinstance(previews, list)  # narrow run_due's int|list return
-            return {
-                "dry_run": True,
-                "jobs": [
-                    {
-                        "job_id": preview.job_id,
-                        "target_dialog_id": preview.target_dialog_id,
-                        "target_title": preview.target_title,
-                        "target_type": preview.target_type,
-                        "send_mode": preview.send_mode.value,
-                        "files": list(preview.files),
-                    }
-                    for preview in previews
-                ],
-            }
-        items = await self._photo_task_service().run_due()
-        jobs = await self._photo_auto_upload_service().run_due()
-        return {"processed_items": items, "processed_jobs": jobs}
-
-    async def _handle_moderation_publish_run(self, payload: dict[str, Any]) -> dict[str, Any]:
-        from src.services.pipeline_service import PipelineService
-        from src.services.publish_service import PublishService
-
-        run_id = int(payload["run_id"])
-        run = await self._db.repos.generation_runs.get(run_id)
-        if run is None:
-            raise RuntimeError("run_not_found")
-        pipeline = await PipelineService(self._db).get(int(payload["pipeline_id"]))
-        if pipeline is None:
-            raise RuntimeError("pipeline_invalid")
-        results = await PublishService(self._db, self._pool).publish_run(run, pipeline)
-        if not results or not all(result.success for result in results):
-            raise RuntimeError("pipeline_run_failed")
-        return {"run_id": run_id, "published": len(results)}

--- a/tests/test_telegram_action_contract.py
+++ b/tests/test_telegram_action_contract.py
@@ -23,6 +23,17 @@ ENTRYPOINT_ROOTS = (
 )
 ENTRYPOINT_FILES = {
     Path("src/services/telegram_command_dispatcher.py"),
+    # Per-domain dispatcher mixins (#1047) must keep delegating Telegram actions
+    # through TelegramActionService, same as the facade they were split out of.
+    Path("src/services/dispatcher/dialogs_mixin.py"),
+    Path("src/services/dispatcher/channels_mixin.py"),
+    Path("src/services/dispatcher/accounts_mixin.py"),
+    Path("src/services/dispatcher/auth_mixin.py"),
+    Path("src/services/dispatcher/scheduler_mixin.py"),
+    Path("src/services/dispatcher/notifications_mixin.py"),
+    Path("src/services/dispatcher/photo_mixin.py"),
+    Path("src/services/dispatcher/search_mixin.py"),
+    Path("src/services/dispatcher/moderation_mixin.py"),
 }
 ENTRYPOINT_FORBIDDEN_ACTION_CALLS = {
     "send_message",

--- a/tests/test_telegram_command_dispatcher_structure.py
+++ b/tests/test_telegram_command_dispatcher_structure.py
@@ -1,0 +1,155 @@
+"""Characterization tests for the TelegramCommandDispatcher domain split (#1047).
+
+These pin the *structure* contract that the 1162-line monolith was broken into
+per-domain mixin modules **without changing behaviour**:
+
+- the public class and error type still import from the historical module path;
+- every command type the queue can carry still resolves to a callable handler
+  via the unchanged ``getattr``-based dispatch;
+- the per-domain mixins are real, independent classes in the new subpackage,
+  and the dispatcher inherits all of them;
+- the module-level symbols that the existing suite patches stay re-exported on
+  the facade module so 150 patch points keep working.
+
+Together with the existing behavioural suite (test_telegram_command_dispatcher.py)
+this is the red→green anchor for the refactor: the behaviour suite proves the
+handlers still *do* the same thing, this file proves they were actually moved.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import src.services.telegram_command_dispatcher as mod
+from src.services.telegram_command_dispatcher import (
+    DEFAULT_REACTION_MIN_INTERVAL_SEC,
+    REACTION_MIN_INTERVAL_SETTING,
+    TelegramCommandDispatcher,
+    TelegramCommandRetryLaterError,
+)
+
+# Every command_type the dispatcher must still route. Derived from the queue
+# contract (command_type -> _handle_<command_type with dots as underscores>).
+EXPECTED_COMMAND_TYPES = [
+    "auth.send_code",
+    "auth.resend_code",
+    "auth.verify_code",
+    "scheduler.reconcile",
+    "scheduler.trigger_warm",
+    "collection.pause",
+    "collection.resume",
+    "dialogs.refresh",
+    "dialogs.cache_clear",
+    "dialogs.leave",
+    "dialogs.send",
+    "dialogs.join",
+    "dialogs.resolve",
+    "dialogs.edit_message",
+    "dialogs.delete_message",
+    "dialogs.forward_messages",
+    "dialogs.pin_message",
+    "dialogs.react",
+    "dialogs.unpin_message",
+    "dialogs.participants",
+    "dialogs.broadcast_stats",
+    "dialogs.archive",
+    "dialogs.unarchive",
+    "dialogs.mark_read",
+    "dialogs.edit_admin",
+    "dialogs.edit_permissions",
+    "dialogs.kick",
+    "dialogs.create_channel",
+    "dialogs.download_media",
+    "search.telegram",
+    "agent.forum_topics_refresh",
+    "channels.add_identifier",
+    "channels.collect_stats",
+    "channels.refresh_types",
+    "channels.refresh_meta",
+    "channels.import_batch",
+    "accounts.connect",
+    "accounts.toggle",
+    "accounts.delete",
+    "notifications.setup_bot",
+    "notifications.delete_bot",
+    "notifications.invalidate_cache",
+    "notifications.test",
+    "photo.send_now",
+    "photo.schedule_send",
+    "photo.run_due",
+    "moderation.publish_run",
+]
+
+
+def test_public_api_imports_from_historical_module_path():
+    """External consumers (web/bootstrap, cli/settings) import these names from
+    src.services.telegram_command_dispatcher — the split must not move them."""
+    assert TelegramCommandDispatcher.__name__ == "TelegramCommandDispatcher"
+    assert issubclass(TelegramCommandRetryLaterError, RuntimeError)
+    assert isinstance(DEFAULT_REACTION_MIN_INTERVAL_SEC, float)
+    assert REACTION_MIN_INTERVAL_SETTING == "reaction_min_interval_sec"
+
+
+def test_every_expected_command_type_resolves_to_a_handler():
+    """The unchanged ``getattr`` dispatch must find a callable for every command
+    type the queue can carry, regardless of which mixin now owns it."""
+    for command_type in EXPECTED_COMMAND_TYPES:
+        handler_name = f"_handle_{command_type.replace('.', '_')}"
+        handler = getattr(TelegramCommandDispatcher, handler_name, None)
+        assert callable(handler), f"missing handler for {command_type!r}: {handler_name}"
+
+
+def test_dispatcher_is_composed_of_per_domain_mixins():
+    """The monolith was split into independent per-domain mixin classes; the
+    dispatcher must inherit all of them (so MRO keeps every handler on self)."""
+    from src.services.dispatcher.accounts_mixin import AccountsCommandsMixin
+    from src.services.dispatcher.auth_mixin import AuthCommandsMixin
+    from src.services.dispatcher.channels_mixin import ChannelsCommandsMixin
+    from src.services.dispatcher.dialogs_mixin import DialogsCommandsMixin
+    from src.services.dispatcher.moderation_mixin import ModerationCommandsMixin
+    from src.services.dispatcher.notifications_mixin import NotificationsCommandsMixin
+    from src.services.dispatcher.photo_mixin import PhotoCommandsMixin
+    from src.services.dispatcher.scheduler_mixin import SchedulerCommandsMixin
+    from src.services.dispatcher.search_mixin import SearchCommandsMixin
+
+    mixins = (
+        AuthCommandsMixin,
+        AccountsCommandsMixin,
+        SchedulerCommandsMixin,
+        DialogsCommandsMixin,
+        ChannelsCommandsMixin,
+        NotificationsCommandsMixin,
+        PhotoCommandsMixin,
+        SearchCommandsMixin,
+        ModerationCommandsMixin,
+    )
+    for mixin in mixins:
+        assert issubclass(TelegramCommandDispatcher, mixin), f"not a base: {mixin.__name__}"
+
+
+def test_patch_sensitive_symbols_stay_on_facade_module():
+    """150 existing tests patch these via the facade module namespace; they must
+    remain bound there after the split or the patches silently no-op."""
+    for name in ("TelegramActionService", "Notifier", "NotificationTargetService", "asyncio"):
+        assert hasattr(mod, name), f"facade no longer re-exports {name!r}"
+
+
+def test_patch_sensitive_handlers_are_defined_on_the_facade_class_body():
+    """These handlers resolve a symbol patched via ``mod`` (TelegramActionService,
+    Notifier, NotificationTargetService) or read ``mod.__file__`` — they must be
+    defined in the facade class' own module so the patch reaches the call site."""
+    facade_module = TelegramCommandDispatcher.__module__
+    for handler_name in (
+        "_handle_dialogs_join",
+        "_handle_dialogs_download_media",
+        "_handle_notifications_test",
+        "_notification_target_service",
+        "_run_loop",
+        "_update_command_safely",
+    ):
+        method = getattr(TelegramCommandDispatcher, handler_name)
+        owner_module = inspect.unwrap(method).__module__
+        assert owner_module == facade_module, (
+            f"{handler_name} must stay in {facade_module} (patch-sensitive), "
+            f"found in {owner_module}"
+        )


### PR DESCRIPTION
Closes #1047 · Родитель #1023 · Группа 2 (горячие зоны)

## Контекст
`src/services/telegram_command_dispatcher.py` — монолит на **1162 строки**, MI rank **C (0.00)**. Диспетчер Telegram-команд (сервис #12 «Диалоги» в карте #1022). Тир-1 риск: 33 tools, ~25 web-экшенов, много phone-bound мутаций, очередь команд — широкая mutation-поверхность. Цель — снизить объём + сложность, разнеся обработчики по доменам, **без смены поведения**.

## Подход: mixin-классы (не register-функции)
Диспетчеризация идёт через `getattr(self, "_handle_<type>")` — lookup обходит MRO инстанса. Эталон `messaging_*.py` использует `register_*`, но там tools регистрируются вызовом функций, а не getattr-диспетчем. Mixin-классы по доменам сохраняют каждый handler на `self` без glue-кода, и `patch.object(type(d), ...)` в тестах продолжает работать через MRO concrete-класса.

## Что сделано
- **47 `_handle_*`** разнесены в `src/services/dispatcher/*_mixin.py` по доменам: `auth` / `accounts` / `scheduler` / `dialogs` / `channels` / `notifications` / `photo` / `search` / `moderation`.
- **Facade** `telegram_command_dispatcher.py` (**1162→436 стр**, MI **C→A**) держит loop-машинерию (`_run_loop`, `_update_command_safely`, `_dispatch`, `_unwrap_result_payload`, `_get_client`, `_pool_method`) + публичный класс. Все внешние импорты (web/bootstrap, cli/settings, settings/forms) и константы re-export'ятся как прежде.
- **5 патч-чувствительных методов оставлены на facade-классе намеренно**: тесты патчат `TelegramActionService` / `Notifier` / `NotificationTargetService` / `__file__` через namespace ЭТОГО модуля → их call-site должен резолвить символы здесь (`_handle_dialogs_join`, `_handle_dialogs_download_media`, `_handle_notifications_test`, `_notification_target_service`).
- Константы и `TelegramCommandRetryLaterError` вынесены в `_constants.py` / `_errors.py` (разрыв цикла facade↔mixins); facade их re-export'ит. Типизация mixin'ов через `_DispatcherProtocol` под `TYPE_CHECKING`.

## Сохранение контракта (TDD red→green)
- **150 характеризационных тестов** (`test_telegram_command_dispatcher.py`) **НЕ менялись** и зелёные — доказывают, что handler'ы делают то же самое.
- Новый `test_telegram_command_dispatcher_structure.py` (5 тестов) фиксирует структурный контракт: 47 команд резолвятся, mixin-композиция собрана, патч-точки на facade. RED до разбивки → GREEN после.
- `test_telegram_action_contract.py`: новые mixin-модули добавлены в `ENTRYPOINT_FILES`, чтобы инвариант делегирования Telegram-действий через `TelegramActionService` покрывал и их.
- Контракт очереди команд (`telegram_commands`, статусы pending→running→completed/failed) и redacted JSON-статус не затронуты.

## Метрики
| | ДО | ПОСЛЕ |
|---|---|---|
| Facade строк | 1162 | 436 (−62%) |
| Facade MI rank | C (0.00) | A (100%) |
| except Exception в facade | 9 | 2 |
| CC-блоки C+ в facade | 3 (`_run_loop` C20, `accounts_toggle` C14, `refresh_types` C11) | 1 (`_run_loop` C20) |
| Подпакет dispatcher/ | — | 13 файлов, 100% MI rank A |

## Верификация
- ✅ Полный сьют: **8446 passed** (parallel) + **898 passed** (serial aiosqlite) = 9344, 0 failed, 0 warnings
- ✅ `ruff check src/ tests/ conftest.py` — clean
- ✅ `lint-imports --config .importlinter` — 1 kept, 0 broken
- ✅ mypy — **0 новых ошибок** (5 имевшихся в монолите переехали в mixin'ы как есть)
- Real-TG `mutation_safe/test_dialogs_*` не запускались (opt-in, без согласия владельца) — поведение handler'ов покрыто фейк-harness тестами.

## runtime_shims / #1046
Задача предупреждала о возможном конфликте с #1046 (ClientPool) в `src/web/runtime_shims.py`. Проверено: диспетчер **не имеет** snapshot-shim в runtime_shims, и origin/main не содержит изменений этого файла → конфликта нет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)