### PR TITLE
test(images): retry/billing + lifecycle + S3 durability guards (#1035)

### DIFF
--- a/src/services/provider_adapters.py
+++ b/src/services/provider_adapters.py
@@ -140,11 +140,12 @@ async def _parse_json_for_text(data: Any) -> str:
                 c = data["choices"][0]
                 if isinstance(c, dict):
                     if "message" in c:
-                        # `content` can be JSON null (tool-call/refusal/filter);
-                        # dict.get(default) keeps the stored None, breaking the
-                        # -> str contract downstream (audit #836/8). Coerce to "".
-                        return c["message"].get("content") or ""
-                    return c.get("text") or ""
+                        # `content` can be JSON null (tool-call/refusal/filter) or
+                        # — for a malformed/unexpected payload — a nested object;
+                        # either breaks the -> str contract downstream. Coerce so a
+                        # dict/null never leaks out (audit #836/8, #971 class).
+                        return _coerce_str(c["message"].get("content"))
+                    return _coerce_str(c.get("text"))
             except Exception:
                 pass
         # Cohere style
@@ -160,8 +161,10 @@ async def _parse_json_for_text(data: Any) -> str:
             try:
                 out = data["outputs"][0]
                 if isinstance(out, dict):
-                    # values can be JSON null; coerce to "" to keep the -> str contract
-                    return out.get("content") or out.get("text") or ""
+                    # values can be JSON null OR a nested object on a malformed
+                    # payload; coerce so the -> str contract holds either way
+                    # (#836 null case + #971 nested-object class).
+                    return _coerce_str(out.get("content") or out.get("text"))
                 return str(out)
             except Exception:
                 pass

--- a/tests/test_image_generation_service.py
+++ b/tests/test_image_generation_service.py
@@ -1083,3 +1083,36 @@ async def test_generate_records_cost_when_allowed():
     result = await svc.generate("together:flux", "a cat")
     assert result == "http://img/result.png"
     assert limits._cost_tracker.get_daily_cost() == pytest.approx(1.0)
+
+
+@pytest.mark.anyio
+async def test_generate_invokes_adapter_once_with_limits_configured():
+    """Even on the limits-enabled path (acquire → adapter → record_cost), the paid
+    adapter is invoked exactly once — the cost-cap wiring adds no retry around the
+    non-idempotent billed call (#958 class, limits branch of generate())."""
+    from src.services.production_limits_service import (
+        CostConfig,
+        ProductionLimitsService,
+        RateLimitConfig,
+    )
+
+    db = MagicMock()
+    db.get_setting = AsyncMock(return_value=None)
+    limits = ProductionLimitsService(
+        db, RateLimitConfig(), CostConfig(cost_per_image=1.0, daily_cost_cap=100.0)
+    )
+    calls = {"n": 0}
+
+    async def counting(text, model_id):
+        calls["n"] += 1
+        return "http://img/result.png"
+
+    svc = ImageGenerationService.__new__(ImageGenerationService)
+    svc._adapters = {"together": counting}
+    svc._s3 = None
+    svc._last_failure = None
+    svc._limits = limits
+
+    result = await svc.generate("together:flux", "a cat")
+    assert result == "http://img/result.png"
+    assert calls["n"] == 1

--- a/tests/test_image_generation_service.py
+++ b/tests/test_image_generation_service.py
@@ -930,6 +930,93 @@ async def test_local_path_uploaded_via_upload_file():
     s3.upload_file.assert_awaited_once()
 
 
+@pytest.mark.anyio
+async def test_generate_skips_mirror_for_already_owned_s3_url():
+    """A result URL already pointing at our S3 (owns_url=True) is NOT re-mirrored.
+
+    Without this guard a presigned S3 URL would be downloaded and re-uploaded on
+    every generation that returned it, churning storage and rotating the key
+    (#836/4). The URL must pass through untouched and upload_url must not run.
+    """
+    svc = _make_clean_service()
+
+    owned = "https://s3.example.com/bucket/images/abc.png?sig=x"
+
+    async def s3_url_adapter(prompt: str, model: str) -> str:
+        return owned
+
+    svc.register_adapter("replicate", s3_url_adapter)
+    s3 = MagicMock()
+    s3.owns_url = MagicMock(return_value=True)
+    s3.upload_url = AsyncMock(return_value="https://s3.example.com/bucket/SHOULD-NOT-BE-USED")
+    svc._s3 = s3
+
+    result = await svc.generate("replicate:m", "x")
+    assert result == owned  # returned unchanged
+    s3.owns_url.assert_called_once_with(owned)
+    s3.upload_url.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_generate_http_mirror_failure_falls_back_to_provider_url():
+    """When mirroring an ephemeral URL into S3 fails (upload_url → None), generate
+    falls back to the original provider URL instead of dropping the result.
+
+    Symmetric to the local-path fallback (test_generate_s3_upload_fails_returns_local_path)
+    — a transient S3 outage must not turn a successful (billed) generation into None.
+    """
+    svc = _make_clean_service()
+
+    provider_url = "https://replicate.delivery/ephemeral.png"
+
+    async def replicate_adapter(prompt: str, model: str) -> str:
+        return provider_url
+
+    svc.register_adapter("replicate", replicate_adapter)
+    s3 = MagicMock()
+    s3.owns_url = MagicMock(return_value=False)
+    s3.upload_url = AsyncMock(return_value=None)  # mirror failed
+    svc._s3 = s3
+
+    result = await svc.generate("replicate:m", "x")
+    assert result == provider_url  # graceful fallback, not None
+    s3.upload_url.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_generate_returns_result_unchanged_when_s3_not_configured():
+    """With no S3 store the adapter result (local path) is returned verbatim —
+    no S3 attribute access, no upload, behaving exactly as a no-S3 deploy."""
+    svc = _make_clean_service()
+    # _make_clean_service uses __new__, so _s3 is absent → getattr(...) is None.
+    assert getattr(svc, "_s3", None) is None
+
+    async def local_adapter(prompt: str, model: str) -> str:
+        return "/data/image/local.png"
+
+    svc.register_adapter("hf", local_adapter)
+    result = await svc.generate("hf:m", "x")
+    assert result == "/data/image/local.png"
+
+
+@pytest.mark.anyio
+async def test_generate_invokes_adapter_exactly_once():
+    """The paid adapter is invoked exactly once per generate() — the service adds
+    no auto-retry around the non-idempotent billed call (#958 double-billing class).
+    """
+    svc = _make_clean_service()
+    calls = {"n": 0}
+
+    async def counting_adapter(prompt: str, model: str) -> str:
+        calls["n"] += 1
+        return "https://img.example.com/x.png"
+
+    svc.register_adapter("fake", counting_adapter)
+    result = await svc.generate("fake:m", "a cat")
+    assert result == "https://img.example.com/x.png"
+    assert calls["n"] == 1
+
+
 # ── production limits enforcement (#814) ──
 
 

--- a/tests/test_provider_adapters.py
+++ b/tests/test_provider_adapters.py
@@ -1,5 +1,8 @@
 """Tests for provider adapters."""
 
+import asyncio
+
+import aiohttp
 import pytest
 
 from src.services.provider_adapters import (
@@ -49,6 +52,55 @@ def fake_client_session_factory(resp):
 
         async def __aenter__(self):
             return FakeSession(resp)
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    return _Factory
+
+
+class _CountingSession:
+    """aiohttp.ClientSession stand-in that counts ``post`` calls and either
+    returns a fixed response or raises a (transient) network error on every call.
+
+    Used by the retry/billing regression guards (#958): a raw-HTTP image/LLM POST
+    is non-idempotent + billed, so the adapter must issue EXACTLY ONE ``post`` and
+    never silently auto-retry on a transient failure. The counter makes a hidden
+    retry loop observable — a single ``post`` keeps the count at 1, any retry
+    drives it past 1 and fails the assertion.
+    """
+
+    def __init__(self, *, resp=None, raise_exc=None, timeout=None):
+        self._resp = resp
+        self._raise_exc = raise_exc
+        self.post_calls = 0
+        # Record the ClientTimeout the adapter passed to ClientSession so the
+        # lifecycle guard can assert the 120s budget is wired through (#633 bug #10).
+        self.init_timeout = timeout
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def post(self, *args, **kwargs):
+        self.post_calls += 1
+        if self._raise_exc is not None:
+            raise self._raise_exc
+        return self._resp
+
+
+def counting_session_factory(session: "_CountingSession"):
+    """Return a fake ``aiohttp.ClientSession`` class yielding *session* and
+    capturing the ``timeout=`` kwarg the adapter constructs it with."""
+
+    class _Factory:
+        def __init__(self, *args, **kwargs):
+            session.init_timeout = kwargs.get("timeout")
+
+        async def __aenter__(self):
+            return session
 
         async def __aexit__(self, exc_type, exc, tb):
             return False
@@ -360,6 +412,59 @@ async def test_generic_http_adapter_error(monkeypatch):
     assert "502" in str(exc_info.value)
 
 
+# === Retry/billing regression guards: raw-HTTP adapters issue exactly one POST ===
+#
+# The image/LLM POST is non-idempotent and billed per request, so a transient
+# network failure must NOT silently auto-retry (the #958 double-billing class:
+# the SDK image adapters pin ``max_retries=0`` for the same reason). The raw
+# aiohttp adapters never wrapped the POST in a retry loop — these guards make
+# that contract explicit so a future "add a retry for resilience" change to a
+# billed POST trips a red test instead of shipping silent double-charges.
+
+
+@pytest.mark.anyio
+async def test_generic_http_adapter_no_retry_on_network_error(monkeypatch):
+    """A transient connection error must surface after exactly ONE POST.
+
+    Regression guard (#958 class): wrapping a billed POST in an auto-retry loop
+    would replay the charge. The counting session proves a single ``post`` —
+    any retry drives the count past 1 and fails here.
+    """
+    session = _CountingSession(raise_exc=aiohttp.ClientConnectionError("connection reset"))
+    monkeypatch.setattr("aiohttp.ClientSession", counting_session_factory(session))
+    adapter = make_generic_http_adapter("https://api.example.com/generate")
+    with pytest.raises(aiohttp.ClientConnectionError):
+        await adapter("prompt")
+    assert session.post_calls == 1
+
+
+@pytest.mark.anyio
+async def test_generic_http_adapter_no_retry_on_5xx(monkeypatch):
+    """A 5xx is a transient error the openai SDK would retry — the raw adapter
+    must not: it raises after a single POST so a billed request is not replayed."""
+    resp = FakeResp(status=503, text_data="Service Unavailable")
+    session = _CountingSession(resp=resp)
+    monkeypatch.setattr("aiohttp.ClientSession", counting_session_factory(session))
+    adapter = make_generic_http_adapter("https://api.example.com/generate")
+    with pytest.raises(RuntimeError, match="503"):
+        await adapter("prompt")
+    assert session.post_calls == 1
+
+
+@pytest.mark.anyio
+async def test_generic_http_adapter_passes_http_timeout(monkeypatch):
+    """The adapter wires the shared 120s budget into ClientSession so a stalled
+    upstream surfaces a timeout instead of hanging the coroutine (#633 bug #10)."""
+    from src.services.provider_adapters import _HTTP_TIMEOUT
+
+    resp = FakeResp(status=200, json_data={"text": "ok"})
+    session = _CountingSession(resp=resp)
+    monkeypatch.setattr("aiohttp.ClientSession", counting_session_factory(session))
+    adapter = make_generic_http_adapter("https://api.example.com/generate")
+    await adapter("prompt")
+    assert session.init_timeout is _HTTP_TIMEOUT
+
+
 # === Context7 adapter tests ===
 
 
@@ -498,6 +603,21 @@ async def test_together_image_adapter_empty_data(monkeypatch):
 
 
 @pytest.mark.anyio
+async def test_together_image_adapter_wraps_non_runtime_crash(monkeypatch):
+    """A provider crash that surfaces as a non-RuntimeError (e.g. ConnectionError)
+    must still be wrapped in a RuntimeError carrying provider context, so callers
+    get a uniform error type and a single billed POST is not retried (#958)."""
+    from src.services.provider_adapters import make_together_image_adapter
+
+    patch_async_openai(monkeypatch, error=ConnectionError("upstream dropped"))
+    adapter = make_together_image_adapter("fake-key")
+    with pytest.raises(RuntimeError, match="Together image error") as exc_info:
+        await adapter("a cat")
+    # Original crash is chained for diagnostics, not swallowed.
+    assert isinstance(exc_info.value.__cause__, ConnectionError)
+
+
+@pytest.mark.anyio
 async def test_huggingface_image_adapter_warns_no_slash(monkeypatch, caplog):
     import logging
 
@@ -562,6 +682,77 @@ async def test_huggingface_image_adapter_non_image_content_type(monkeypatch):
             await adapter("a cat")
 
 
+# === HuggingFace retry/billing + lifecycle guards ===
+#
+# HuggingFace is the ONLY image adapter still on raw aiohttp (its SDK returns a
+# PIL.Image, pulling Pillow). Its image POST is just as non-idempotent and billed
+# as the SDK adapters that pin ``max_retries=0`` (#958), so it gets the same
+# regression guard: exactly one POST, no silent retry, and the 120s budget wired
+# through so a stalled upstream times out instead of hanging the worker.
+
+
+@pytest.mark.anyio
+async def test_huggingface_image_adapter_no_retry_on_network_error(monkeypatch):
+    """A transient connection error surfaces after exactly ONE POST — the billed
+    image request is never silently replayed (the #958 double-billing class)."""
+    from src.services.provider_adapters import make_huggingface_image_adapter
+
+    session = _CountingSession(raise_exc=aiohttp.ClientConnectionError("connection reset"))
+    monkeypatch.setattr("aiohttp.ClientSession", counting_session_factory(session))
+
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        adapter = make_huggingface_image_adapter("fake-token", output_dir=tmpdir)
+        with pytest.raises(aiohttp.ClientConnectionError):
+            await adapter("a cat", "stabilityai/sdxl")
+    assert session.post_calls == 1
+
+
+@pytest.mark.anyio
+async def test_huggingface_image_adapter_no_retry_on_timeout(monkeypatch):
+    """A timeout (the openai SDK's prime retry trigger) is propagated after a
+    single POST — the raw HF adapter must not auto-retry a billed request."""
+    from src.services.provider_adapters import make_huggingface_image_adapter
+
+    session = _CountingSession(raise_exc=asyncio.TimeoutError())
+    monkeypatch.setattr("aiohttp.ClientSession", counting_session_factory(session))
+
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        adapter = make_huggingface_image_adapter("fake-token", output_dir=tmpdir)
+        with pytest.raises((asyncio.TimeoutError, TimeoutError)):
+            await adapter("a cat", "stabilityai/sdxl")
+    assert session.post_calls == 1
+
+
+@pytest.mark.anyio
+async def test_huggingface_image_adapter_passes_http_timeout(monkeypatch):
+    """The HF adapter wires the shared 120s budget into ClientSession (#633 bug #10)."""
+    from src.services.provider_adapters import _HTTP_TIMEOUT, make_huggingface_image_adapter
+
+    class ImageResp(FakeResp):
+        content_type = "image/png"
+
+        def __init__(self):
+            super().__init__(status=200)
+
+        async def read(self):
+            return b"\x89PNG\r\n\x1a\n"
+
+    session = _CountingSession(resp=ImageResp())
+    monkeypatch.setattr("aiohttp.ClientSession", counting_session_factory(session))
+
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        adapter = make_huggingface_image_adapter("fake-token", output_dir=tmpdir)
+        await adapter("a cat", "stabilityai/sdxl")
+    assert session.init_timeout is _HTTP_TIMEOUT
+    assert session.post_calls == 1
+
+
 @pytest.mark.anyio
 async def test_openai_image_adapter_success(monkeypatch):
     from src.services.provider_adapters import make_openai_image_adapter
@@ -609,6 +800,50 @@ async def test_openai_image_adapter_empty_data(monkeypatch):
     adapter = make_openai_image_adapter("fake-key")
     with pytest.raises(RuntimeError, match="empty"):
         await adapter("a sunset")
+
+
+@pytest.mark.anyio
+async def test_openai_image_adapter_wraps_non_runtime_crash(monkeypatch):
+    """A non-RuntimeError SDK crash is wrapped in a RuntimeError with provider
+    context and the original cause chained (uniform error type, no retry)."""
+    from src.services.provider_adapters import make_openai_image_adapter
+
+    patch_async_openai(monkeypatch, error=ConnectionError("upstream dropped"))
+    adapter = make_openai_image_adapter("fake-key")
+    with pytest.raises(RuntimeError, match="OpenAI image error") as exc_info:
+        await adapter("a sunset")
+    assert isinstance(exc_info.value.__cause__, ConnectionError)
+
+
+@pytest.mark.anyio
+async def test_openai_image_adapter_single_generate_call(monkeypatch):
+    """The billed images.generate POST is issued exactly once — no service- or
+    adapter-level auto-retry on the non-idempotent paid request (#958 class)."""
+    from src.services.provider_adapters import make_openai_image_adapter
+
+    calls = {"n": 0}
+
+    class _CountingImages:
+        async def generate(self, **kwargs):
+            calls["n"] += 1
+            return _FakeImagesResponse([_FakeImage(url="https://x/y.png")])
+
+    class _CountingClient:
+        def __init__(self, **kwargs):
+            self.images = _CountingImages()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    import openai
+
+    monkeypatch.setattr(openai, "AsyncOpenAI", _CountingClient)
+    adapter = make_openai_image_adapter("fake-key")
+    await adapter("a sunset", "dall-e-3")
+    assert calls["n"] == 1
 
 
 @pytest.mark.anyio
@@ -1031,3 +1266,58 @@ async def test_parse_json_openai_content_null_returns_empty():
     """OpenAI content can be JSON null (tool-call/refusal) — coerce to "" not None (#836/8)."""
     data = {"choices": [{"message": {"content": None}}]}
     assert await _parse_json_for_text(data) == ""
+
+
+# === _parse_json_for_text -> str contract on unexpected nested shapes (#836/#971) ===
+#
+# The function is annotated ``-> str`` and downstream treats the result as text
+# (string ops, prompt assembly). Earlier audits (#836/#971) closed this leak for
+# the ``result`` / ``outputs`` *null* cases via ``_coerce_str``, but two extraction
+# points still returned the raw value when a provider nested an object where text
+# was expected: ``choices[0].message.content`` and ``outputs[0].content``. A
+# malformed/unexpected provider payload would then leak a ``dict`` out of a
+# ``-> str`` function. These guards lock every shape to a real ``str``.
+
+
+@pytest.mark.anyio
+async def test_parse_json_openai_content_dict_coerced_to_str():
+    """choices[0].message.content as an object (not text) must coerce to str,
+    not leak the dict out of the -> str contract (#836/#971 class)."""
+    data = {"choices": [{"message": {"content": {"unexpected": "object"}}}]}
+    result = await _parse_json_for_text(data)
+    assert isinstance(result, str)
+
+
+@pytest.mark.anyio
+async def test_parse_json_outputs_content_dict_coerced_to_str():
+    """outputs[0].content as an object must coerce to str (-> str contract)."""
+    data = {"outputs": [{"content": {"unexpected": "object"}}]}
+    result = await _parse_json_for_text(data)
+    assert isinstance(result, str)
+
+
+@pytest.mark.anyio
+async def test_parse_json_choices_text_dict_coerced_to_str():
+    """choices[0].text as an object must coerce to str (-> str contract)."""
+    data = {"choices": [{"text": {"unexpected": "object"}}]}
+    result = await _parse_json_for_text(data)
+    assert isinstance(result, str)
+
+
+@pytest.mark.anyio
+async def test_parse_json_deeply_nested_result_stays_str():
+    """A deeply nested ``{"result": {"result": {...}}}`` (no known text key at the
+    top level) falls through to the str() fallback — always a str, never a dict."""
+    data = {"result": {"result": {"text": "deep"}}}
+    result = await _parse_json_for_text(data)
+    assert isinstance(result, str)
+    # The inner object is stringified (no top-level text/content/generated_text key).
+    assert "result" in result
+
+
+@pytest.mark.anyio
+async def test_parse_json_outputs_text_dict_coerced_to_str():
+    """outputs[0].text as an object must coerce to str (-> str contract)."""
+    data = {"outputs": [{"text": {"unexpected": "object"}}]}
+    result = await _parse_json_for_text(data)
+    assert isinstance(result, str)


### PR DESCRIPTION
Закрывает подзадачу #1035 эпика #1024 (Тир 2 — контентный цикл). TDD-покрытие класса retry/billing #958 по **всем** image-адаптерам, lifecycle и S3 durability.

## Что и почему
Платная генерация картинок **не идемпотентна** и оплачивается за запрос. Любой молчаливый авто-retry = дубль-биллинг (прецедент #958). SDK-адаптеры уже фиксируют `max_retries=0`, но raw-HTTP пути и S3-ветка сервиса не имели регресс-гарда, а `_parse_json_for_text` мог утечь не-str из функции с аннотацией `-> str`.

Каждый TDD-red доказан инъекцией реалистичной регрессии (retry-loop / снятие guard'а) → красный тест → откат инъекции → зелёный.

### 1. retry/billing (регресс-гарды — ровно один POST)
- **`generic_http_adapter`** (пробел из issue): ровно один POST на transient сетевой ошибке / 5xx; `_HTTP_TIMEOUT` (120s) проброшен в `ClientSession`.
- **HuggingFace image-адаптер** — единственный платный image POST всё ещё на raw aiohttp: ровно один POST на connection error / timeout; timeout-бюджет проброшен.
- **OpenAI image-адаптер**: `images.generate` вызывается ровно один раз; не-`RuntimeError` краш оборачивается в `RuntimeError` с контекстом провайдера + chained cause. Аналогично для Together.
- **`ImageGenerationService.generate`**: платный адаптер вызывается ровно один раз (нет авто-retry на уровне сервиса).

### 2. lifecycle / `-> str` контракт `_parse_json_for_text`
- **FIX (исходник)**: `choices[0].message.content`, `choices[0].text`, `outputs[0].content`, `outputs[0].text` теперь проходят через `_coerce_str`. Вложенный объект на malformed-пейлоаде раньше утекал dict из `-> str` функции — та же семья багов #836/#971, что уже была закрыта для null-веток `result`/`outputs`. Сначала 4 падающих теста (red), затем фикс (green).
- Глубоко вложенный `{"result":{"result":...}}` остаётся str.
- provider crash (не-RuntimeError) / empty data / timeout по адаптерам.

### 3. S3 durability (follow-up #873, S3-ветка `generate()`)
- `owns_url=True` результат **не** перезаливается (red доказан снятием guard'а).
- `upload_url → None` → fallback к provider URL, не None (red доказан).
- S3 не сконфигурирован → результат адаптера возвращается как есть.

## Объём
- src: только фокусный фикс `_coerce_str` в `_parse_json_for_text` (+10/-7).
- tests: +290 строк `test_provider_adapters.py`, +87 строк `test_image_generation_service.py`.
- ⚠️ НЕ трогает client_pool/dispatcher (изолировано от #1046/#1047).

## Проверки
- `ruff check` затронутых файлов — чисто.
- `pytest` затронутых файлов: 176 passed; широкий прогон (provider/image/s3/generation): 1117 passed, 23 skipped, без warnings.
- mypy `provider_adapters.py`: 0 ошибок; остальные ошибки предсуществующие на нетронутых строках.

Closes #1035

🤖 Generated with [Claude Code](https://claude.com/claude-code)