### PR TITLE
test(dispatcher): claim-races, recovery, phone-isolation, rate-limit (TDD) (#1030)

### DIFF
--- a/src/services/dispatcher/dialogs_mixin.py
+++ b/src/services/dispatcher/dialogs_mixin.py
@@ -205,6 +205,37 @@ class DialogsCommandsMixin(_Base):
                 },
             )
 
+    async def _record_reaction(self, *phones: str) -> None:
+        """Stamp the last-reaction time for every phone a reaction went out for,
+        then evict entries that are older than the rate-limit window.
+
+        Two phones are passed when the pool normalises the requested phone
+        (``"+1"`` requested, ``"1"`` acquired): ``_ensure_reaction_can_run`` reads
+        under the *requested* phone, so we must record under it too — recording
+        only under the acquired phone would let the next reaction for ``"+1"``
+        skip the gate entirely (#1030). Recording under both keys keeps the gate
+        correct whichever form the next command carries.
+
+        The map is in-memory only and keyed by phone, so without eviction a
+        long-lived worker reacting across many accounts grows it without bound.
+        Entries older than the interval carry no information — the gate would let
+        that phone react regardless — so pruning them changes no behaviour and is
+        not an idempotency ledger.
+        """
+        now = time.monotonic()
+        for phone in phones:
+            if phone:
+                self._last_reaction_at_monotonic[phone] = now
+        min_interval = await self._reaction_min_interval()
+        stale_before = now - min_interval
+        stale = [
+            phone
+            for phone, stamp in self._last_reaction_at_monotonic.items()
+            if stamp < stale_before
+        ]
+        for phone in stale:
+            del self._last_reaction_at_monotonic[phone]
+
     async def _handle_dialogs_pin_message(self, payload: dict[str, Any]) -> dict[str, Any]:
         result = await TelegramActionService(self._pool).pin_message(
             phone=str(payload["phone"]),
@@ -226,7 +257,9 @@ class DialogsCommandsMixin(_Base):
             native=True,
             resolve_entity=True,
         )
-        self._last_reaction_at_monotonic[result.phone] = time.monotonic()
+        # Record under both the requested phone (what the gate reads) and the
+        # acquired phone the pool handed out, then prune stale entries (#1030).
+        await self._record_reaction(phone, result.phone)
         return {"phone": result.phone}
 
     async def _handle_dialogs_unpin_message(self, payload: dict[str, Any]) -> dict[str, Any]:

--- a/src/services/dispatcher/dialogs_mixin.py
+++ b/src/services/dispatcher/dialogs_mixin.py
@@ -221,12 +221,22 @@ class DialogsCommandsMixin(_Base):
         Entries older than the interval carry no information — the gate would let
         that phone react regardless — so pruning them changes no behaviour and is
         not an idempotency ledger.
+
+        This runs *after* the (irreversible) Telegram send, so the stamping —
+        plain in-memory writes that cannot fail — happens unconditionally, while
+        the prune is best-effort: it needs a live DB settings read for the
+        interval, and a transient failure there must not bubble up and flip an
+        already-sent reaction to FAILED (which would re-send it on retry, #1030).
         """
         now = time.monotonic()
         for phone in phones:
             if phone:
                 self._last_reaction_at_monotonic[phone] = now
-        min_interval = await self._reaction_min_interval()
+        try:
+            min_interval = await self._reaction_min_interval()
+        except Exception as exc:  # noqa: BLE001 — bookkeeping must not fail the send
+            logger.warning("reaction timestamp prune skipped (interval read failed): %s", exc)
+            return
         stale_before = now - min_interval
         stale = [
             phone

--- a/tests/repositories/test_runtime_repositories.py
+++ b/tests/repositories/test_runtime_repositories.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
@@ -462,6 +463,202 @@ async def test_cancel_pending_commands_unfiltered_skips_running(tmp_path):
         running_check = await db.repos.telegram_commands.get_command(running_id)
         assert running_check is not None
         assert running_check.status == TelegramCommandStatus.RUNNING
+    finally:
+        await db.close()
+
+
+# ---------------------------------------------------------------------------
+# Claim races, recovery, and run_after gating (#1030, epic #1024 tier-1).
+#
+# These guard the thin spots a single dispatcher worker shares with any peer:
+# the claim transaction must hand a PENDING row to exactly one caller, a worker
+# crash must not strand RUNNING rows, and run_after must gate by wall-clock.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_concurrent_claim_hands_command_to_exactly_one_worker(tmp_path):
+    """Two workers racing on one PENDING row: exactly one wins (#1030).
+
+    ``claim_next_command`` runs SELECT+UPDATE inside ``db.transaction()`` under
+    the connection-wide write lock (#569). Even with five concurrent claims,
+    only one transitions the single row PENDING → RUNNING; the rest see it gone
+    and return None. A regression that drops the lock or splits the
+    select-then-update would let two workers run the same Telegram command.
+    """
+    db = Database(str(tmp_path / "test.db"))
+    await db.initialize()
+
+    try:
+        command_id = await db.repos.telegram_commands.create_command(
+            TelegramCommand(
+                command_type="dialogs.react",
+                payload={"phone": "+1", "message_id": 1, "emoji": "👍"},
+                requested_by="test",
+            )
+        )
+
+        results = await asyncio.gather(
+            *[db.repos.telegram_commands.claim_next_command() for _ in range(5)]
+        )
+
+        claimed = [cmd for cmd in results if cmd is not None]
+        assert len(claimed) == 1, f"expected exactly one winner, got {len(claimed)}"
+        assert claimed[0].id == command_id
+        assert claimed[0].status == TelegramCommandStatus.RUNNING
+
+        stored = await db.repos.telegram_commands.get_command(command_id)
+        assert stored is not None
+        assert stored.status == TelegramCommandStatus.RUNNING
+        # No second claim possible — the queue is now empty.
+        assert await db.repos.telegram_commands.claim_next_command() is None
+    finally:
+        await db.close()
+
+
+@pytest.mark.anyio
+async def test_concurrent_claim_two_commands_two_workers_no_overlap(tmp_path):
+    """Two PENDING rows, four racing claims: each row goes to a distinct worker.
+
+    Guards against a claim that re-reads the same lowest-id row twice before the
+    UPDATE lands — every claimed command id must be unique.
+    """
+    db = Database(str(tmp_path / "test.db"))
+    await db.initialize()
+
+    try:
+        first = await db.repos.telegram_commands.create_command(
+            TelegramCommand(command_type="dialogs.react", payload={"phone": "+1"}, requested_by="t")
+        )
+        second = await db.repos.telegram_commands.create_command(
+            TelegramCommand(command_type="dialogs.react", payload={"phone": "+2"}, requested_by="t")
+        )
+
+        results = await asyncio.gather(
+            *[db.repos.telegram_commands.claim_next_command() for _ in range(4)]
+        )
+        claimed_ids = sorted(cmd.id for cmd in results if cmd is not None)
+
+        assert claimed_ids == [first, second]
+        assert len(claimed_ids) == len(set(claimed_ids)), "a command was claimed twice"
+    finally:
+        await db.close()
+
+
+@pytest.mark.anyio
+async def test_claim_and_cancel_race_never_leaves_command_in_two_states(tmp_path):
+    """claim ↔ cancel on the same PENDING row resolve to one outcome (#1030).
+
+    Either cancel wins (CANCELLED, claim returns None) or claim wins (RUNNING,
+    cancel returns False). The row must never end up RUNNING *and* reported
+    cancelled, which would let a cancelled command still fire a Telegram call.
+    """
+    db = Database(str(tmp_path / "test.db"))
+    await db.initialize()
+
+    try:
+        command_id = await db.repos.telegram_commands.create_command(
+            TelegramCommand(command_type="dialogs.react", payload={"phone": "+1"}, requested_by="t")
+        )
+
+        claimed, cancelled = await asyncio.gather(
+            db.repos.telegram_commands.claim_next_command(),
+            db.repos.telegram_commands.cancel_command(command_id),
+        )
+        final = await db.repos.telegram_commands.get_command(command_id)
+        assert final is not None
+
+        claim_won = claimed is not None
+        # Exactly one side took effect — never both, never neither.
+        assert claim_won != cancelled, (
+            f"claim_won={claim_won} cancelled={cancelled} — both or neither acted"
+        )
+        if claim_won:
+            assert final.status == TelegramCommandStatus.RUNNING
+            assert claimed.id == command_id
+        else:
+            assert final.status == TelegramCommandStatus.CANCELLED
+    finally:
+        await db.close()
+
+
+@pytest.mark.anyio
+async def test_reset_running_on_startup_requeues_orphaned_commands(tmp_path):
+    """A worker crash leaves rows RUNNING; startup must requeue them (#1030).
+
+    ``claim_next_command`` only picks PENDING rows, so a RUNNING row left behind
+    by a killed worker would stay claimed forever. ``reset_running_on_startup``
+    flips RUNNING → PENDING and clears started_at so the command is eligible and
+    its retry shows a fresh run timestamp. PENDING / terminal rows are untouched.
+    """
+    db = Database(str(tmp_path / "test.db"))
+    await db.initialize()
+
+    try:
+        repo = db.repos.telegram_commands
+        # Orphaned RUNNING (claimed, then "crash" before finishing).
+        orphan_id = await repo.create_command(
+            TelegramCommand(command_type="dialogs.react", payload={"phone": "+1"}, requested_by="t")
+        )
+        claimed = await repo.claim_next_command()
+        assert claimed is not None and claimed.id == orphan_id
+        assert claimed.status == TelegramCommandStatus.RUNNING
+        assert claimed.started_at is not None
+
+        # An untouched PENDING row and a terminal SUCCEEDED row must survive intact.
+        pending_id = await repo.create_command(
+            TelegramCommand(command_type="dialogs.react", payload={"phone": "+2"}, requested_by="t")
+        )
+        done_id = await repo.create_command(
+            TelegramCommand(command_type="dialogs.react", payload={"phone": "+3"}, requested_by="t")
+        )
+        await repo.update_command(done_id, status=TelegramCommandStatus.SUCCEEDED)
+
+        reset_count = await repo.reset_running_on_startup()
+        assert reset_count == 1, "only the single RUNNING row should be requeued"
+
+        recovered = await repo.get_command(orphan_id)
+        assert recovered is not None
+        assert recovered.status == TelegramCommandStatus.PENDING
+        assert recovered.started_at is None, "started_at must reset so retry shows fresh run"
+
+        pending = await repo.get_command(pending_id)
+        assert pending is not None and pending.status == TelegramCommandStatus.PENDING
+        done = await repo.get_command(done_id)
+        assert done is not None and done.status == TelegramCommandStatus.SUCCEEDED
+
+        # The recovered command is claimable again — recovery actually worked.
+        reclaimed = await repo.claim_next_command()
+        assert reclaimed is not None and reclaimed.id == orphan_id
+    finally:
+        await db.close()
+
+
+@pytest.mark.anyio
+async def test_claim_next_command_picks_due_run_after(tmp_path):
+    """A run_after in the past is due and gets claimed (#1030).
+
+    Complements ``test_claim_next_command_skips_future_run_after``: that proves
+    the future row is *skipped*; this proves a past row is *picked*, so a delayed
+    retry actually resumes once its run_after passes.
+    """
+    db = Database(str(tmp_path / "test.db"))
+    await db.initialize()
+
+    try:
+        due_id = await db.repos.telegram_commands.create_command(
+            TelegramCommand(
+                command_type="dialogs.react",
+                payload={"phone": "+1", "message_id": 1},
+                requested_by="test",
+                run_after=datetime.now(timezone.utc) - timedelta(minutes=5),
+            )
+        )
+
+        claimed = await db.repos.telegram_commands.claim_next_command()
+        assert claimed is not None
+        assert claimed.id == due_id
+        assert claimed.status == TelegramCommandStatus.RUNNING
     finally:
         await db.close()
 

--- a/tests/repositories/test_runtime_repositories.py
+++ b/tests/repositories/test_runtime_repositories.py
@@ -485,6 +485,11 @@ async def test_concurrent_claim_hands_command_to_exactly_one_worker(tmp_path):
     only one transitions the single row PENDING → RUNNING; the rest see it gone
     and return None. A regression that drops the lock or splits the
     select-then-update would let two workers run the same Telegram command.
+
+    Scope: web and worker share one connection in one process (#569), so this
+    races coroutines on that shared connection — it proves the select-then-update
+    stays atomic under the write lock, not cross-process SQLite isolation (which
+    the architecture does not rely on).
     """
     db = Database(str(tmp_path / "test.db"))
     await db.initialize()

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -10,6 +10,7 @@ from telethon import TelegramClient
 from src.config import AppConfig, DatabaseConfig
 from src.database import Database
 from src.database.repositories.accounts import AccountSessionDecryptError
+from src.models import TelegramCommand, TelegramCommandStatus
 from src.search.engine import SearchEngine
 from src.web.bootstrap import _log_task_exception, build_web_container, start_container
 from src.web.log_handler import LogBuffer
@@ -144,6 +145,85 @@ async def test_start_container_worker_mode_runs_inflight_recovery(tmp_path):
         await start_container(container)
         container.photo_task_service.recover_running.assert_awaited_once()
         container.db.repos.generation_runs.reset_running_on_startup.assert_awaited_once()
+    finally:
+        await db.close()
+
+
+@pytest.mark.anyio
+async def test_start_container_worker_recovers_orphaned_telegram_commands(tmp_path):
+    """Worker startup requeues telegram_commands stranded in RUNNING (#1030).
+
+    A worker killed mid-dispatch leaves its claimed command RUNNING; only
+    PENDING rows are claimable, so without recovery that command is stuck
+    forever. Driving the real start_container path (not just the repo method)
+    proves the dispatcher's recovery is actually wired into worker boot.
+    """
+    db = Database(str(tmp_path / "test.db"))
+    await db.initialize()
+
+    # Seed a command and promote it to RUNNING, simulating an interrupted worker.
+    command_id = await db.repos.telegram_commands.create_command(
+        TelegramCommand(
+            command_type="dialogs.react",
+            payload={"phone": "+1", "message_id": 1, "emoji": "👍"},
+            requested_by="test",
+        )
+    )
+    await db.repos.telegram_commands.update_command(
+        command_id, status=TelegramCommandStatus.RUNNING
+    )
+
+    container = _make_container(db)
+    container.runtime_mode = "worker"
+    container.auth.is_configured = False
+    container.scheduler = AsyncMock()
+    container.scheduler.load_settings = AsyncMock()
+
+    try:
+        await start_container(container)
+
+        recovered = await db.repos.telegram_commands.get_command(command_id)
+        assert recovered is not None
+        assert recovered.status == TelegramCommandStatus.PENDING
+        assert recovered.started_at is None
+    finally:
+        await db.close()
+
+
+@pytest.mark.anyio
+async def test_start_container_web_mode_skips_telegram_command_recovery(tmp_path):
+    """Web restart must not touch the live worker's RUNNING telegram_commands.
+
+    Mirror of the photo/generation web-skip guard (#836/2) for telegram_commands:
+    in a split deploy the web side shares the DB and must leave in-flight rows for
+    the worker to own.
+    """
+    db = Database(str(tmp_path / "test.db"))
+    await db.initialize()
+
+    command_id = await db.repos.telegram_commands.create_command(
+        TelegramCommand(
+            command_type="dialogs.react",
+            payload={"phone": "+1", "message_id": 1, "emoji": "👍"},
+            requested_by="test",
+        )
+    )
+    await db.repos.telegram_commands.update_command(
+        command_id, status=TelegramCommandStatus.RUNNING
+    )
+
+    container = _make_container(db)
+    container.runtime_mode = "web"
+    container.scheduler = AsyncMock()
+    container.scheduler.load_settings = AsyncMock()
+
+    try:
+        await start_container(container)
+
+        # The worker still owns this row — web must not have requeued it.
+        still_running = await db.repos.telegram_commands.get_command(command_id)
+        assert still_running is not None
+        assert still_running.status == TelegramCommandStatus.RUNNING
     finally:
         await db.close()
 

--- a/tests/test_telegram_command_dispatcher.py
+++ b/tests/test_telegram_command_dispatcher.py
@@ -608,6 +608,265 @@ async def test_run_loop_marks_invalid_reaction_failed_without_calling_telegram()
     assert kwargs["result_payload"]["emoji"] == "✅"
 
 
+# ---------------------------------------------------------------------------
+# Per-phone reaction rate-limit: real enforcement, key consistency, and the
+# memory-growth guard (#1030, epic #1024 tier-1).
+# ---------------------------------------------------------------------------
+
+
+def _react_db(*, min_interval: str = "30"):
+    """A mock DB whose only relevant behaviour is the reaction-interval setting
+    and an empty account list (so the flood-wait gate is a no-op)."""
+    db = _mock_db()
+    db.get_setting.return_value = min_interval
+    db.get_account_summaries.return_value = []
+    db.get_accounts.return_value = []
+    return db
+
+
+def _patch_reaction_service(acquired_phone: str):
+    """Patch TelegramActionService in the dialogs mixin so send_reaction reports
+    ``acquired_phone`` (the phone the pool actually handed out, which the pool is
+    free to normalise) regardless of the requested phone.
+
+    Returns ``(patcher, send_reaction_mock)``; the patcher is already started and
+    the caller must ``.stop()`` it when done.
+    """
+    svc_patch = patch("src.services.dispatcher.dialogs_mixin.TelegramActionService")
+    svc_cls = svc_patch.start()
+    send_reaction = AsyncMock(return_value=MagicMock(phone=acquired_phone))
+    svc_cls.return_value.send_reaction = send_reaction
+    return svc_patch, send_reaction
+
+
+async def test_reaction_rate_limit_enforced_after_a_successful_reaction():
+    """A second reaction within the interval is delayed, not sent (#1030).
+
+    The existing suite seeds ``_last_reaction_at_monotonic`` by hand; this drives
+    the real handler so the success path that records the timestamp is exercised
+    end-to-end. The first reaction goes out; the second (immediate) one must be
+    bounced to PENDING with run_after instead of hitting Telegram again.
+    """
+    db = _react_db(min_interval="30")
+    pool = _mock_pool()
+    pool.is_warming = MagicMock(return_value=False)
+    d = _dispatcher(db=db, pool=pool)
+
+    svc_patch, send_reaction = _patch_reaction_service(acquired_phone="+1")
+    try:
+        payload = {"phone": "+1", "chat_id": -100, "message_id": 1, "emoji": "👍"}
+        await d._handle_dialogs_react(payload)
+        assert send_reaction.await_count == 1
+
+        with pytest.raises(TelegramCommandRetryLaterError, match="rate limit"):
+            await d._handle_dialogs_react({**payload, "message_id": 2})
+        # The blocked reaction must NOT have reached Telegram.
+        assert send_reaction.await_count == 1
+    finally:
+        svc_patch.stop()
+
+
+async def test_reaction_rate_limit_keyed_by_requested_phone_not_normalized():
+    """Rate-limit must hold even when the pool normalises the phone (#1030).
+
+    Bug: ``_handle_dialogs_react`` recorded the last-reaction time under the
+    phone the *pool returned* (``result.phone``), while ``_ensure_reaction_can_run``
+    reads under the phone from the *payload*. When the pool hands back a
+    normalised phone (``"+1"`` requested, ``"1"`` acquired), the write and the
+    read land on different keys, so the gate never sees the prior reaction and
+    the next one fires immediately — defeating the per-phone FloodWait guard.
+    """
+    db = _react_db(min_interval="30")
+    pool = _mock_pool()
+    pool.is_warming = MagicMock(return_value=False)
+    d = _dispatcher(db=db, pool=pool)
+
+    # Pool acquires under a normalised phone that differs from the request.
+    svc_patch, send_reaction = _patch_reaction_service(acquired_phone="1")
+    try:
+        payload = {"phone": "+1", "chat_id": -100, "message_id": 1, "emoji": "👍"}
+        await d._handle_dialogs_react(payload)
+        assert send_reaction.await_count == 1
+
+        # Same requested phone, immediately again — must be rate-limited.
+        with pytest.raises(TelegramCommandRetryLaterError, match="rate limit"):
+            await d._handle_dialogs_react({**payload, "message_id": 2})
+        assert send_reaction.await_count == 1, (
+            "second reaction slipped past the rate-limit because the timestamp "
+            "was keyed by the normalised acquired phone, not the requested one"
+        )
+    finally:
+        svc_patch.stop()
+
+
+async def test_reaction_timestamps_do_not_grow_unbounded():
+    """Stale per-phone reaction timestamps are pruned (#1030 memory leak).
+
+    ``_last_reaction_at_monotonic`` is an in-memory dict keyed by phone with no
+    eviction: every distinct phone that ever reacted left a permanent entry, so
+    a long-lived worker reacting across many accounts grows it without bound.
+    Entries older than the rate-limit window carry no information (the gate would
+    let that phone react anyway), so they must be evicted. This is not a DB
+    ledger — pruning a stale monotonic timestamp changes no idempotency state.
+    """
+    db = _react_db(min_interval="30")
+    pool = _mock_pool()
+    pool.is_warming = MagicMock(return_value=False)
+    d = _dispatcher(db=db, pool=pool)
+
+    now = time.monotonic()
+    # 500 phones reacted long ago (well past any sane interval ceiling).
+    for i in range(500):
+        d._last_reaction_at_monotonic[f"+{i}"] = now - 100_000
+    # One phone reacted just now — its entry is still meaningful.
+    d._last_reaction_at_monotonic["+recent"] = now
+
+    svc_patch, _ = _patch_reaction_service(acquired_phone="+fresh")
+    try:
+        await d._handle_dialogs_react(
+            {"phone": "+fresh", "chat_id": -100, "message_id": 1, "emoji": "👍"}
+        )
+    finally:
+        svc_patch.stop()
+
+    tracked = d._last_reaction_at_monotonic
+    assert len(tracked) < 500, (
+        f"reaction timestamp map is not pruned (size={len(tracked)}); stale "
+        "per-phone entries accumulate forever"
+    )
+    # The recently-active phone and the just-reacted one are retained.
+    assert "+recent" in tracked
+    assert "+fresh" in tracked
+
+
+# ---------------------------------------------------------------------------
+# Phone-bound isolation: a command for account X must run on X's client, two
+# commands for different phones must run on different clients, and a command
+# with no phone must fail loudly rather than silently mis-route (#1030).
+# ---------------------------------------------------------------------------
+
+
+class _PhoneRoutingClient:
+    """A per-phone fake Telethon client that records the phone it belongs to."""
+
+    def __init__(self, phone: str):
+        self.phone = phone
+        self.sent: list[tuple[object, str]] = []
+
+    async def get_entity(self, identifier):
+        return MagicMock(id=identifier, _client_phone=self.phone)
+
+    async def send_message(self, entity, text):
+        # Tag every send with the owning phone so the test can assert isolation.
+        self.sent.append((entity, text))
+        return MagicMock(id=len(self.sent), _client_phone=self.phone)
+
+
+class _PhoneRoutingPool:
+    """Pool double that hands back a *distinct* client per phone.
+
+    A real class (not MagicMock) so ``explicit_pool_method`` recognises
+    ``get_native_client_by_phone`` as implemented and ``TelegramActionService``
+    routes through it — proving the requested phone selects the right client.
+    """
+
+    def __init__(self, clients: dict[str, _PhoneRoutingClient]):
+        self._clients = clients
+        self.acquired: list[str] = []
+        self.released: list[str] = []
+
+    async def get_native_client_by_phone(self, phone, *, wait_for_flood=False):
+        client = self._clients.get(phone)
+        if client is None:
+            return None
+        self.acquired.append(phone)
+        return client, phone
+
+    def release_client(self, phone):
+        self.released.append(phone)
+
+
+async def test_dialogs_send_routes_to_the_clients_own_phone():
+    """A send for +1 must go out on +1's client, never another account's (#1030)."""
+    client_a = _PhoneRoutingClient("+1")
+    client_b = _PhoneRoutingClient("+2")
+    pool = _PhoneRoutingPool({"+1": client_a, "+2": client_b})
+    d = _dispatcher(pool=pool)
+
+    result = await d._handle_dialogs_send({"phone": "+1", "recipient": -100, "text": "hi"})
+
+    assert result["phone"] == "+1"
+    assert len(client_a.sent) == 1, "the +1 client must be the one that sent"
+    assert client_b.sent == [], "the +2 client must not have been touched"
+    assert pool.released == ["+1"], "the acquired client must be released"
+
+
+async def test_concurrent_sends_for_distinct_phones_use_distinct_clients():
+    """Two sends for different phones at once each hit their own client (#1030).
+
+    Guards against the dispatcher cross-wiring accounts under concurrency — a
+    +1 command sending through +2's session would post to the wrong account.
+    """
+    client_a = _PhoneRoutingClient("+1")
+    client_b = _PhoneRoutingClient("+2")
+    pool = _PhoneRoutingPool({"+1": client_a, "+2": client_b})
+    d = _dispatcher(pool=pool)
+
+    await asyncio.gather(
+        d._handle_dialogs_send({"phone": "+1", "recipient": -100, "text": "from-1"}),
+        d._handle_dialogs_send({"phone": "+2", "recipient": -200, "text": "from-2"}),
+    )
+
+    assert [text for _, text in client_a.sent] == ["from-1"]
+    assert [text for _, text in client_b.sent] == ["from-2"]
+    assert sorted(pool.acquired) == ["+1", "+2"]
+
+
+async def test_dialogs_send_missing_phone_fails_loudly():
+    """A phone-bound command with no phone must raise, not run on a random client.
+
+    The handler reads ``payload["phone"]`` directly, so a missing phone is a
+    hard KeyError — surfaced to ``_run_loop`` as a FAILED command rather than
+    silently sending from whichever account the pool happens to pick (#1030).
+    """
+    pool = _PhoneRoutingPool({"+1": _PhoneRoutingClient("+1")})
+    d = _dispatcher(pool=pool)
+
+    with pytest.raises(KeyError):
+        await d._handle_dialogs_send({"recipient": -100, "text": "orphan"})
+
+    assert pool.acquired == [], "no client should have been acquired without a phone"
+
+
+async def test_run_loop_marks_missing_phone_command_failed_not_silent():
+    """A command with no phone is recorded FAILED, never silently dropped (#1030).
+
+    The poll loop must convert the handler's KeyError into a FAILED status (so an
+    operator sees the bad command) instead of letting it kill the loop or pass
+    unnoticed.
+    """
+    db = _mock_db()
+    command = TelegramCommand(
+        id=11,
+        command_type="dialogs.send",
+        payload={"recipient": -100, "text": "no phone here"},
+    )
+    db.repos.telegram_commands.claim_next_command = AsyncMock(return_value=command)
+    d = _dispatcher(db=db, pool=_PhoneRoutingPool({}))
+
+    async def _update_and_stop(*args, **kwargs):
+        d._stop_event.set()
+
+    db.repos.telegram_commands.update_command = AsyncMock(side_effect=_update_and_stop)
+
+    await d._run_loop()
+
+    db.repos.telegram_commands.update_command.assert_awaited_once()
+    kwargs = db.repos.telegram_commands.update_command.await_args.kwargs
+    assert kwargs["status"] == TelegramCommandStatus.FAILED
+    assert "phone" in kwargs["error"]
+
+
 async def test_dialogs_pin_unpin():
     pool = _mock_pool()
     c = _client_mock()

--- a/tests/test_telegram_command_dispatcher.py
+++ b/tests/test_telegram_command_dispatcher.py
@@ -739,6 +739,40 @@ async def test_reaction_timestamps_do_not_grow_unbounded():
     assert "+fresh" in tracked
 
 
+async def test_reaction_bookkeeping_failure_does_not_fail_an_already_sent_reaction():
+    """Post-send rate-limit bookkeeping must not fail a sent reaction (#1030).
+
+    ``_handle_dialogs_react`` sends the reaction (an irreversible Telegram side
+    effect) *before* recording it. Recording now reads the live interval setting
+    from the DB to prune stale entries; if that read raises after the reaction
+    already went out, the exception would bubble to ``_run_loop`` and the command
+    would be persisted FAILED — so a retry/recovery re-sends a reaction Telegram
+    already saw. The bookkeeping is best-effort: a settings read that blows up
+    must not undo a completed send. The in-memory timestamp is still recorded so
+    the rate-limit gate keeps working.
+    """
+    db = _react_db(min_interval="30")
+    # The interval read (used only for pruning) fails after the send succeeded.
+    db.get_setting.side_effect = RuntimeError("settings DB unavailable")
+    pool = _mock_pool()
+    pool.is_warming = MagicMock(return_value=False)
+    d = _dispatcher(db=db, pool=pool)
+
+    svc_patch, send_reaction = _patch_reaction_service(acquired_phone="+1")
+    try:
+        result = await d._handle_dialogs_react(
+            {"phone": "+1", "chat_id": -100, "message_id": 1, "emoji": "👍"}
+        )
+    finally:
+        svc_patch.stop()
+
+    # The reaction was sent once and the handler returned success, not an error.
+    assert send_reaction.await_count == 1
+    assert result == {"phone": "+1"}
+    # The timestamp is still recorded so the gate enforces spacing next time.
+    assert "+1" in d._last_reaction_at_monotonic
+
+
 # ---------------------------------------------------------------------------
 # Phone-bound isolation: a command for account X must run on X's client, two
 # commands for different phones must run on different clients, and a command


### PR DESCRIPTION
## Что

Тир-1 регресс-тесты на тонкие места `TelegramCommandDispatcher` (эпик #1024) + фиксы двух реальных багов, которые тесты вскрыли (TDD: red → fix → green).

## Найденные и исправленные баги

**1. Rate-limit реакций обходился при нормализации phone пулом.**
`_handle_dialogs_react` записывал время последней реакции под *выданным* пулом phone (`result.phone`), а `_ensure_reaction_can_run` читает под *запрошенным* (`payload["phone"]`). Когда пул нормализует phone (`"+1"` запрошен → `"1"` выдан), запись и чтение попадают в разные ключи → следующая реакция проскакивает гейт. Прямой риск FloodWait. **Фикс:** писать под обоими ключами.

**2. Утечка памяти `_last_reaction_at_monotonic`.**
In-memory dict рос без ограничения — по одной вечной записи на каждый phone, который когда-либо реагировал. **Фикс:** evict записей старше окна rate-limit после каждого успеха. Это монотонный timestamp в памяти, **не** БД-ledger идемпотентности — удаление устаревших записей не меняет поведение (учтён урок #1039).

## Покрытие тестами

- **claim-гонки** (repo): 2+ параллельных `claim_next_command` → ровно один победитель; две команды → двум воркерам без пересечения; гонка claim ↔ cancel разрешается в одно состояние (никогда RUNNING+cancelled).
- **recovery**: `reset_running_on_startup` восстанавливает orphaned RUNNING (repo) и вызывается на worker-старте, но пропускается в web-режиме (bootstrap, split-deploy).
- **run_after**: команда с прошедшим `run_after` выбирается (дополняет существующий skip-future).
- **phone-isolation**: команда исполняется client'ом своего phone; параллельные send для разных phone → разными clients; отсутствие phone → явная ошибка (KeyError → FAILED в poll-loop), не тихий мисроутинг.
- **rate-limit**: реальное соблюдение интервала после успеха, консистентность ключа при нормализации, гард против утечки памяти.

## Проверки

- `pytest` затронутого кластера: 215 passed, без warnings (`filterwarnings=error`).
- `pytest -n auto` на dispatcher-тестах: 158 passed (стабильно в параллели).
- `ruff check`: чисто.
- `mypy src/services/dispatcher/dialogs_mixin.py`: 0 ошибок в изменённом файле (vs baseline).

Closes #1030

🤖 Generated with [Claude Code](https://claude.com/claude-code)