### PR TITLE
docs: doc-coverage report via interrogate (#1072)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,17 @@ jobs:
         continue-on-error: true
         run: bandit -c pyproject.toml -r src -q
 
+      # Doc-coverage gate (#1072): interrogate measures the % of functions /
+      # classes / modules carrying a docstring (documentation debt). Soft
+      # baseline `fail_under = 23` lives in [tool.interrogate] (pyproject.toml);
+      # the script reads it. ADVISORY for now (continue-on-error) — it surfaces
+      # regressions without forcing a docstring sprint. Ratchet to blocking and
+      # raise the baseline as coverage climbs. NOT a dead-code check — that's the
+      # complexity/vulture path above; "no docstring" ≠ "uncalled".
+      - name: Doc-coverage report (advisory)
+        continue-on-error: true
+        run: python scripts/doc_coverage.py --path src
+
       - name: Enforce pytest warnings as errors
         run: |
           python - <<'PY'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,7 @@ Reads (`SELECT`) stay lock-free. Repositories accept `database: Database | None 
 - GitHub Actions: `.github/workflows/ci.yml` — ruff lint + pytest on push to `main`/`fix/**`/`codex/**` and all PRs; branch names containing `+` are rejected
 - Import architecture contracts: `lint-imports --config .importlinter` — CLI/web/agent-tools entrypoints must not import `telethon` directly (raw Telethon stays behind the telegram layer)
 - CI enforces `filterwarnings = ["error"]` in `pyproject.toml` (dedicated check step), then runs parallel tests (`-n auto -m "not aiosqlite_serial"`), then serial (`-m aiosqlite_serial`)
+- Code-health/doc tooling in `static-checks`: `scripts/code_health.py --fail-on F` (blocking cyclomatic-complexity gate, radon+vulture) and `scripts/doc_coverage.py` (advisory doc-coverage report, wraps `interrogate`; config in `[tool.interrogate]`). **Doc-coverage (no docstring) ≠ dead code (uncalled, vulture) — independent signals, different PRs.**
 - Other workflows: `real-provider.yml` (opt-in live provider smoke), `docs.yml` (mkdocs → GitHub Pages), `release.yml`
 
 ## Real Telegram Testing

--- a/docs/reference/doc-coverage.md
+++ b/docs/reference/doc-coverage.md
@@ -1,0 +1,67 @@
+# Doc-coverage (долг документации)
+
+Отчёт о покрытии кода docstring'ами — какие функции, классы и модули **не
+задокументированы**. Это «долг документации»: что стоит описать, чтобы
+авто-доки (mkdocstrings, Swagger) были полнее. Часть эпика автодокументации
+([#1022](https://github.com/axisrow/tg_content_factory/issues/1022)).
+
+Под капотом — [`interrogate`](https://interrogate.readthedocs.io/), обёрнутый в
+`scripts/doc_coverage.py` по образцу `scripts/code_health.py`.
+
+## Что это НЕ
+
+!!! warning "Doc-coverage ≠ мёртвый код"
+    «Нет docstring» (этот отчёт, interrogate) и «не вызывается» (мёртвый код,
+    vulture в `scripts/code_health.py`) — **независимые сигналы**.
+
+    - Недокументированная, но используемая функция — кандидат на docstring.
+    - Документированная, но никем не вызываемая — кандидат на удаление.
+    - Пересечение «нет docstring **И** не вызывается» — кандидат на внимание:
+      либо задокументировать, либо удалить.
+
+    Не путайте эти две оси. Они закрываются разными PR и разными инструментами.
+
+## Запуск
+
+```bash
+# Информационный отчёт по src/ (общий %, худшие файлы, список недокументированного)
+python scripts/doc_coverage.py
+
+# Другой путь / больше строк в топах
+python scripts/doc_coverage.py --path src/web --top 40
+
+# CI-гейт: ненулевой exit, если покрытие ниже порога
+python scripts/doc_coverage.py --fail-under 23
+
+# Отключить гейт явно (только отчёт), даже если в конфиге задан fail_under
+python scripts/doc_coverage.py --fail-under 0
+```
+
+Без `--fail-under` берётся `fail_under` из `[tool.interrogate]` в
+`pyproject.toml` — единый источник истины и для скрипта, и для CLI-гейта
+`interrogate -c pyproject.toml`.
+
+## Конфигурация
+
+Политика (исключения, ignore-флаги, baseline-порог) живёт в одном месте —
+`[tool.interrogate]` в `pyproject.toml`:
+
+```toml
+[tool.interrogate]
+fail_under = 23            # мягкий baseline (ratchet floor)
+ignore_init_method = true
+ignore_magic = true
+ignore_private = true
+exclude = ["tests", "scripts", "build", "dist", "site"]
+```
+
+`fail_under` — **мягкий** baseline. Сегодня покрытие ~24%; порог `23` ловит
+регрессии, не заставляя документировать всё разом. Поднимайте его по мере роста
+покрытия.
+
+## CI
+
+Шаг `Doc-coverage report (advisory)` в `static-checks` (`.github/workflows/ci.yml`)
+прогоняет отчёт. Он **advisory** (`continue-on-error: true`), как `pip-audit` и
+`bandit`: показывает регрессии, но сам по себе не «краснит» CI. Когда покрытие
+вырастет — можно сделать гейт блокирующим и поднять baseline.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,7 @@ nav:
     - CLI / Web Parity: reference/parity.md
     - Agent Tools: reference/agent-tools.md
     - RSS / Atom Feeds: reference/rss-feeds.md
+    - Doc-coverage: reference/doc-coverage.md
   - Architecture: architecture.md
   - Service Map: feature-map.md
   - Parity Matrix: parity-matrix.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,11 @@ dev = [
     # CI cyclomatic-complexity gate (`--fail-on F`). ruff (above) is the third.
     "radon>=6.0.1",
     "vulture>=2.16",
+    # Doc-coverage tooling (#1072): scripts/doc_coverage.py wraps interrogate
+    # (% of functions/classes/modules with a docstring → documentation debt
+    # report). Config in [tool.interrogate] below. NOT dead code — that's
+    # vulture above; "no docstring" and "uncalled" are independent signals.
+    "interrogate>=1.7.0",
     # Security scans wired into CI static-checks (issue #1053), advisory for now:
     # pip-audit scans installed deps for known CVEs, bandit flags security
     # anti-patterns in src/. Dependabot (.github/dependabot.yml) opens the fix
@@ -194,3 +199,21 @@ exclude_lines = [
 # skip-list / `# nosec` here before the step is ever made blocking.
 [tool.bandit]
 exclude_dirs = ["tests"]
+
+# Doc-coverage (interrogate, #1072). scripts/doc_coverage.py and the advisory
+# CI step read this. `fail_under` is a SOFT baseline — the project is at ~24%
+# today; 23 is a ratchet floor that surfaces regressions without forcing a
+# docstring-everything sprint. Raise it as coverage climbs. interrogate ignores
+# things that don't need a docstring (magic/init/nested/private, overloads).
+[tool.interrogate]
+fail_under = 23
+ignore_init_method = true
+ignore_init_module = true
+ignore_magic = true
+ignore_nested_functions = true
+ignore_private = true
+ignore_semiprivate = true
+ignore_property_decorators = true
+ignore_overloaded_functions = true
+exclude = ["tests", "scripts", "build", "dist", "site"]
+verbose = 1

--- a/scripts/doc_coverage.py
+++ b/scripts/doc_coverage.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Отчёт о doc-coverage (долге документации) по дереву исходников.
+
+Запуск:
+    python scripts/doc_coverage.py [--path src] [--top 20] [--fail-under 23]
+
+Оборачивает `interrogate` (% функций/классов/модулей с docstring) и печатает
+воспроизводимую сводку:
+  * общий процент покрытия документацией и счётчики covered/missing;
+  * худшие по покрытию файлы (топ);
+  * плоский список недокументированного (файл:строка — имя) — это и есть
+    «долг документации»: где не хватает docstring.
+
+С `--fail-under N` возвращает ненулевой exit code, когда покрытие ниже N —
+для опционального (мягкого) CI-гейта. Настройки самого interrogate
+(исключения, baseline `fail_under`) живут в `[tool.interrogate]` в
+pyproject.toml — единый источник истины.
+
+NB: doc-coverage — это НЕ мёртвый код. «Нет docstring» (interrogate, здесь) и
+«не вызывается» (vulture, scripts/code_health.py) — независимые сигналы.
+Пересечение «нет docstring И не вызывается» — кандидат на внимание (либо
+задокументировать, либо удалить), но сами по себе эти отчёты не путать.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# interrogate ставится из [dev] extra (`pip install -e ".[dev]"`). Импорт —
+# опциональный: без инструмента скрипт падает с понятной подсказкой, а не
+# трейсбеком (как ensure_tools в scripts/code_health.py).
+try:
+    from interrogate import config as interrogate_config  # type: ignore[import-untyped]
+    from interrogate.coverage import InterrogateCoverage  # type: ignore[import-untyped]
+except ImportError:  # pragma: no cover - проверяется через подсказку ниже
+    InterrogateCoverage = None  # type: ignore[assignment, misc]
+    interrogate_config = None  # type: ignore[assignment]
+
+# Ключи [tool.interrogate], которые НЕ являются полями InterrogateConfig:
+# `exclude` уходит отдельным аргументом, `fail_under`/`verbose` к подсчёту
+# покрытия отношения не имеют (их трогает только сам отчёт/гейт).
+_NON_CONF_KEYS = {"exclude", "fail_under", "verbose", "paths"}
+
+_COLOR = sys.stdout.isatty()
+
+
+def _c(text: str, code: str) -> str:
+    return f"\033[{code}m{text}\033[0m" if _COLOR else text
+
+
+def bold(text: str) -> str:
+    return _c(text, "1")
+
+
+def dim(text: str) -> str:
+    return _c(text, "2")
+
+
+def red(text: str) -> str:
+    return _c(text, "31")
+
+
+def warn(text: str) -> str:
+    return _c(text, "33")
+
+
+def good(text: str) -> str:
+    return _c(text, "32")
+
+
+def header(title: str) -> None:
+    print()
+    print(bold(f"=== {title} ==="))
+
+
+def format_percent(perc: float) -> str:
+    """Процент покрытия с одним знаком, покрашенный по уровню (зелёный/жёлтый/красный)."""
+    text = f"{perc:.1f}%"
+    if perc >= 80.0:
+        return good(text)
+    if perc >= 50.0:
+        return warn(text)
+    return red(text)
+
+
+# --------------------------------------------------------------------------- #
+# Чистая логика отчёта (тестируется на фейках формы interrogate)
+# --------------------------------------------------------------------------- #
+
+
+def worst_files(results: object, top: int) -> list:
+    """Файлы с неполным покрытием, от худшего к лучшему, не более `top`.
+
+    Полностью задокументированные файлы (100%) опускаются — в отчёте о долге
+    им не место.
+    """
+    incomplete = [f for f in results.file_results if f.perc_covered < 100.0]  # type: ignore[attr-defined]
+    incomplete.sort(key=lambda f: (f.perc_covered, -f.missing))
+    return incomplete[:top]
+
+
+def undocumented_nodes(results: object) -> list[tuple[str, int | None, str, str]]:
+    """Плоский список недокументированного: (файл, строка, имя, тип-узла).
+
+    Пробегает все узлы всех файлов и оставляет только `covered == False` —
+    это конкретные функции/классы/модули без docstring.
+    """
+    out: list[tuple[str, int | None, str, str]] = []
+    for file_result in results.file_results:  # type: ignore[attr-defined]
+        for node in file_result.nodes:
+            if not node.covered:
+                out.append((file_result.filename, node.lineno, node.name, node.node_type))
+    return out
+
+
+def gate_exit_code(perc_covered: float, fail_under: float | None) -> int:
+    """Exit code для CI-гейта: 1, если покрытие строго ниже порога, иначе 0.
+
+    `fail_under is None` — информационный прогон без гейта, всегда 0.
+    """
+    if fail_under is None:
+        return 0
+    return 1 if perc_covered < fail_under else 0
+
+
+def split_pyproject_config(raw: dict) -> tuple[dict, list[str], float | None]:
+    """Разложить сырой `[tool.interrogate]` на (поля conf, excluded, fail_under).
+
+    interrogate складывает в pyproject и поля `InterrogateConfig`, и служебные
+    ключи (`exclude`, `fail_under`, `verbose`). Чтобы наш отчёт считал покрытие
+    ровно как CLI-гейт (`interrogate -c pyproject.toml`), мы должны прокинуть в
+    `InterrogateCoverage` те же `conf` и `excluded`, а `fail_under` использовать
+    как дефолтный порог гейта.
+    """
+    conf_kwargs = {k: v for k, v in raw.items() if k not in _NON_CONF_KEYS}
+    excluded = list(raw.get("exclude") or [])
+    fail_under = raw.get("fail_under")
+    return conf_kwargs, excluded, (float(fail_under) if fail_under is not None else None)
+
+
+# --------------------------------------------------------------------------- #
+# Секции отчёта
+# --------------------------------------------------------------------------- #
+
+
+def section_summary(results: object) -> None:
+    header("Doc-coverage (interrogate)")
+    perc = results.perc_covered  # type: ignore[attr-defined]
+    print(
+        f"Покрытие документацией: {bold(format_percent(perc))}    "
+        f"задокументировано {bold(str(results.covered))} из {bold(str(results.total))}    "  # type: ignore[attr-defined]
+        f"без docstring: {bold(str(results.missing))}"  # type: ignore[attr-defined]
+    )
+
+
+def section_worst_files(results: object, top: int) -> None:
+    header("Худшие по покрытию файлы")
+    worst = worst_files(results, top)
+    if not worst:
+        print(dim("  все файлы задокументированы на 100% — отлично"))
+        return
+    print(dim(f"Топ-{len(worst)} файлов с наибольшим долгом документации:"))
+    for f in worst:
+        perc = format_percent(f.perc_covered)
+        print(f"  {perc:>16}  {f.missing:>4} без docstring  {f.filename}")
+
+
+def section_undocumented(results: object, top: int) -> None:
+    header("Недокументированные функции/классы/модули")
+    items = undocumented_nodes(results)
+    print(f"Всего без docstring: {bold(str(len(items)))}")
+    if not items:
+        return
+    print(dim(f"\nПервые {min(top, len(items))} (файл:строка — имя):"))
+    for filename, lineno, name, node_type in items[:top]:
+        loc = f"{filename}:{lineno}" if lineno else filename
+        print(f"  {dim(node_type):<22} {name:<32} {dim(loc)}")
+
+
+# --------------------------------------------------------------------------- #
+# main
+# --------------------------------------------------------------------------- #
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Отчёт о doc-coverage (долге документации).")
+    parser.add_argument("--path", default="src", help="Путь для анализа (по умолчанию src)")
+    parser.add_argument("--top", type=int, default=20, help="Сколько строк показывать в топах")
+    parser.add_argument(
+        "--fail-under",
+        type=float,
+        default=None,
+        metavar="N",
+        help=(
+            "Вернуть ненулевой exit code, если покрытие ниже N%% (для опционального CI-гейта). "
+            "По умолчанию берётся fail_under из [tool.interrogate]; передайте 0, чтобы отключить."
+        ),
+    )
+    args = parser.parse_args()
+
+    if InterrogateCoverage is None or interrogate_config is None:
+        print(bold("Не найден инструмент interrogate."), file=sys.stderr)
+        print("Установите его: pip install interrogate  (входит в [dev] extra)", file=sys.stderr)
+        return 1
+
+    path = Path(args.path)
+    if not path.exists():
+        print(f"Путь не найден: {path}", file=sys.stderr)
+        return 2
+
+    print(bold(f"Анализ doc-coverage: {path}"))
+
+    # Читаем [tool.interrogate] из pyproject.toml, чтобы наш отчёт считал
+    # покрытие ровно как CLI-гейт `interrogate -c pyproject.toml` (те же
+    # ignore-флаги и exclude). Без этого total/процент расходятся.
+    raw = interrogate_config.parse_pyproject_toml("pyproject.toml") or {}
+    conf_kwargs, excluded, cfg_fail_under = split_pyproject_config(raw)
+    conf = interrogate_config.InterrogateConfig(**conf_kwargs)
+
+    # interrogate конкатенирует excluded как tuple — list туда передавать нельзя.
+    coverage = InterrogateCoverage(paths=[str(path)], conf=conf, excluded=tuple(excluded) or None)
+    results = coverage.get_coverage()
+
+    # Порог гейта: явный --fail-under важнее конфигового fail_under.
+    fail_under = args.fail_under if args.fail_under is not None else cfg_fail_under
+
+    section_summary(results)
+    section_worst_files(results, args.top)
+    section_undocumented(results, args.top)
+
+    header("Итог")
+    perc = results.perc_covered
+    if fail_under is not None and fail_under > 0:
+        if perc < fail_under:
+            print(red(f"Покрытие {perc:.1f}% ниже порога {fail_under:.1f}% → провал (fail-under)"))
+        else:
+            print(good(f"Покрытие {perc:.1f}% не ниже порога {fail_under:.1f}% → ок"))
+    else:
+        print(dim("Информационный прогон (exit 0). Для CI-гейта используйте --fail-under N."))
+    print(dim("NB: doc-coverage ≠ мёртвый код (vulture, scripts/code_health.py) — это разные сигналы."))
+
+    # fail_under == 0 явно отключает гейт (gate_exit_code тогда вернёт 0).
+    return gate_exit_code(perc, fail_under if fail_under else None)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/doc_coverage.py
+++ b/scripts/doc_coverage.py
@@ -38,9 +38,11 @@ except ImportError:  # pragma: no cover - проверяется через по
     InterrogateCoverage = None  # type: ignore[assignment, misc]
     interrogate_config = None  # type: ignore[assignment]
 
-# Ключи [tool.interrogate], которые НЕ являются полями InterrogateConfig:
-# `exclude` уходит отдельным аргументом, `fail_under`/`verbose` к подсчёту
-# покрытия отношения не имеют (их трогает только сам отчёт/гейт).
+# Служебные ключи [tool.interrogate], которые НЕ передаются в InterrogateConfig
+# как kwargs: `exclude`/`paths` идут отдельными аргументами InterrogateCoverage;
+# `verbose` — не поле конфига вовсе; `fail_under` поле конфига есть, но к
+# подсчёту покрытия (get_coverage) отношения не имеет — гейт мы считаем сами,
+# поэтому его тоже отделяем.
 _NON_CONF_KEYS = {"exclude", "fail_under", "verbose", "paths"}
 
 _COLOR = sys.stdout.isatty()
@@ -140,6 +142,25 @@ def split_pyproject_config(raw: dict) -> tuple[dict, list[str], float | None]:
     return conf_kwargs, excluded, (float(fail_under) if fail_under is not None else None)
 
 
+def known_config_kwargs(conf_kwargs: dict) -> tuple[dict, list[str]]:
+    """Оставить только ключи, которые реально являются полями InterrogateConfig.
+
+    Возвращает (отфильтрованные kwargs, имена отброшенных неизвестных ключей).
+    Без этого фильтра новый ключ в [tool.interrogate], валидный для CLI
+    interrogate, но не для InterrogateConfig (например `generate_badge`,
+    `output`), уронил бы `InterrogateConfig(**kwargs)` с TypeError. Лучше
+    предупредить и продолжить, чем падать трейсбеком на advisory-прогоне.
+    """
+    if interrogate_config is None:  # pragma: no cover - main() выходит раньше
+        return conf_kwargs, []
+    import attr
+
+    valid = {field.name for field in attr.fields(interrogate_config.InterrogateConfig)}
+    kept = {k: v for k, v in conf_kwargs.items() if k in valid}
+    dropped = sorted(k for k in conf_kwargs if k not in valid)
+    return kept, dropped
+
+
 # --------------------------------------------------------------------------- #
 # Секции отчёта
 # --------------------------------------------------------------------------- #
@@ -214,9 +235,18 @@ def main() -> int:
 
     # Читаем [tool.interrogate] из pyproject.toml, чтобы наш отчёт считал
     # покрытие ровно как CLI-гейт `interrogate -c pyproject.toml` (те же
-    # ignore-флаги и exclude). Без этого total/процент расходятся.
-    raw = interrogate_config.parse_pyproject_toml("pyproject.toml") or {}
+    # ignore-флаги и exclude). Без этого total/процент расходятся. Ищем pyproject
+    # рядом со скриптом (корень репо), а не в текущем cwd — иначе запуск из
+    # подкаталога ронял бы чтение конфига (как и graceful-выход выше по --path).
+    pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
+    if not pyproject.exists():
+        print(f"Не найден {pyproject} — нечего читать как [tool.interrogate].", file=sys.stderr)
+        return 2
+    raw = interrogate_config.parse_pyproject_toml(str(pyproject)) or {}
     conf_kwargs, excluded, cfg_fail_under = split_pyproject_config(raw)
+    conf_kwargs, dropped = known_config_kwargs(conf_kwargs)
+    if dropped:
+        print(warn(f"Игнорирую неизвестные ключи [tool.interrogate]: {', '.join(dropped)}"), file=sys.stderr)
     conf = interrogate_config.InterrogateConfig(**conf_kwargs)
 
     # interrogate конкатенирует excluded как tuple — list туда передавать нельзя.

--- a/tests/test_doc_coverage.py
+++ b/tests/test_doc_coverage.py
@@ -193,6 +193,35 @@ def test_split_pyproject_config_handles_empty() -> None:
     assert fail_under is None
 
 
+def test_known_config_kwargs_drops_unknown_keys() -> None:
+    """Неизвестный для InterrogateConfig ключ отсеивается, а не роняет конструктор."""
+    pytest.importorskip("interrogate.config")
+    kept, dropped = doc_coverage.known_config_kwargs(
+        {"ignore_magic": True, "generate_badge": "x", "output": "y"}
+    )
+    assert kept == {"ignore_magic": True}
+    assert dropped == ["generate_badge", "output"]
+
+
+def test_known_config_kwargs_keeps_all_valid() -> None:
+    pytest.importorskip("interrogate.config")
+    kept, dropped = doc_coverage.known_config_kwargs({"ignore_magic": True, "ignore_private": True})
+    assert kept == {"ignore_magic": True, "ignore_private": True}
+    assert dropped == []
+
+
+def test_known_config_kwargs_result_constructs_config() -> None:
+    """То, что прошло фильтр, гарантированно конструирует InterrogateConfig."""
+    cfg = pytest.importorskip("interrogate.config")
+    raw = cfg.parse_pyproject_toml("pyproject.toml") or {}
+    conf_kwargs, _, _ = doc_coverage.split_pyproject_config(raw)
+    # Подсунем заведомо чужой ключ — он не должен дойти до конструктора.
+    conf_kwargs["definitely_not_a_field"] = 123
+    kept, dropped = doc_coverage.known_config_kwargs(conf_kwargs)
+    assert "definitely_not_a_field" in dropped
+    cfg.InterrogateConfig(**kept)  # не должно бросить TypeError
+
+
 def test_split_pyproject_config_matches_real_pyproject() -> None:
     """Реальный [tool.interrogate] раскладывается без лишних ключей.
 

--- a/tests/test_doc_coverage.py
+++ b/tests/test_doc_coverage.py
@@ -1,0 +1,220 @@
+"""Тесты для scripts/doc_coverage.py — отчёта doc-coverage (interrogate, #1072).
+
+Логика отчёта (агрегация худших файлов, список недокументированного, гейт
+`--fail-under`) проверяется на лёгких фейк-объектах, повторяющих форму
+`interrogate.coverage.InterrogateResults`, — реальный interrogate в горячий
+путь тестов не тащим (детерминированность + скорость, по образцу того, как
+scripts/code_health.py опирается на формат radon, а не запускает его в тестах).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+# scripts/ — не пакет; грузим модуль по пути, как это делают другие
+# тесты-обёртки над вспомогательными скриптами.
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "doc_coverage.py"
+_spec = importlib.util.spec_from_file_location("doc_coverage", _SCRIPT)
+assert _spec and _spec.loader
+doc_coverage = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(doc_coverage)
+
+
+# --------------------------------------------------------------------------- #
+# Лёгкие фейки формы interrogate.coverage.*
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class FakeNode:
+    """Зеркалит interrogate CovNode: документируемый узел (модуль/класс/функция)."""
+
+    name: str
+    covered: bool
+    node_type: str = "FuncDef"
+    lineno: int | None = 1
+
+
+@dataclass
+class FakeFileResult:
+    """Зеркалит interrogate InterrogateFileResult."""
+
+    filename: str
+    total: int
+    covered: int
+    nodes: list[FakeNode] = field(default_factory=list)
+
+    @property
+    def missing(self) -> int:
+        return self.total - self.covered
+
+    @property
+    def perc_covered(self) -> float:
+        return 100.0 * self.covered / self.total if self.total else 100.0
+
+
+@dataclass
+class FakeResults:
+    """Зеркалит interrogate InterrogateResults."""
+
+    total: int
+    covered: int
+    file_results: list[FakeFileResult] = field(default_factory=list)
+
+    @property
+    def missing(self) -> int:
+        return self.total - self.covered
+
+    @property
+    def perc_covered(self) -> float:
+        return 100.0 * self.covered / self.total if self.total else 100.0
+
+
+def _sample_results() -> FakeResults:
+    files = [
+        FakeFileResult(
+            "src/good.py",
+            total=2,
+            covered=2,
+            nodes=[FakeNode("a", True), FakeNode("b", True)],
+        ),
+        FakeFileResult(
+            "src/bad.py",
+            total=4,
+            covered=1,
+            nodes=[
+                FakeNode("Module", True, node_type="Module", lineno=None),
+                FakeNode("undoc_one", False, lineno=10),
+                FakeNode("undoc_two", False, lineno=20),
+                FakeNode("undoc_three", False, lineno=30),
+            ],
+        ),
+        FakeFileResult(
+            "src/mid.py",
+            total=2,
+            covered=1,
+            nodes=[FakeNode("ok", True), FakeNode("nope", False, lineno=5)],
+        ),
+    ]
+    total = sum(f.total for f in files)
+    covered = sum(f.covered for f in files)
+    return FakeResults(total=total, covered=covered, file_results=files)
+
+
+# --------------------------------------------------------------------------- #
+# worst_files — худшие по покрытию файлы
+# --------------------------------------------------------------------------- #
+
+
+def test_worst_files_orders_by_coverage_ascending() -> None:
+    worst = doc_coverage.worst_files(_sample_results(), top=10)
+    # bad.py (25%) хуже mid.py (50%); полностью покрытый good.py не попадает.
+    assert [f.filename for f in worst] == ["src/bad.py", "src/mid.py"]
+
+
+def test_worst_files_excludes_fully_documented() -> None:
+    worst = doc_coverage.worst_files(_sample_results(), top=10)
+    assert all(f.perc_covered < 100.0 for f in worst)
+
+
+def test_worst_files_respects_top_limit() -> None:
+    assert len(doc_coverage.worst_files(_sample_results(), top=1)) == 1
+
+
+# --------------------------------------------------------------------------- #
+# undocumented_nodes — плоский список недокументированного
+# --------------------------------------------------------------------------- #
+
+
+def test_undocumented_nodes_lists_only_missing() -> None:
+    items = doc_coverage.undocumented_nodes(_sample_results())
+    names = {name for _, _, name, _ in items}
+    assert names == {"undoc_one", "undoc_two", "undoc_three", "nope"}
+
+
+def test_undocumented_nodes_carries_location() -> None:
+    items = doc_coverage.undocumented_nodes(_sample_results())
+    by_name = {name: (filename, lineno) for filename, lineno, name, _ in items}
+    assert by_name["undoc_one"] == ("src/bad.py", 10)
+    assert by_name["nope"] == ("src/mid.py", 5)
+
+
+# --------------------------------------------------------------------------- #
+# Гейт --fail-under
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("perc", "threshold", "expected"),
+    [
+        (23.83, 20.0, 0),  # выше порога → ок
+        (23.83, 23.83, 0),  # ровно на пороге → ок (>=)
+        (23.83, 25.0, 1),  # ниже порога → провал
+        (100.0, 80.0, 0),
+    ],
+)
+def test_gate_exit_code(perc: float, threshold: float, expected: int) -> None:
+    assert doc_coverage.gate_exit_code(perc, threshold) == expected
+
+
+def test_gate_none_threshold_is_informational() -> None:
+    # Без --fail-under прогон информационный: всегда exit 0.
+    assert doc_coverage.gate_exit_code(0.0, None) == 0
+
+
+# --------------------------------------------------------------------------- #
+# split_pyproject_config — отделить служебные ключи от полей InterrogateConfig
+# --------------------------------------------------------------------------- #
+
+
+def test_split_pyproject_config_separates_service_keys() -> None:
+    raw = {
+        "fail_under": 23,
+        "ignore_magic": True,
+        "ignore_private": True,
+        "exclude": ["tests", "scripts"],
+        "verbose": 1,
+    }
+    conf_kwargs, excluded, fail_under = doc_coverage.split_pyproject_config(raw)
+    # Служебные ключи не должны протечь в kwargs InterrogateConfig.
+    assert conf_kwargs == {"ignore_magic": True, "ignore_private": True}
+    assert excluded == ["tests", "scripts"]
+    assert fail_under == 23.0
+
+
+def test_split_pyproject_config_handles_empty() -> None:
+    conf_kwargs, excluded, fail_under = doc_coverage.split_pyproject_config({})
+    assert conf_kwargs == {}
+    assert excluded == []
+    assert fail_under is None
+
+
+def test_split_pyproject_config_matches_real_pyproject() -> None:
+    """Реальный [tool.interrogate] раскладывается без лишних ключей.
+
+    Это смоук на согласованность скрипта с pyproject: если в конфиг добавят
+    ключ, который не является полем InterrogateConfig, конструирование conf в
+    main() упадёт — здесь ловим заранее.
+    """
+    cfg = pytest.importorskip("interrogate.config")
+    raw = cfg.parse_pyproject_toml("pyproject.toml") or {}
+    if not raw:
+        pytest.skip("в pyproject.toml нет [tool.interrogate]")
+    conf_kwargs, _, fail_under = doc_coverage.split_pyproject_config(raw)
+    # Все оставшиеся ключи должны быть валидными полями InterrogateConfig.
+    cfg.InterrogateConfig(**conf_kwargs)
+    assert fail_under is not None
+
+
+# --------------------------------------------------------------------------- #
+# format_percent — покраска/формат процента
+# --------------------------------------------------------------------------- #
+
+
+def test_format_percent_has_one_decimal() -> None:
+    # Без TTY цвета нет — проверяем чистую числовую часть.
+    assert "23.8%" in doc_coverage.format_percent(23.83)


### PR DESCRIPTION
## Что и зачем

Часть эпика автодокументации (#1022, **пункт 3**): «подсветка недокументированного» — отчёт о **долге документации**. Автодоки (mkdocstrings, Swagger) полны ровно настолько, насколько код задокументирован; нужен воспроизводимый отчёт «где нет docstring», чтобы видеть долг и ловить регрессии.

> ⚠️ **doc-coverage ≠ мёртвый код.** «Нет docstring» (interrogate, этот PR) и «не вызывается» (vulture, `scripts/code_health.py`) — **независимые сигналы**, закрываются разными PR. Пересечение «нет docstring И не вызывается» — кандидат на внимание, но сами оси не путать.

## Что сделано

- **`scripts/doc_coverage.py`** — обёртка над `interrogate` по образцу `scripts/code_health.py`: общий %, худшие по покрытию файлы, плоский список недокументированного (файл:строка — имя), мягкий гейт `--fail-under` для CI. Читает тот же `[tool.interrogate]` из `pyproject.toml`, что и CLI-гейт `interrogate -c pyproject.toml`, — отчёт и гейт **не расходятся** (24.5%, total 3066, missing 2316).
- **`pyproject.toml`** — `interrogate>=1.7.0` в `[dev]`; `[tool.interrogate]` с мягким baseline `fail_under = 23` (ratchet floor — ловит регрессии, не заставляя документировать всё разом; поднимать по мере роста).
- **`.github/workflows/ci.yml`** — advisory-шаг `Doc-coverage report (advisory)` (`continue-on-error`, как `pip-audit`/`bandit`): показывает регрессии, сам по себе не «краснит» CI.
- **`docs/reference/doc-coverage.md`** (+ запись в nav `mkdocs.yml`) — страница с явным разделением «doc-coverage vs мёртвый код»; упоминание инструмента в `CLAUDE.md`.
- **`tests/test_doc_coverage.py`** — 🔴 TDD на чистую логику (`worst_files`, `undocumented_nodes`, `gate_exit_code`, `split_pyproject_config`) на лёгких фейках формы interrogate; **14 тестов**.

## Изоляция

Только config + docs + скрипт + тесты + advisory CI. Никаких изменений в продкоде/рантайме. `mkdocs build --strict` зелёный, `scripts/code_health.py --fail-on F` не задет.

## Проверки

- `pytest tests/test_doc_coverage.py` → 14 passed
- `ruff check` → clean; `mypy scripts/doc_coverage.py` → clean
- `python scripts/doc_coverage.py` → отчёт 24.5%, gate (baseline 23) ок
- smoke-набор + инвариант test-levels → зелёные

Closes #1072

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014KK19WhcZAxoFezQmU6hLT
