### PR TITLE
test(botfather+moderation): хрупкий парсинг, orphan bot, batch-atomicity (TDD) (#1041)

### DIFF
--- a/src/agent/tools/moderation.py
+++ b/src/agent/tools/moderation.py
@@ -166,11 +166,12 @@ def register(db, client_pool, embedding_service, **kwargs):
         if gate:
             return gate
         try:
-            approved = []
-            for rid in ids:
-                await db.repos.generation_runs.set_moderation_status(rid, "approved")
-                approved.append(rid)
-            return _text_response(f"Одобрено {len(approved)} run(s): {approved}")
+            # Atomic batch (#1041): one transaction for all ids — either every
+            # run flips to "approved" or none does. The previous per-id loop
+            # autocommitted each update, so a mid-batch failure left earlier
+            # ids approved with no rollback yet still reported full success.
+            await db.repos.generation_runs.set_moderation_status_bulk(ids, "approved")
+            return _text_response(f"Одобрено {len(ids)} run(s): {ids}")
         except Exception as e:
             return _text_response(f"Ошибка массового одобрения: {e}")
 
@@ -198,11 +199,10 @@ def register(db, client_pool, embedding_service, **kwargs):
         if gate:
             return gate
         try:
-            rejected = []
-            for rid in ids:
-                await db.repos.generation_runs.set_moderation_status(rid, "rejected")
-                rejected.append(rid)
-            return _text_response(f"Отклонено {len(rejected)} run(s): {rejected}")
+            # Atomic batch (#1041): all ids reject together or none does. See
+            # bulk_approve_runs for the rationale on the prior per-id loop.
+            await db.repos.generation_runs.set_moderation_status_bulk(ids, "rejected")
+            return _text_response(f"Отклонено {len(ids)} run(s): {ids}")
         except Exception as e:
             return _text_response(f"Ошибка массового отклонения: {e}")
 

--- a/src/cli/commands/pipeline.py
+++ b/src/cli/commands/pipeline.py
@@ -681,26 +681,34 @@ def run(args: argparse.Namespace) -> None:
                 print(f"Rejected run id={args.run_id}")
 
             elif args.pipeline_action == "bulk-approve":
-                approved = 0
+                # Atomic batch (#1041): resolve which ids exist (preserving the
+                # skip-missing behaviour), then flip them all in one transaction
+                # so a mid-batch failure rolls back instead of half-applying.
+                existing_approve_ids: list[int] = []
                 for run_id in args.run_ids:
                     run = await db.repos.generation_runs.get(run_id)
                     if run is None:
                         print(f"  Run id={run_id} not found, skipping.")
                         continue
-                    await db.repos.generation_runs.set_moderation_status(run_id, "approved")
-                    approved += 1
-                print(f"Bulk approved: {approved}/{len(args.run_ids)}")
+                    existing_approve_ids.append(run_id)
+                await db.repos.generation_runs.set_moderation_status_bulk(
+                    existing_approve_ids, "approved"
+                )
+                print(f"Bulk approved: {len(existing_approve_ids)}/{len(args.run_ids)}")
 
             elif args.pipeline_action == "bulk-reject":
-                rejected = 0
+                # Atomic batch (#1041): see bulk-approve above for the rationale.
+                existing_reject_ids: list[int] = []
                 for run_id in args.run_ids:
                     run = await db.repos.generation_runs.get(run_id)
                     if run is None:
                         print(f"  Run id={run_id} not found, skipping.")
                         continue
-                    await db.repos.generation_runs.set_moderation_status(run_id, "rejected")
-                    rejected += 1
-                print(f"Bulk rejected: {rejected}/{len(args.run_ids)}")
+                    existing_reject_ids.append(run_id)
+                await db.repos.generation_runs.set_moderation_status_bulk(
+                    existing_reject_ids, "rejected"
+                )
+                print(f"Bulk rejected: {len(existing_reject_ids)}/{len(args.run_ids)}")
 
             elif args.pipeline_action == "publish":
                 run = await db.repos.generation_runs.get(args.run_id)

--- a/src/database/repositories/generation_runs.py
+++ b/src/database/repositories/generation_runs.py
@@ -85,6 +85,25 @@ class GenerationRunsRepository:
             (status, run_id),
         )
 
+    async def set_moderation_status_bulk(self, run_ids: list[int], status: str) -> None:
+        """Atomically set ``moderation_status`` for many runs (issue #1041).
+
+        Bulk approve/reject previously looped one autocommit
+        :meth:`set_moderation_status` per id, so a failure on id N left ids
+        1..N-1 committed with no rollback — a half-applied batch that the tool
+        still reported as a full success. Wrapping every id in a single
+        ``BEGIN IMMEDIATE`` transaction makes the batch all-or-nothing: a
+        mid-batch error rolls the whole update back and propagates so the
+        caller can surface the failure instead of a partial-success message.
+        """
+        if not run_ids:
+            return
+        async with self._database.transaction() as conn:
+            await conn.executemany(
+                "UPDATE generation_runs SET moderation_status = ?, updated_at = datetime('now') WHERE id = ?",
+                [(status, run_id) for run_id in run_ids],
+            )
+
     async def set_image_url(self, run_id: int, image_url: str) -> None:
         await self._database.execute_write(
             "UPDATE generation_runs SET image_url = ?, updated_at = datetime('now') WHERE id = ?",

--- a/src/services/notification_service.py
+++ b/src/services/notification_service.py
@@ -107,5 +107,21 @@ class NotificationService:
 
             await botfather.delete_bot(client, bot.bot_username)
 
-        await self._notifications.delete_bot(tg_user_id)
+        # BotFather already destroyed the live bot. If the DB row delete now
+        # fails the row becomes an orphan: get_status() keeps reporting the bot
+        # as configured while it no longer exists in Telegram (issue #1041).
+        # Surface that loudly so the operator can clean the stale row instead of
+        # letting it fail silently.
+        try:
+            await self._notifications.delete_bot(tg_user_id)
+        except Exception:
+            logger.error(
+                "Orphan notification bot record: @%s (user %s) was deleted in "
+                "Telegram via BotFather but its DB row could not be removed; "
+                "the row is now stale and must be cleaned up manually",
+                bot.bot_username,
+                tg_user_id,
+                exc_info=True,
+            )
+            raise
         logger.info("Notification bot deleted for user %s", tg_user_id)

--- a/src/telegram/botfather.py
+++ b/src/telegram/botfather.py
@@ -11,6 +11,19 @@ logger = logging.getLogger(__name__)
 BOTFATHER = "BotFather"
 _TOKEN_RE = re.compile(r"(\d{8,}:[A-Za-z0-9_\-]{35,})")
 
+# Redaction is intentionally BROADER than _TOKEN_RE: the orphan branch fires
+# precisely when BotFather's reply drifted from the expected token format, so a
+# valid token may still be present in the text yet not match the strict regex.
+# We scrub any "<8+ digits><sep><20+ token-ish chars>" run — colon OR space/
+# dash/equals separators — before that text is logged or raised, so a format
+# change can never leak the bot credential into logs (#1041 review follow-up).
+_TOKEN_REDACT_RE = re.compile(r"\d{8,}[\s:=\-][A-Za-z0-9_\-]{20,}")
+
+
+def _redact_tokens(text: str) -> str:
+    """Replace any bot-token-like substring with a placeholder for safe logging."""
+    return _TOKEN_REDACT_RE.sub("<redacted-token>", text)
+
 
 async def create_bot(client: TelegramClient, name: str, username: str) -> str:
     """Create a bot via BotFather. Returns the bot token."""
@@ -39,16 +52,17 @@ async def create_bot(client: TelegramClient, name: str, username: str) -> str:
             # reply format) means we have a live orphan bot we can't record or
             # use — flag it loudly with the username so it can be deleted by
             # hand (issue #1041).
+            safe_response = _redact_tokens(resp.text)
             logger.error(
                 "Orphan bot @%s: BotFather created it but the token could not be "
                 "parsed from the response; delete it manually. Response: %s",
                 username,
-                resp.text,
+                safe_response,
             )
             raise RuntimeError(
                 f"Could not extract token from BotFather response — orphan bot "
                 f"@{username} was created in Telegram but has no token and must "
-                f"be deleted manually. Response: {resp.text}"
+                f"be deleted manually. Response: {safe_response}"
             )
 
         logger.info("Bot @%s created successfully", username)

--- a/src/telegram/botfather.py
+++ b/src/telegram/botfather.py
@@ -34,7 +34,22 @@ async def create_bot(client: TelegramClient, name: str, username: str) -> str:
 
         token_match = _TOKEN_RE.search(resp.text)
         if not token_match:
-            raise RuntimeError(f"Could not extract token from BotFather response: {resp.text}")
+            # The username step already succeeded, so BotFather has CREATED the
+            # bot in Telegram. A regex miss here (e.g. BotFather changed its
+            # reply format) means we have a live orphan bot we can't record or
+            # use — flag it loudly with the username so it can be deleted by
+            # hand (issue #1041).
+            logger.error(
+                "Orphan bot @%s: BotFather created it but the token could not be "
+                "parsed from the response; delete it manually. Response: %s",
+                username,
+                resp.text,
+            )
+            raise RuntimeError(
+                f"Could not extract token from BotFather response — orphan bot "
+                f"@{username} was created in Telegram but has no token and must "
+                f"be deleted manually. Response: {resp.text}"
+            )
 
         logger.info("Bot @%s created successfully", username)
         return token_match.group(1)

--- a/src/web/routes/moderation.py
+++ b/src/web/routes/moderation.py
@@ -130,20 +130,25 @@ async def publish_run(request: Request, run_id: int):
 @router.post("/bulk-approve")
 async def bulk_approve(request: Request, run_ids: list[int] = Form(default=[])):
     db = deps.get_db(request)
-    for run_id in run_ids:
-        run = await db.repos.generation_runs.get(run_id)
-        if run is not None:
-            await db.repos.generation_runs.set_moderation_status(run_id, "approved")
-
+    await _bulk_set_moderation(db, run_ids, "approved")
     return _moderation_redirect("runs_approved")
 
 
 @router.post("/bulk-reject")
 async def bulk_reject(request: Request, run_ids: list[int] = Form(default=[])):
     db = deps.get_db(request)
-    for run_id in run_ids:
-        run = await db.repos.generation_runs.get(run_id)
-        if run is not None:
-            await db.repos.generation_runs.set_moderation_status(run_id, "rejected")
-
+    await _bulk_set_moderation(db, run_ids, "rejected")
     return _moderation_redirect("runs_rejected")
+
+
+async def _bulk_set_moderation(db, run_ids: list[int], status: str) -> None:
+    """Atomically flip moderation status for existing runs (issue #1041).
+
+    The previous per-id loop autocommitted each update, so a failure partway
+    through left the batch half-applied with no rollback. We resolve which ids
+    actually exist (preserving the old skip-missing behaviour), then route the
+    survivors through a single transaction so the batch is all-or-nothing.
+    """
+    existing = [rid for rid in run_ids if await db.repos.generation_runs.get(rid) is not None]
+    if existing:
+        await db.repos.generation_runs.set_moderation_status_bulk(existing, status)

--- a/tests/routes/test_moderation_routes.py
+++ b/tests/routes/test_moderation_routes.py
@@ -234,6 +234,46 @@ async def test_bulk_reject(client):
 
 
 @pytest.mark.anyio
+async def test_bulk_approve_is_atomic_on_midbatch_failure(client):
+    """RED→GREEN (#1041): web bulk-approve must be all-or-nothing.
+
+    Like the agent tool, the route used to loop one autocommit
+    set_moderation_status per id. A crash partway through left earlier runs
+    approved with no rollback. The route now routes survivors through the
+    atomic set_moderation_status_bulk; if that raises mid-batch, NO run flips.
+    """
+    db = client._transport_app.state.db
+    _, run_id_1 = await _create_pipeline_and_run(db)
+    _, run_id_2 = await _create_pipeline_and_run(db)
+
+    # Make the underlying executemany apply the first row, then explode.
+    conn = db.db
+    real_executemany = conn.executemany
+
+    async def exploding_executemany(sql, seq):
+        seq = list(seq)
+        await real_executemany(sql, seq[:1])
+        raise RuntimeError("simulated mid-batch crash")
+
+    conn.executemany = exploding_executemany
+    try:
+        with pytest.raises(RuntimeError, match="mid-batch"):
+            await client.post(
+                "/moderation/bulk-approve",
+                data={"run_ids": [str(run_id_1), str(run_id_2)]},
+                follow_redirects=False,
+            )
+    finally:
+        conn.executemany = real_executemany
+
+    # Neither run may have been left approved.
+    run_1 = await db.repos.generation_runs.get(run_id_1)
+    run_2 = await db.repos.generation_runs.get(run_id_2)
+    assert run_1.moderation_status == "pending"
+    assert run_2.moderation_status == "pending"
+
+
+@pytest.mark.anyio
 async def test_bulk_approve_empty(client):
     """Test bulk approve with no IDs doesn't crash."""
     resp = await client.post("/moderation/bulk-approve", follow_redirects=False)

--- a/tests/test_agent_threads_moderation_runtime_paths.py
+++ b/tests/test_agent_threads_moderation_runtime_paths.py
@@ -316,18 +316,22 @@ class TestBulkApproveRuns:
 
     @pytest.mark.anyio
     async def test_approves_multiple(self, mock_db):
+        # Atomic batch (#1041): one bulk call carries every id, not a per-id loop.
         mock_db.repos = MagicMock()
-        mock_db.repos.generation_runs.set_moderation_status = AsyncMock()
+        bulk = AsyncMock()
+        mock_db.repos.generation_runs.set_moderation_status_bulk = bulk
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["bulk_approve_runs"]({"run_ids": "1,2,3", "confirm": True})
         text = _text(result)
         assert "Одобрено 3 run(s)" in text
-        assert mock_db.repos.generation_runs.set_moderation_status.await_count == 3
+        bulk.assert_awaited_once_with([1, 2, 3], "approved")
 
     @pytest.mark.anyio
     async def test_exception(self, mock_db):
         mock_db.repos = MagicMock()
-        mock_db.repos.generation_runs.set_moderation_status = AsyncMock(side_effect=Exception("fail"))
+        mock_db.repos.generation_runs.set_moderation_status_bulk = AsyncMock(
+            side_effect=Exception("fail")
+        )
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["bulk_approve_runs"]({"run_ids": "1", "confirm": True})
         assert "Ошибка массового одобрения" in _text(result)
@@ -336,12 +340,15 @@ class TestBulkApproveRuns:
 class TestBulkRejectRuns:
     @pytest.mark.anyio
     async def test_rejects_multiple(self, mock_db):
+        # Atomic batch (#1041): one bulk call carries every id, not a per-id loop.
         mock_db.repos = MagicMock()
-        mock_db.repos.generation_runs.set_moderation_status = AsyncMock()
+        bulk = AsyncMock()
+        mock_db.repos.generation_runs.set_moderation_status_bulk = bulk
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["bulk_reject_runs"]({"run_ids": "4,5", "confirm": True})
         text = _text(result)
         assert "Отклонено 2 run(s)" in text
+        bulk.assert_awaited_once_with([4, 5], "rejected")
 
     @pytest.mark.anyio
     async def test_invalid_ids(self, mock_db):

--- a/tests/test_agent_tools_moderation.py
+++ b/tests/test_agent_tools_moderation.py
@@ -140,7 +140,7 @@ class TestBulkApproveRunsTool:
 
     @pytest.mark.anyio
     async def test_bulk_approve_success(self, mock_db):
-        mock_db.repos.generation_runs.set_moderation_status = AsyncMock()
+        mock_db.repos.generation_runs.set_moderation_status_bulk = AsyncMock()
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["bulk_approve_runs"]({"run_ids": "1,2,3", "confirm": True})
         assert "Одобрено 3 run(s)" in _text(result)
@@ -149,7 +149,84 @@ class TestBulkApproveRunsTool:
 class TestBulkRejectRunsTool:
     @pytest.mark.anyio
     async def test_bulk_reject_success(self, mock_db):
-        mock_db.repos.generation_runs.set_moderation_status = AsyncMock()
+        mock_db.repos.generation_runs.set_moderation_status_bulk = AsyncMock()
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["bulk_reject_runs"]({"run_ids": "5,6", "confirm": True})
         assert "Отклонено 2 run(s)" in _text(result)
+
+
+# ---------------------------------------------------------------------------
+# Batch atomicity (issue #1041) — partial failures must not silently leave the
+# batch half-applied. The bulk tools must delegate to a single atomic
+# repository call (set_moderation_status_bulk) so all run_ids commit together
+# or none do, and a mid-batch failure surfaces an error instead of a partial
+# "Одобрено N" success message.
+# ---------------------------------------------------------------------------
+
+
+class TestBulkApproveAtomicity:
+    @pytest.mark.anyio
+    async def test_delegates_to_single_atomic_bulk_call(self, mock_db):
+        """RED→GREEN (#1041): one atomic bulk write, not a per-id loop.
+
+        The pre-fix loop issued one autocommit ``set_moderation_status`` per id,
+        so a failure on id N left ids 1..N-1 committed with no rollback. The fix
+        routes through ``set_moderation_status_bulk`` which wraps every id in a
+        single transaction.
+        """
+        bulk = AsyncMock()
+        mock_db.repos.generation_runs.set_moderation_status_bulk = bulk
+
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["bulk_approve_runs"](
+            {"run_ids": "1,2,3", "confirm": True}
+        )
+
+        assert "Одобрено 3 run(s)" in _text(result)
+        bulk.assert_awaited_once_with([1, 2, 3], "approved")
+
+    @pytest.mark.anyio
+    async def test_failure_reports_error_not_partial_success(self, mock_db):
+        """A failing atomic bulk write must NOT claim the batch was approved."""
+        mock_db.repos.generation_runs.set_moderation_status_bulk = AsyncMock(
+            side_effect=RuntimeError("db locked")
+        )
+
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["bulk_approve_runs"](
+            {"run_ids": "1,2,3", "confirm": True}
+        )
+
+        text = _text(result)
+        assert "Одобрено 3" not in text  # never claim success on failure
+        assert "Ошибка" in text
+
+
+class TestBulkRejectAtomicity:
+    @pytest.mark.anyio
+    async def test_delegates_to_single_atomic_bulk_call(self, mock_db):
+        bulk = AsyncMock()
+        mock_db.repos.generation_runs.set_moderation_status_bulk = bulk
+
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["bulk_reject_runs"](
+            {"run_ids": "5,6", "confirm": True}
+        )
+
+        assert "Отклонено 2 run(s)" in _text(result)
+        bulk.assert_awaited_once_with([5, 6], "rejected")
+
+    @pytest.mark.anyio
+    async def test_failure_reports_error_not_partial_success(self, mock_db):
+        mock_db.repos.generation_runs.set_moderation_status_bulk = AsyncMock(
+            side_effect=RuntimeError("db locked")
+        )
+
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["bulk_reject_runs"](
+            {"run_ids": "1,2,3", "confirm": True}
+        )
+
+        text = _text(result)
+        assert "Отклонено 3" not in text
+        assert "Ошибка" in text

--- a/tests/test_cli_pipeline_commands.py
+++ b/tests/test_cli_pipeline_commands.py
@@ -320,12 +320,62 @@ class TestPipelineReject:
 # ---------------------------------------------------------------------------
 
 
+def _create_pending_run(cli_env) -> int:
+    """Create a generation run in the CLI DB and return its id."""
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(cli_env.repos.generation_runs.create_run(1, "tmpl"))
+    finally:
+        loop.close()
+
+
 class TestPipelineBulkApprove:
     def test_not_found_run(self, cli_env, capsys):
 
         run(_ns(pipeline_action="bulk-approve", run_ids=[998, 999]))
         out = capsys.readouterr().out
         assert "Bulk approved: 0/2" in out
+
+    def test_approves_existing_runs(self, cli_env, capsys):
+        rid1 = _create_pending_run(cli_env)
+        rid2 = _create_pending_run(cli_env)
+
+        run(_ns(pipeline_action="bulk-approve", run_ids=[rid1, rid2]))
+        assert "Bulk approved: 2/2" in capsys.readouterr().out
+
+        db_path = cli_env._db_path
+        assert _read_run_moderation(db_path, rid1) == "approved"
+        assert _read_run_moderation(db_path, rid2) == "approved"
+
+    def test_atomic_on_midbatch_failure(self, cli_env, capsys):
+        """RED→GREEN (#1041): a mid-batch failure leaves NO run approved.
+
+        The pre-fix CLI loop autocommitted one set_moderation_status per id, so
+        a crash partway through left earlier ids approved with no rollback. The
+        atomic path wraps the survivors in one transaction — proven here by
+        making the underlying executemany apply the first row then explode.
+        """
+        rid1 = _create_pending_run(cli_env)
+        rid2 = _create_pending_run(cli_env)
+
+        conn = cli_env.db
+        real_executemany = conn.executemany
+
+        async def exploding_executemany(sql, seq):
+            seq = list(seq)
+            await real_executemany(sql, seq[:1])
+            raise RuntimeError("simulated mid-batch crash")
+
+        conn.executemany = exploding_executemany
+        try:
+            with pytest.raises(RuntimeError, match="mid-batch"):
+                run(_ns(pipeline_action="bulk-approve", run_ids=[rid1, rid2]))
+        finally:
+            conn.executemany = real_executemany
+
+        db_path = cli_env._db_path
+        assert _read_run_moderation(db_path, rid1) == "pending"
+        assert _read_run_moderation(db_path, rid2) == "pending"
 
 
 class TestPipelineBulkReject:
@@ -334,6 +384,17 @@ class TestPipelineBulkReject:
         run(_ns(pipeline_action="bulk-reject", run_ids=[998, 999]))
         out = capsys.readouterr().out
         assert "Bulk rejected: 0/2" in out
+
+    def test_rejects_existing_runs(self, cli_env, capsys):
+        rid1 = _create_pending_run(cli_env)
+        rid2 = _create_pending_run(cli_env)
+
+        run(_ns(pipeline_action="bulk-reject", run_ids=[rid1, rid2]))
+        assert "Bulk rejected: 2/2" in capsys.readouterr().out
+
+        db_path = cli_env._db_path
+        assert _read_run_moderation(db_path, rid1) == "rejected"
+        assert _read_run_moderation(db_path, rid2) == "rejected"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_deepagents_sync_provider_paths.py
+++ b/tests/test_deepagents_sync_provider_paths.py
@@ -354,7 +354,8 @@ class TestDeepagentsSyncRejectRun:
 
 class TestDeepagentsSyncBulkApproveRuns:
     def test_success(self, mock_db):
-        mock_db.repos.generation_runs.set_moderation_status = AsyncMock(return_value=None)
+        # Atomic batch (#1041): one bulk call, not a per-id loop.
+        mock_db.repos.generation_runs.set_moderation_status_bulk = AsyncMock(return_value=None)
         tool_map = _build_sync_tools(mock_db)
         result = tool_map["bulk_approve_runs"]("1,2,3", confirm=True)
         assert "Одобрено 3" in result
@@ -365,7 +366,7 @@ class TestDeepagentsSyncBulkApproveRuns:
         assert "Ошибка" in result
 
     def test_empty_string(self, mock_db):
-        mock_db.repos.generation_runs.set_moderation_status = AsyncMock(return_value=None)
+        mock_db.repos.generation_runs.set_moderation_status_bulk = AsyncMock(return_value=None)
         tool_map = _build_sync_tools(mock_db)
         result = tool_map["bulk_approve_runs"]("")
         assert "run_ids пуст" in result
@@ -373,7 +374,8 @@ class TestDeepagentsSyncBulkApproveRuns:
 
 class TestDeepagentsSyncBulkRejectRuns:
     def test_success(self, mock_db):
-        mock_db.repos.generation_runs.set_moderation_status = AsyncMock(return_value=None)
+        # Atomic batch (#1041): one bulk call, not a per-id loop.
+        mock_db.repos.generation_runs.set_moderation_status_bulk = AsyncMock(return_value=None)
         tool_map = _build_sync_tools(mock_db)
         result = tool_map["bulk_reject_runs"]("10,20", confirm=True)
         assert "Отклонено 2" in result

--- a/tests/test_generation_runs_repo.py
+++ b/tests/test_generation_runs_repo.py
@@ -1,4 +1,74 @@
+from contextlib import contextmanager
+
 import pytest
+
+
+@contextmanager
+def _patched(obj, attr, value):
+    """Temporarily swap an attribute, restoring it on exit."""
+    original = getattr(obj, attr)
+    setattr(obj, attr, value)
+    try:
+        yield
+    finally:
+        setattr(obj, attr, original)
+
+
+@pytest.mark.anyio
+async def test_set_moderation_status_bulk_applies_all(db):
+    """set_moderation_status_bulk flips every id in one call (issue #1041)."""
+    repo = db.repos.generation_runs
+    ids = [await repo.create_run(7, f"p-{i}") for i in range(3)]
+
+    await repo.set_moderation_status_bulk(ids, "approved")
+
+    for run_id in ids:
+        run = await repo.get(run_id)
+        assert run is not None
+        assert run.moderation_status == "approved"
+
+
+@pytest.mark.anyio
+async def test_set_moderation_status_bulk_empty_is_noop(db):
+    """An empty id list must not open a transaction or raise (issue #1041)."""
+    repo = db.repos.generation_runs
+    await repo.set_moderation_status_bulk([], "approved")
+
+
+@pytest.mark.anyio
+async def test_set_moderation_status_bulk_rolls_back_on_midbatch_failure(db):
+    """RED→GREEN (#1041): a mid-batch failure leaves NO id half-applied.
+
+    The pre-fix bulk tool looped one autocommit ``set_moderation_status`` per
+    id, so a crash after committing ids 1..N-1 left those approved with no way
+    back. The atomic version wraps the whole batch in one ``BEGIN IMMEDIATE``;
+    we prove the rollback is real by letting the underlying ``executemany``
+    apply the first row and then raise — the committed DB must still show every
+    run as ``pending``.
+    """
+    repo = db.repos.generation_runs
+    ids = [await repo.create_run(7, f"p-{i}") for i in range(3)]
+
+    conn = db.db
+    assert conn is not None
+    real_executemany = conn.executemany
+
+    async def exploding_executemany(sql, seq):
+        seq = list(seq)
+        # Apply the first row for real, then blow up mid-batch — exactly the
+        # window where the old per-id loop would have left a partial commit.
+        await real_executemany(sql, seq[:1])
+        raise RuntimeError("simulated mid-batch crash")
+
+    with pytest.raises(RuntimeError, match="mid-batch"):
+        with _patched(conn, "executemany", exploding_executemany):
+            await repo.set_moderation_status_bulk(ids, "approved")
+
+    # The transaction must have rolled the first (real) write back.
+    for run_id in ids:
+        run = await repo.get(run_id)
+        assert run is not None
+        assert run.moderation_status == "pending"
 
 
 @pytest.mark.anyio

--- a/tests/test_messaging_deepagents_provider_paths.py
+++ b/tests/test_messaging_deepagents_provider_paths.py
@@ -611,13 +611,15 @@ class TestDeepagentsSyncModeration:
         assert "отклонён" in result.lower()
 
     def test_bulk_approve_runs(self, mock_db):
-        mock_db.repos.generation_runs.set_moderation_status = AsyncMock()
+        # Atomic batch (#1041): one bulk call, not a per-id loop.
+        mock_db.repos.generation_runs.set_moderation_status_bulk = AsyncMock()
         tool_map = _build_sync_tools(mock_db)
         result = tool_map["bulk_approve_runs"]("1,2,3", confirm=True)
         assert "Одобрено 3" in result
 
     def test_bulk_reject_runs(self, mock_db):
-        mock_db.repos.generation_runs.set_moderation_status = AsyncMock()
+        # Atomic batch (#1041): one bulk call, not a per-id loop.
+        mock_db.repos.generation_runs.set_moderation_status_bulk = AsyncMock()
         tool_map = _build_sync_tools(mock_db)
         result = tool_map["bulk_reject_runs"]("10,20", confirm=True)
         assert "Отклонено 2" in result

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -161,6 +161,81 @@ async def test_create_bot_no_token_in_response():
         await botfather.create_bot(mock_client, "MyBot", "mybot_bot")
 
 
+# ---------------------------------------------------------------------------
+# Brittle BotFather parsing (issue #1041) — failure modes around create_bot's
+# token regex, _click_inline button matching, and _is_error coverage. The token
+# regex in particular is a blind spot: by the time it runs, BotFather has
+# ALREADY created the bot, so a regex miss orphans a live bot in Telegram.
+# ---------------------------------------------------------------------------
+
+
+async def test_create_bot_token_miss_warns_about_orphan(caplog):
+    """RED→GREEN (#1041): a token-regex miss leaves a live orphan bot.
+
+    By the time ``create_bot`` reaches the final response, the username has been
+    accepted and BotFather has created the bot. If ``_TOKEN_RE`` fails to match
+    (BotFather changed its reply format), the bot exists in Telegram but we have
+    no token and no record — an orphan. The raised error must name the bot
+    username and the word "orphan" so the operator can find and delete it.
+    """
+    import logging
+
+    mock_conv = _make_conv(
+        MagicMock(text="Alright, send me the name."),
+        MagicMock(text="Good. Now choose a username."),
+        MagicMock(text="Your bot is ready! (but the token format changed)"),
+    )
+    mock_client = MagicMock()
+    mock_client.conversation.return_value = mock_conv
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(RuntimeError) as exc_info:
+            await botfather.create_bot(mock_client, "MyBot", "mybot_orphan_bot")
+
+    message = str(exc_info.value).lower()
+    logged = " ".join(r.getMessage() for r in caplog.records).lower()
+    combined = message + " " + logged
+    assert "orphan" in combined
+    assert "mybot_orphan_bot" in combined
+
+
+def test_is_error_does_not_false_positive_on_token_reply():
+    """A successful token reply must not be misread as an error (#1041).
+
+    ``_is_error`` runs on the name/username step replies. The substring list
+    must not flag a legitimate BotFather success message — otherwise create_bot
+    raises AFTER the bot is created, orphaning it. Guard the known-good replies.
+    """
+    assert botfather._is_error("Good. Now let's choose a username for your bot.") is False
+    assert botfather._is_error("Alright! A new bot. How are we going to call it?") is False
+    assert (
+        botfather._is_error(
+            "Done! Congratulations on your new bot. Use this token to access the HTTP API:"
+        )
+        is False
+    )
+
+
+def test_is_error_matches_too_many_requests():
+    """Rate-limit replies are errors too — currently uncovered (#1041)."""
+    # BotFather rate-limit / generic failure wordings beyond the original set.
+    assert botfather._is_error("Sorry, too many attempts. Please try again later.") is True
+
+
+async def test_click_inline_localized_label_raises_clearly():
+    """_click_inline matches by English substring; a localized keyboard misses.
+
+    This documents the brittleness called out in #1041: if BotFather renders
+    the keyboard in another language, the substring match fails and we get a
+    clear 'not found' error rather than a silent wrong-button click.
+    """
+    # Russian "Удалить бота" instead of "Delete Bot".
+    msg = _make_message([["Удалить бота", "Отмена"]])
+    with pytest.raises(RuntimeError, match="not found"):
+        await botfather._click_inline(msg, "Delete Bot")
+    msg.click.assert_not_awaited()
+
+
 async def test_delete_bot_success():
     bot_msg = _make_message([["@mybot_bot"]])
     options_msg = _make_message([["Bot Info", "Delete Bot"]])
@@ -388,6 +463,66 @@ async def test_teardown_bot_success(db, real_pool_harness_factory):
         await svc.teardown_bot()
 
     assert await db.get_notification_bot(777) is None
+
+
+@pytest.mark.anyio
+async def test_teardown_bot_db_delete_failure_warns_about_orphan(
+    db, real_pool_harness_factory, caplog
+):
+    """RED→GREEN (#1041): a DB-delete failure AFTER BotFather succeeds must not
+    fail silently — it leaves an orphan DB row pointing at a bot that no longer
+    exists in Telegram.
+
+    ``teardown_bot`` deletes the live bot via BotFather first, then removes the
+    DB row. If the DB delete raises after BotFather already destroyed the bot,
+    the row survives: ``get_status`` will keep reporting the bot as configured
+    while ``send_notification`` silently can't reach it. The service must log a
+    loud orphan warning (so the operator can clean the row) and surface the
+    failure rather than swallow it.
+    """
+    saved = NotificationBot(
+        tg_user_id=999,
+        tg_username="frank",
+        bot_id=333,
+        bot_username="leadhunter_frank_bot",
+        bot_token="999999999:AABBCCDDEEFFaabbccddeeffAABBCCDDEEFF",
+    )
+    await db.save_notification_bot(saved)
+
+    harness = real_pool_harness_factory()
+    await _connect_notification_account(
+        harness,
+        phone="+70001111111",
+        session_string="session-1",
+        me_id=999,
+        me_username="frank",
+        is_primary=True,
+    )
+    svc = NotificationService(db, NotificationTargetService(db, harness.pool))
+
+    # BotFather succeeds (bot is gone from Telegram) but the DB delete blows up.
+    with (
+        patch(
+            "src.services.notification_service.botfather.delete_bot",
+            new_callable=AsyncMock,
+        ),
+        patch.object(
+            svc._notifications.notification_bots,
+            "delete_bot",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("db locked"),
+        ),
+    ):
+        import logging
+
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(RuntimeError):
+                await svc.teardown_bot()
+
+    # The operator must be told the live bot is gone but the row remains.
+    combined = " ".join(r.getMessage() for r in caplog.records).lower()
+    assert "orphan" in combined
+    assert "leadhunter_frank_bot" in combined or "999" in combined
 
 
 @pytest.mark.anyio

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -199,6 +199,55 @@ async def test_create_bot_token_miss_warns_about_orphan(caplog):
     assert "mybot_orphan_bot" in combined
 
 
+async def test_create_bot_token_miss_redacts_token_from_logs_and_error(caplog):
+    """RED→GREEN (#1041 review): orphan branch must not LEAK a token.
+
+    The orphan branch fires exactly when the token regex drifts — which means a
+    valid token may still be present in the reply (e.g. BotFather changed the
+    delimiter). Logging/raising the raw response would then write the bot
+    credential to logs. The response must be redacted before it is logged or
+    embedded in the raised error.
+    """
+    import logging
+
+    # A real-shaped token but with a SPACE delimiter, so _TOKEN_RE (which wants
+    # a colon) misses it — the exact format-drift the orphan branch handles.
+    leaked = "123456789 ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi"
+    mock_conv = _make_conv(
+        MagicMock(text="Alright, send me the name."),
+        MagicMock(text="Good. Now choose a username."),
+        MagicMock(text=f"Here is your bot! Token: {leaked}"),
+    )
+    mock_client = MagicMock()
+    mock_client.conversation.return_value = mock_conv
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(RuntimeError) as exc_info:
+            await botfather.create_bot(mock_client, "MyBot", "mybot_leak_bot")
+
+    logged = " ".join(r.getMessage() for r in caplog.records)
+    message = str(exc_info.value)
+    # The token-like substring must NOT appear in either surface.
+    assert leaked not in logged
+    assert leaked not in message
+    assert "<redacted-token>" in logged
+    assert "<redacted-token>" in message
+
+
+def test_redact_tokens_scrubs_token_variants():
+    """_redact_tokens scrubs colon/space/dash-delimited token-like runs (#1041)."""
+    assert "<redacted-token>" == botfather._redact_tokens(
+        "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi"
+    )
+    assert "<redacted-token>" == botfather._redact_tokens(
+        "123456789 ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi"
+    )
+    # Plain prose without a token run is left untouched.
+    assert botfather._redact_tokens("Sorry, that username is taken.") == (
+        "Sorry, that username is taken."
+    )
+
+
 def test_is_error_does_not_false_positive_on_token_reply():
     """A successful token reply must not be misread as an error (#1041).
 


### PR DESCRIPTION
Подзадача эпика баг-ханта #1024 — **тёмные write-половины** вокруг мутаций BotFather и модерации. Все три бага через TDD: падающий тест (red) → фикс (green) → регресс-гард; **каждый гард проверен мутацией продкода**, чтобы исключить false-confidence.

## 1. Хрупкий парсинг BotFather — `src/telegram/botfather.py`
- **`create_bot` orphan**: при промахе `_TOKEN_RE` (BotFather сменил формат ответа) бот **уже создан** в Telegram, но токена нет → orphan-бот. Раньше летела голая `RuntimeError` без контекста. Теперь логируется orphan-error с username, и текст ошибки прямо называет «orphan @username … must be deleted manually».
- **Регресс-гарды**: `_is_error` не ложно-срабатывает на успешном ответе и ловит rate-limit; `_click_inline` чётко падает `not found` на локализованной (не-английской) клавиатуре.

## 2. Orphan bot record при teardown — `src/services/notification_service.py`
`teardown_bot` сначала `botfather.delete_bot` (живой TG), затем `notifications.delete_bot` (DB). Если DB-delete падает **после** успеха BotFather → бот удалён в TG, но строка-сирота остаётся в БД (`get_status` врёт «настроен», `send_notification` молча не доходит). Теперь падение оборачивается loud orphan-error и пробрасывается, а не теряется молча.

## 3. Атомарность batch-модерации — 4 поверхности
Тот же баг скопирован в agent-tool, web route, CLI и sync-обёртку deepagents: `for rid: await set_moderation_status(rid)` — N автокоммитов; mid-batch сбой оставлял батч наполовину применённым, но всё равно рапортовал «Одобрено N».
- Новый `GenerationRunsRepository.set_moderation_status_bulk(ids, status)` — один `BEGIN IMMEDIATE` на весь батч (all-or-nothing).
- `bulk_approve_runs`/`bulk_reject_runs` (agent-tool), web `bulk-approve`/`bulk-reject`, CLI `pipeline bulk-approve`/`bulk-reject` переведены на атомарный вызов (web/CLI сохраняют skip-missing семантику).
- **Rollback доказан интеграционно** (не только моками): `executemany` применяет первую строку и падает — БД остаётся в `pending` (репозиторий, web, CLI).

## Проверка
- `8554 passed, 138 skipped, 0 failed` (полный parallel-safe набор)
- ruff чисто; mypy — без новых ошибок vs baseline
- Каждый регресс-гард верифицирован мутацией: ломаю продкод (per-id loop / убираю "sorry" / match-any-кнопку) → гард краснеет → revert

Live-прогоны: BotFather/модерация-мутации **не** конвертированы в generic live pytest — все тесты fake-only.

Closes #1041

🤖 Generated with [Claude Code](https://claude.com/claude-code)