### PR TITLE
test(clientpool/auth): flood-ротация, primary-гонки, cross-process auth (TDD) (#1029)

### DIFF
--- a/src/services/account_service.py
+++ b/src/services/account_service.py
@@ -39,6 +39,14 @@ class AccountService:
             accounts = await self._accounts.list_accounts()
             for acc in accounts:
                 if acc.id == account_id:
-                    await self._pool.remove_client(acc.phone)
+                    # The DB is the source of truth: the pool is rebuilt from it on
+                    # restart. A pool.remove_client failure must NOT abort the DB
+                    # delete (#1029) — otherwise the account stays in the DB (a
+                    # "ghost" the operator thinks is gone) while its client lingers.
+                    # Mirror toggle()'s add_client handling: log, don't propagate.
+                    try:
+                        await self._pool.remove_client(acc.phone)
+                    except Exception as e:
+                        logger.warning("Failed to remove client for %s: %s", acc.phone, e)
                     break
         await self._accounts.delete_account(account_id)

--- a/src/services/account_service.py
+++ b/src/services/account_service.py
@@ -31,7 +31,13 @@ class AccountService:
                         except Exception as e:
                             logger.warning("Failed to add client for %s: %s", acc.phone, e)
                     else:
-                        await self._pool.remove_client(acc.phone)
+                        # set_active already updated the DB (source of truth), so a
+                        # pool.remove_client failure must not propagate (#1029) —
+                        # symmetric with the add_client branch above and delete().
+                        try:
+                            await self._pool.remove_client(acc.phone)
+                        except Exception as e:
+                            logger.warning("Failed to remove client for %s: %s", acc.phone, e)
                 return
 
     async def delete(self, account_id: int) -> None:

--- a/src/telegram/auth.py
+++ b/src/telegram/auth.py
@@ -256,7 +256,6 @@ class TelegramAuth:
         if stored_hash != phone_code_hash:
             raise ValueError("Phone code hash mismatch")
 
-        needs_2fa = False
         try:
             try:
                 logger.info(
@@ -271,7 +270,6 @@ class TelegramAuth:
                 )
             except SessionPasswordNeededError:
                 if not password_2fa:
-                    needs_2fa = True
                     raise TwoFactorRequiredError()
                 logger.info(
                     "auth.verify_code rpc start phone=%s rpc=sign_in_2fa timeout_s=%s",
@@ -283,6 +281,12 @@ class TelegramAuth:
                     "sign_in",
                     AUTH_RPC_TIMEOUT_SECONDS,
                 )
+            # sign_in succeeded — Telegram now considers this client authorized.
+            # session.save() is the ONLY way to capture that session for reuse, so
+            # if it raises we must NOT tear down the pending client (#1029): doing
+            # so would strand an authorized session with no string to persist,
+            # forcing a fresh send-code/verify onboarding. Keep the pending entry
+            # so the operator can retry verify_code and recover the session.
             session_string = client.session.save()
         except TwoFactorRequiredError:
             duration_ms = int((time.monotonic() - started_at) * 1000)
@@ -292,13 +296,15 @@ class TelegramAuth:
             duration_ms = int((time.monotonic() - started_at) * 1000)
             logger.exception("auth.verify_code error phone=%s duration_ms=%d", phone, duration_ms)
             raise
-        finally:
-            if not needs_2fa:
-                del self._pending[phone]
-                try:
-                    await client.disconnect()
-                except Exception:
-                    logger.warning("Failed to disconnect temporary auth client for %s", phone)
+
+        # Only now that the session string is captured is it safe to drop the
+        # pending client and disconnect — a failure before this point leaves the
+        # pending entry intact for a retry (#1029).
+        del self._pending[phone]
+        try:
+            await client.disconnect()
+        except Exception:
+            logger.warning("Failed to disconnect temporary auth client for %s", phone)
 
         duration_ms = int((time.monotonic() - started_at) * 1000)
         logger.info("auth.verify_code success phone=%s duration_ms=%d", phone, duration_ms)

--- a/tests/test_account_lease_pool.py
+++ b/tests/test_account_lease_pool.py
@@ -247,3 +247,60 @@ async def test_shared_fallback_uses_round_robin_order(db):
 
     assert seen[:3] == phones
     assert seen[3] == phones[0]
+
+
+@pytest.mark.anyio
+async def test_mixed_flooded_leased_free_returns_only_free_exclusive(db):
+    """#1029: with one flooded, one already-leased (in_use) and one free account,
+    acquire_available must return the FREE one as an exclusive (non-shared) lease.
+    Covers the mixed-state path the existing single-condition tests miss."""
+    phones = ["+78001", "+78002", "+78003"]
+    for p in phones:
+        await db.add_account(Account(phone=p, session_string=p, is_active=True))
+
+    # +78001 flooded, +78002 already leased out, +78003 free.
+    await db.update_account_flood("+78001", datetime.now(timezone.utc) + timedelta(hours=1))
+    pool = AccountLeasePool(db, {"+78002"})
+
+    lease = await pool.acquire_available(set(phones))
+    assert lease is not None
+    assert lease.account.phone == "+78003"
+    assert lease.shared is False
+
+
+@pytest.mark.anyio
+async def test_mixed_flood_plus_all_others_leased_falls_back_to_shared_non_flooded(db):
+    """#1029: when the only free account is flooded and every non-flooded account
+    is already leased, acquire_available must fall back to a SHARED lease on a
+    non-flooded account — never on the flooded one. Flooded accounts are excluded
+    in BOTH the exclusive and shared passes."""
+    phones = ["+78101", "+78102", "+78103"]
+    for p in phones:
+        await db.add_account(Account(phone=p, session_string=p, is_active=True))
+
+    # +78101 flooded (and free); +78102, +78103 leased but NOT flooded.
+    await db.update_account_flood("+78101", datetime.now(timezone.utc) + timedelta(hours=1))
+    pool = AccountLeasePool(db, {"+78102", "+78103"})
+
+    lease = await pool.acquire_available(set(phones))
+    assert lease is not None
+    assert lease.shared is True
+    # The flooded account must never be handed out, even as a shared fallback.
+    assert lease.account.phone != "+78101"
+    assert lease.account.phone in {"+78102", "+78103"}
+
+
+@pytest.mark.anyio
+async def test_all_flooded_returns_none_even_when_some_free(db):
+    """#1029: if every connected account is flood-waited, acquire_available
+    returns None regardless of in_use state — flood is a hard gate in both
+    passes, so there is nothing to hand out."""
+    phones = ["+78201", "+78202", "+78203"]
+    for p in phones:
+        await db.add_account(Account(phone=p, session_string=p, is_active=True))
+    future = datetime.now(timezone.utc) + timedelta(hours=1)
+    for p in phones:
+        await db.update_account_flood(p, future)
+
+    pool = AccountLeasePool(db, set())  # all free, but all flooded
+    assert await pool.acquire_available(set(phones)) is None

--- a/tests/test_account_service.py
+++ b/tests/test_account_service.py
@@ -77,6 +77,24 @@ async def test_account_service_toggle_add_client_error(mock_bundle, mock_pool):
 
 
 @pytest.mark.anyio
+async def test_account_service_toggle_deactivate_remove_client_error(mock_bundle, mock_pool):
+    """#1029: deactivating an account already wrote set_active to the DB, so a
+    pool.remove_client failure must NOT propagate — otherwise the DB says the
+    account is inactive while the in-memory client lingers AND the caller sees an
+    error. Mirror the activate branch (and delete()): log, don't raise."""
+    acc = Account(id=1, phone="+7999", session_string="sess", is_active=True)
+    mock_bundle.list_accounts.return_value = [acc]
+    mock_pool.remove_client.side_effect = Exception("pool removal failed")
+    svc = AccountService(mock_bundle, mock_pool)
+
+    # Must not raise — the pool error is logged, not propagated.
+    await svc.toggle(1)
+
+    mock_bundle.set_active.assert_called_once_with(1, False)
+    mock_pool.remove_client.assert_called_once_with("+7999")
+
+
+@pytest.mark.anyio
 async def test_account_service_toggle_not_found(mock_bundle):
     mock_bundle.list_accounts.return_value = []
     svc = AccountService(mock_bundle)

--- a/tests/test_account_service.py
+++ b/tests/test_account_service.py
@@ -103,6 +103,26 @@ async def test_account_service_delete_no_pool(mock_bundle):
 
 
 @pytest.mark.anyio
+async def test_account_service_delete_proceeds_when_pool_remove_fails(mock_bundle, mock_pool):
+    """#1029 consistency regression: if pool.remove_client raises, the account
+    must STILL be deleted from the DB. The DB is the source of truth — the pool is
+    rebuilt from it on restart, so letting a pool failure abort delete_account
+    leaves a 'ghost' account the operator believes is gone but that reappears
+    (and an orphaned in-memory client). This mirrors toggle(), which already
+    swallows add_client failures (test_account_service_toggle_add_client_error)."""
+    acc = Account(id=1, phone="+7999", session_string="sess")
+    mock_bundle.list_accounts.return_value = [acc]
+    mock_pool.remove_client.side_effect = Exception("pool removal failed")
+    svc = AccountService(mock_bundle, mock_pool)
+
+    # Must not raise — the pool error is logged, not propagated.
+    await svc.delete(1)
+
+    mock_pool.remove_client.assert_called_once_with("+7999")
+    mock_bundle.delete_account.assert_called_once_with(1)
+
+
+@pytest.mark.anyio
 async def test_account_service_init_with_db():
     from src.database import Database
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -199,3 +199,143 @@ class TestVerifyCode:
         )
         # needs_2fa keeps the pending client alive for the follow-up password step.
         assert "+1234567890" in auth._pending
+
+    @pytest.mark.anyio
+    async def test_verify_code_hash_mismatch_raises_before_sign_in(self):
+        """A phone_code_hash that does not match the pending one is rejected
+        before any sign_in RPC — the stored hash is bound to the MTProto session,
+        so a stale hash must fail loudly rather than silently signing in."""
+        auth = TelegramAuth(api_id=123, api_hash="abc")
+        mock_client = AsyncMock()
+        mock_client.session = SimpleNamespace(save=lambda: "session123")
+        auth._pending["+1234567890"] = (mock_client, "hash123")
+
+        with pytest.raises(ValueError, match="Phone code hash mismatch"):
+            await auth.verify_code("+1234567890", "11111", "stale_hash")
+
+        mock_client.sign_in.assert_not_awaited()
+        # Pending stays intact so a retry with the right hash can still succeed.
+        assert "+1234567890" in auth._pending
+
+    @pytest.mark.anyio
+    async def test_verify_code_no_pending_raises(self):
+        """#1029: verifying with no pending entry (e.g. a cross-process verify
+        that never ran send_code in this process) must fail with a clear error,
+        not a KeyError."""
+        auth = TelegramAuth(api_id=123, api_hash="abc")
+        with pytest.raises(ValueError, match="No pending auth"):
+            await auth.verify_code("+1234567890", "11111", "hash123")
+
+    @pytest.mark.anyio
+    async def test_verify_code_session_save_failure_does_not_lose_pending(self):
+        """#1029 data-loss regression: if ``session.save()`` raises AFTER a
+        successful ``sign_in``, the account is already authorized on Telegram's
+        side but we have no session string. The pending entry MUST survive so the
+        operator can retry the save instead of losing the authenticated session
+        forever (which would force a fresh send-code/verify onboarding)."""
+        auth = TelegramAuth(api_id=123, api_hash="abc")
+        mock_client = AsyncMock()
+
+        def _exploding_save():
+            raise RuntimeError("session serialization failed")
+
+        mock_client.session = SimpleNamespace(save=_exploding_save)
+        auth._pending["+1234567890"] = (mock_client, "hash123")
+
+        with pytest.raises(RuntimeError, match="session serialization failed"):
+            await auth.verify_code("+1234567890", "11111", "hash123")
+
+        # sign_in succeeded — the account is authorized — so the pending client
+        # must NOT have been dropped/disconnected: that would strand the session.
+        assert "+1234567890" in auth._pending
+        mock_client.disconnect.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_verify_code_retry_after_save_failure_recovers_session(self):
+        """#1029: after a transient ``session.save()`` failure the operator can
+        retry ``verify_code`` and recover the session — the surviving pending
+        client signs in idempotently and the second save succeeds."""
+        auth = TelegramAuth(api_id=123, api_hash="abc")
+        mock_client = AsyncMock()
+        save_calls = {"n": 0}
+
+        def _flaky_save():
+            save_calls["n"] += 1
+            if save_calls["n"] == 1:
+                raise RuntimeError("transient serialization failure")
+            return "recovered_session"
+
+        mock_client.session = SimpleNamespace(save=_flaky_save)
+        auth._pending["+1234567890"] = (mock_client, "hash123")
+
+        with pytest.raises(RuntimeError):
+            await auth.verify_code("+1234567890", "11111", "hash123")
+
+        # Retry: pending survived, so this call recovers the session.
+        session = await auth.verify_code("+1234567890", "11111", "hash123")
+        assert session == "recovered_session"
+        # Now that the session is durably captured, the client is cleaned up.
+        assert "+1234567890" not in auth._pending
+        mock_client.disconnect.assert_awaited_once()
+
+
+class TestSignInFresh:
+    @pytest.mark.anyio
+    async def test_sign_in_fresh_restores_string_session(self):
+        """#1029 cross-process: sign_in_fresh must rebuild the MTProto session
+        from the session_str produced by send_code (possibly in another process),
+        because Telegram binds phone_code_hash to that exact session."""
+        auth = TelegramAuth(api_id=123, api_hash="abc")
+        mock_client = AsyncMock()
+        mock_client.session = SimpleNamespace(save=lambda: "final_session")
+
+        captured: dict[str, object] = {}
+
+        def _fake_string_session(value=""):
+            captured["session_str"] = value
+            return SimpleNamespace(_value=value)
+
+        with (
+            patch("src.telegram.auth.TelegramClient", return_value=mock_client),
+            patch("src.telegram.auth.StringSession", _fake_string_session),
+        ):
+            session = await auth.sign_in_fresh(
+                "+1234567890",
+                "11111",
+                "hash123",
+                session_str="restored_mtproto_state",
+            )
+
+        assert session == "final_session"
+        # The send_code session string was fed back into StringSession verbatim.
+        assert captured["session_str"] == "restored_mtproto_state"
+        mock_client.sign_in.assert_awaited_once_with(
+            "+1234567890", "11111", phone_code_hash="hash123"
+        )
+        mock_client.disconnect.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_sign_in_fresh_session_save_failure_does_not_swallow(self):
+        """#1029 data-loss regression for the cross-process path: a save() that
+        raises after a successful sign_in must propagate (so the caller knows the
+        session was NOT captured) rather than being masked as success."""
+        auth = TelegramAuth(api_id=123, api_hash="abc")
+        mock_client = AsyncMock()
+
+        def _exploding_save():
+            raise RuntimeError("save failed post sign_in")
+
+        mock_client.session = SimpleNamespace(save=_exploding_save)
+
+        with (
+            patch("src.telegram.auth.TelegramClient", return_value=mock_client),
+            patch("src.telegram.auth.StringSession", lambda _value="": SimpleNamespace()),
+        ):
+            with pytest.raises(RuntimeError, match="save failed post sign_in"):
+                await auth.sign_in_fresh(
+                    "+1234567890", "11111", "hash123", session_str="state"
+                )
+
+        # sign_in_fresh has no in-memory pending to preserve, but it must always
+        # disconnect its throwaway client (no leak) even on the save failure.
+        mock_client.disconnect.assert_awaited_once()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -197,7 +197,8 @@ class TestVerifyCode:
             "needs 2FA password" in r.getMessage() and r.levelno == logging.INFO
             for r in caplog.records
         )
-        # needs_2fa keeps the pending client alive for the follow-up password step.
+        # TwoFactorRequiredError re-raises before the post-try cleanup, so the
+        # pending client stays alive for the follow-up password step.
         assert "+1234567890" in auth._pending
 
     @pytest.mark.anyio

--- a/tests/test_client_pool.py
+++ b/tests/test_client_pool.py
@@ -214,6 +214,73 @@ async def test_pool_skips_flooded_returns_next(real_pool_harness_factory):
 
 
 @pytest.mark.anyio
+async def test_get_available_client_bounded_rotations_returns_none(real_pool_harness_factory):
+    """#1029: get_available_client rotates at most len(clients) times before
+    giving up. If backend acquisition fails on every rotation, the loop must NOT
+    spin forever — it returns None after exactly one attempt per connected client.
+
+    Without the ``for _ in range(max(1, len(self.clients)))`` bound this would
+    loop indefinitely (each acquire_available keeps returning a lease that
+    _acquire_from_lease then fails to honour)."""
+    harness = real_pool_harness_factory()
+    for phone in ("+70010000001", "+70010000002", "+70010000003"):
+        harness.queue_cli_client(phone=phone, client=FakeCliTelethonClient())
+        await harness.add_account(phone, session_string=f"s-{phone}")
+    await harness.initialize_connected_accounts()
+    assert len(harness.pool.clients) == 3
+
+    # Every backend acquisition fails — simulates e.g. all sessions bricked.
+    calls = {"n": 0}
+
+    async def _always_fail(account_lease, **kwargs):
+        calls["n"] += 1
+        # Release the lease the way the real _acquire_from_lease does on failure,
+        # so the next rotation can re-select an account instead of starving.
+        if not account_lease.shared:
+            await harness.pool._lease_pool.release(account_lease.account.phone)
+        return None
+
+    harness.pool._acquire_from_lease = _always_fail  # type: ignore[method-assign]
+
+    result = await harness.pool.get_available_client()
+
+    assert result is None
+    # Bounded: one acquisition attempt per connected client, never more.
+    assert calls["n"] == 3
+
+
+@pytest.mark.anyio
+async def test_get_available_client_recovers_on_later_rotation(real_pool_harness_factory):
+    """#1029: a transient backend failure on the first rotation must not abort
+    the whole call — get_available_client retries the next account and succeeds,
+    proving the rotation loop is a real fallback, not a single shot."""
+    harness = real_pool_harness_factory()
+    for phone in ("+70011000001", "+70011000002"):
+        harness.queue_cli_client(phone=phone, client=FakeCliTelethonClient())
+        await harness.add_account(phone, session_string=f"s-{phone}")
+    await harness.initialize_connected_accounts()
+
+    real_acquire = harness.pool._acquire_from_lease
+    calls = {"n": 0}
+
+    async def _fail_first_then_real(account_lease, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            if not account_lease.shared:
+                await harness.pool._lease_pool.release(account_lease.account.phone)
+            return None
+        return await real_acquire(account_lease, **kwargs)
+
+    harness.pool._acquire_from_lease = _fail_first_then_real  # type: ignore[method-assign]
+
+    result = await harness.pool.get_available_client()
+
+    assert result is not None
+    # Recovered on the second rotation.
+    assert calls["n"] == 2
+
+
+@pytest.mark.anyio
 async def test_resolve_channel_returns_raw_id(real_pool_harness_factory):
     harness = real_pool_harness_factory()
     client = harness.queue_cli_client(

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,3 +1,4 @@
+import asyncio
 import sqlite3
 from datetime import datetime, timedelta, timezone
 
@@ -92,6 +93,76 @@ async def test_single_primary_partial_index_rejects_raw_double_primary(db):
             "INSERT INTO accounts (phone, session_string, is_primary) VALUES (?, ?, 1)",
             ("+70000000004", "s2"),
         )
+
+
+@pytest.mark.anyio
+async def test_concurrent_add_primary_yields_exactly_one(db):
+    """#1029 / #733 race: two coroutines each adding an account with
+    is_primary=True concurrently must NOT both win. The atomic CASE/NOT EXISTS
+    derivation inside the INSERT (and the partial unique index behind it) means
+    exactly one ends up primary even when the inserts interleave."""
+    await asyncio.gather(
+        db.add_account(Account(phone="+70000010001", session_string="s1", is_primary=True)),
+        db.add_account(Account(phone="+70000010002", session_string="s2", is_primary=True)),
+    )
+
+    accounts = await db.get_accounts()
+    primaries = [a for a in accounts if a.is_primary]
+    assert len(primaries) == 1
+
+
+@pytest.mark.anyio
+async def test_delete_primary_reassigns_to_remaining_account(db):
+    """#1029: deleting the primary account must auto-promote the lowest-id
+    remaining account so the system never sits with zero primary while other
+    accounts exist. Regression guard for the delete→reassign half of the
+    one-primary invariant (delete_account → _promote_primary_if_none)."""
+    primary_id = await db.add_account(
+        Account(phone="+70000020001", session_string="s1", is_primary=True)
+    )
+    await db.add_account(Account(phone="+70000020002", session_string="s2"))
+    await db.add_account(Account(phone="+70000020003", session_string="s3"))
+
+    await db.delete_account(primary_id)
+
+    accounts = await db.get_accounts()
+    assert all(a.phone != "+70000020001" for a in accounts)
+    primaries = [a for a in accounts if a.is_primary]
+    assert len(primaries) == 1
+    # Lowest remaining id wins.
+    assert primaries[0].phone == "+70000020002"
+
+
+@pytest.mark.anyio
+async def test_delete_last_account_leaves_no_primary(db):
+    """#1029: deleting the only account must not crash trying to promote a
+    non-existent successor — zero accounts means zero primary, cleanly."""
+    only_id = await db.add_account(
+        Account(phone="+70000030001", session_string="s1", is_primary=True)
+    )
+
+    await db.delete_account(only_id)
+
+    accounts = await db.get_accounts()
+    assert accounts == []
+
+
+@pytest.mark.anyio
+async def test_delete_non_primary_does_not_change_primary(db):
+    """#1029: deleting a NON-primary account must leave the existing primary
+    untouched (the reassign only fires when the primary slot is empty)."""
+    primary_id = await db.add_account(
+        Account(phone="+70000040001", session_string="s1", is_primary=True)
+    )
+    secondary_id = await db.add_account(Account(phone="+70000040002", session_string="s2"))
+    assert primary_id and secondary_id
+
+    await db.delete_account(secondary_id)
+
+    accounts = await db.get_accounts()
+    primaries = [a for a in accounts if a.is_primary]
+    assert len(primaries) == 1
+    assert primaries[0].phone == "+70000040001"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Что это

Подзадача эпика #1024 (тир 1, горячая зона). Регресс-тесты на тонкие места `ClientPool` и auth-флоу. TDD: падающий тест → фикс → гард.

В процессе найдено и исправлено **2 реальных бага дата-целостности** — оба воспроизведены красным тестом до фикса, не «known-limitation».

## Найденные баги (исправлены)

### Баг A — потеря авторизованной сессии (`src/telegram/auth.py`)
`verify_code` сохранял `session.save()` в `try`, но `finally` безусловно делал `del _pending` + `disconnect`. Если `save()` падал **после** успешного `sign_in`, Telegram уже считал клиента авторизованным, а строка сессии терялась навсегда → требовался повторный onboarding. `phone_code_hash` привязан к MTProto-сессии, второй раз её не восстановить.

**Фикс:** pending очищается/disconnect только после успешного захвата `session_string`; при падении `save()` pending выживает → оператор может повторить `verify_code` и восстановить сессию. Заодно убран мёртвый `needs_2fa`.

### Баг B — рассинхрон pool↔DB при удалении (`src/services/account_service.py`)
`delete()` вызывал `pool.remove_client` **перед** `delete_account` без `try/except`: падение `remove_client` пробрасывалось наверх и отменяло удаление из DB → аккаунт-«призрак» остаётся в БД (источник истины), возвращается после рестарта.

**Фикс:** ошибка pool глушится (как уже делает `toggle()` для `add_client`), DB-удаление выполняется всегда. Устранена асимметрия toggle/delete.

## Регресс-гарды (фиксируют уже корректное поведение)

- **Flood-ротация смешанные состояния** (`test_account_lease_pool.py`): flooded+leased+free одновременно, shared-fallback не отдаёт flooded, all-flooded → None.
- **Максимум ротаций** (`test_client_pool.py`): `get_available_client` делает ≤ `len(clients)` попыток перед None; recover на поздней ротации при транзиентном сбое backend.
- **Primary-гонки #733** (`test_database.py`): concurrent add (`gather`) → ровно один primary; delete primary → авто-reassign lowest-id; delete last → ноль primary; delete non-primary не трогает primary.
- **Cross-process auth** (`test_auth.py`): hash mismatch, no-pending, `sign_in_fresh` восстанавливает `StringSession` из `session_str`.

Пункт #4 (#449, порядок DB-first при CLI verify-code) уже покрыт существующим `test_cli_verify_code_persists_account_before_pool_warmup` — дубль не добавлялся.

## Проверки
- `ruff check` — чисто
- `mypy` — без новых ошибок vs baseline (268→268 на изменённых src-файлах)
- `pytest -n auto` — стабилен (143 связанных теста зелёные параллельно; `test_database.py` серийно — 77 зелёных)
- smoke-префлайт зелёный

## Объём
7 файлов, +379/−10 (src ~24 / tests ~355) — в рамках оценки issue (L, ~280–480 LOC).

Closes #1029

🤖 Generated with [Claude Code](https://claude.com/claude-code)