### PR TITLE
fix(content-cycle): align AUTO moderation_status, skip pending (#1036)

### DIFF
--- a/src/database/repositories/generation_runs.py
+++ b/src/database/repositories/generation_runs.py
@@ -80,6 +80,24 @@ class GenerationRunsRepository:
         )
 
     async def set_moderation_status(self, run_id: int, status: str) -> None:
+        """Set the run's moderation lifecycle state (issue #1036).
+
+        Valid values and what they mean for the content cycle:
+
+        - ``pending``   — awaiting a human moderation decision. Only reachable
+          for MODERATED pipelines; it is the create_run / DB default. AUTO
+          content never rests here (it has no human review).
+        - ``approved``  — cleared for publishing. Set by a human approve action
+          (MODERATED) or automatically the moment an AUTO run finishes
+          generating (so AUTO skips ``pending`` entirely).
+        - ``rejected``  — a human declined the draft; it will not be published.
+        - ``published`` — delivered to every target. Set atomically together with
+          ``published_at`` by :meth:`set_published_at`; never set here directly.
+
+        Invariant: a run is never simultaneously ``pending`` and carrying a
+        ``published_at``. ``list_pending_moderation`` surfaces ``pending`` +
+        ``approved`` (drafts and approved-but-not-yet-delivered runs).
+        """
         await self._database.execute_write(
             "UPDATE generation_runs SET moderation_status = ?, updated_at = datetime('now') WHERE id = ?",
             (status, run_id),

--- a/src/services/content_generation_service.py
+++ b/src/services/content_generation_service.py
@@ -151,18 +151,6 @@ class ContentGenerationService:
 
             await self._db.repos.generation_runs.save_result(run_id, generated_text, metadata)
 
-            # Single point that aligns moderation_status with the effective
-            # publish mode (issue #1036). AUTO content has no human review, so it
-            # must skip 'pending' the instant generation completes: a 'pending'
-            # AUTO run would surface in the moderation queue and, if the later
-            # publish fails, stay stranded there forever. 'approved' is the
-            # publish-eligible state PublishService expects; a successful delivery
-            # then advances it to 'published'. MODERATED stays 'pending' (the
-            # create_run / DB default) until a human approves it. dry_run never
-            # publishes, so its status is left untouched.
-            if not dry_run and effective_publish_mode == PipelinePublishMode.AUTO.value:
-                await self._db.repos.generation_runs.set_moderation_status(run_id, "approved")
-
             if self._quality_service and generated_text:
                 quality = await self._quality_service.score_content(
                     generated_text,
@@ -173,6 +161,26 @@ class ContentGenerationService:
                     quality.overall,
                     quality.issues,
                 )
+
+            # Single point that aligns moderation_status with the effective
+            # publish mode (issue #1036). AUTO content has no human review, so it
+            # must skip 'pending' the instant generation completes: a 'pending'
+            # AUTO run would surface in the moderation queue and, if the later
+            # publish fails, stay stranded there forever. 'approved' is the
+            # publish-eligible state PublishService expects; a successful delivery
+            # then advances it to 'published'. MODERATED stays 'pending' (the
+            # create_run / DB default) until a human approves it. dry_run never
+            # publishes, so its status is left untouched.
+            #
+            # This runs only AFTER every fallible post-save step above (quality
+            # scoring / set_quality_score) has succeeded. If any of them raises,
+            # the except below sets status='failed' and the run keeps its
+            # non-publishable 'pending' moderation_status — so the background
+            # CONTENT_PUBLISH handler (which selects moderation_status='approved')
+            # can never deliver a failed generation to Telegram (review: Codex).
+            if not dry_run and effective_publish_mode == PipelinePublishMode.AUTO.value:
+                await self._db.repos.generation_runs.set_moderation_status(run_id, "approved")
+
             run = await self._db.repos.generation_runs.get(run_id)
             if run is None:
                 raise RuntimeError(f"Generation run {run_id} not found after save")

--- a/src/services/content_generation_service.py
+++ b/src/services/content_generation_service.py
@@ -95,7 +95,8 @@ class ContentGenerationService:
         3. Render prompt template with source messages
         4. Call backend (GenerationService RAG or AgentManager)
         5. Handle image generation if image_model is set (skipped for dry_run)
-        6. Save result with moderation_status='pending'
+        6. Save result, then align moderation_status with the effective publish
+           mode: AUTO → 'approved' (skips 'pending'); MODERATED → 'pending' (#1036)
         7. Return the GenerationRun
 
         If dry_run=True: skips image generation and draft notifications; marks
@@ -149,6 +150,19 @@ class ContentGenerationService:
                             await self._db.repos.generation_runs.set_image_url(run_id, image_url)
 
             await self._db.repos.generation_runs.save_result(run_id, generated_text, metadata)
+
+            # Single point that aligns moderation_status with the effective
+            # publish mode (issue #1036). AUTO content has no human review, so it
+            # must skip 'pending' the instant generation completes: a 'pending'
+            # AUTO run would surface in the moderation queue and, if the later
+            # publish fails, stay stranded there forever. 'approved' is the
+            # publish-eligible state PublishService expects; a successful delivery
+            # then advances it to 'published'. MODERATED stays 'pending' (the
+            # create_run / DB default) until a human approves it. dry_run never
+            # publishes, so its status is left untouched.
+            if not dry_run and effective_publish_mode == PipelinePublishMode.AUTO.value:
+                await self._db.repos.generation_runs.set_moderation_status(run_id, "approved")
+
             if self._quality_service and generated_text:
                 quality = await self._quality_service.score_content(
                     generated_text,

--- a/src/services/publish_service.py
+++ b/src/services/publish_service.py
@@ -51,6 +51,23 @@ class PublishService:
             logger.warning("Run %s has no generated_text, skipping publish", run.id)
             return [PublishResult(success=False, error="No generated text")]
 
+        # Single, service-level guard against publishing a run whose generation
+        # did not complete (issue #1036 review, Codex). publish_run is the one
+        # path every publish entrypoint funnels through — CONTENT_GENERATE
+        # auto-publish, the CONTENT_PUBLISH batch, the web/CLI moderation
+        # "publish" button (via the dispatcher), and the agent publish tool. A
+        # run can carry generated_text (saved before a later step failed) yet end
+        # at status='failed'; or a human/agent could approve a failed run. Gating
+        # delivery on status='completed' here blocks every such case at the one
+        # irreversible boundary, not just in CONTENT_PUBLISH's SQL filter.
+        if run.status != "completed":
+            logger.warning(
+                "Run %s is not eligible for publish: status=%s (must be 'completed')",
+                run.id,
+                run.status,
+            )
+            return [PublishResult(success=False, error="Run generation is not completed")]
+
         effective_mode = (
             (run.metadata or {}).get("effective_publish_mode", pipeline.publish_mode.value)
         )

--- a/src/services/task_handlers/content.py
+++ b/src/services/task_handlers/content.py
@@ -165,8 +165,14 @@ class ContentTaskHandler:
 
             filter_sql = "AND pipeline_id = ?" if pipeline_id is not None else ""
             params: tuple = (pipeline_id,) if pipeline_id is not None else ()
+            # Require status='completed' as well as moderation_status='approved'
+            # (defense-in-depth, issue #1036 review). A run is only ever marked
+            # 'approved' after generation fully succeeds, but gating publish on
+            # the execution status too guarantees a failed/running run can never
+            # be delivered to Telegram even if some path left it 'approved'.
             cur = await db.execute(
-                f"SELECT * FROM generation_runs WHERE moderation_status = 'approved' {filter_sql} ORDER BY id ASC",
+                "SELECT * FROM generation_runs WHERE moderation_status = 'approved' "
+                f"AND status = 'completed' {filter_sql} ORDER BY id ASC",
                 params,
             )
             rows = await cur.fetchall()

--- a/tests/test_content_generation_service.py
+++ b/tests/test_content_generation_service.py
@@ -41,6 +41,10 @@ class FakeGenerationRunsRepo:
         if run_id in self._runs:
             self._runs[run_id].status = status
 
+    async def set_moderation_status(self, run_id, status):
+        if run_id in self._runs:
+            self._runs[run_id].moderation_status = status
+
     async def save_result(self, run_id, generated_text, metadata=None):
         if run_id in self._runs:
             self._runs[run_id].generated_text = generated_text

--- a/tests/test_content_generation_service_edge_cases.py
+++ b/tests/test_content_generation_service_edge_cases.py
@@ -864,6 +864,64 @@ async def test_generate_exception_sets_failed():
         _restore_provider(orig)
 
 
+@pytest.mark.anyio
+async def test_auto_not_approved_when_post_save_step_fails():
+    """A fallible post-save step (set_quality_score) that raises after the text
+    is saved must NOT leave an AUTO run publish-eligible (issue #1036 review,
+    Codex finding). Otherwise the background CONTENT_PUBLISH handler — which
+    selects moderation_status='approved' without checking status — could later
+    deliver a failed generation to Telegram. The run must end 'failed' and keep
+    its non-publishable 'pending' moderation_status."""
+    engine = DummySearchEngine([_make_msg()])
+    db = FakeDB()
+
+    # set_quality_score blows up (e.g. a transient DB write error) AFTER
+    # save_result has persisted generated_text.
+    async def boom_quality(run_id, score, issues=None):
+        raise RuntimeError("DB locked writing quality score")
+
+    db.repos.generation_runs.set_quality_score = boom_quality
+
+    class _Quality:
+        async def score_content(self, text, model=None):
+            from src.services.quality_scoring_service import QualityScore
+
+            return QualityScore(
+                relevance=0.9,
+                language_quality=0.9,
+                informativeness=0.9,
+                structure=0.9,
+                overall=0.9,
+                issues=[],
+            )
+
+    service = ContentGenerationService(db, engine, quality_service=_Quality())
+    pipeline = ContentPipeline(
+        id=1,
+        name="Test",
+        prompt_template="prompt",
+        llm_model="m",
+        generation_backend=PipelineGenerationBackend.CHAIN,
+        publish_mode=PipelinePublishMode.AUTO,
+    )
+
+    orig = _patch_provider(_provider())
+    try:
+        with pytest.raises(RuntimeError, match="DB locked"):
+            await service.generate(pipeline)
+    finally:
+        _restore_provider(orig)
+
+    # The run exists, generated_text was saved, but it must be 'failed' and
+    # NOT publish-eligible: moderation_status stays 'pending', never 'approved'.
+    runs = list(db.repos.generation_runs._runs.values())
+    assert len(runs) == 1
+    run = runs[0]
+    assert run.status == "failed"
+    assert run.moderation_status != "approved"
+    assert run.moderation_status == "pending"
+
+
 # ---------------------------------------------------------------------------
 # Tests: _generate_image edge cases
 # ---------------------------------------------------------------------------

--- a/tests/test_content_generation_service_edge_cases.py
+++ b/tests/test_content_generation_service_edge_cases.py
@@ -71,6 +71,10 @@ class FakeGenerationRunsRepo:
         if run_id in self._runs:
             self._runs[run_id].status = status
 
+    async def set_moderation_status(self, run_id, status):
+        if run_id in self._runs:
+            self._runs[run_id].moderation_status = status
+
     async def save_result(self, run_id, generated_text, metadata=None):
         if run_id in self._runs:
             self._runs[run_id].generated_text = generated_text
@@ -987,3 +991,110 @@ async def test_run_generation_selects_deep_agents():
 
     result = await service._run_generation(pipeline, None, 512, 0.7)
     assert result["generated_text"] == "deep output"
+
+
+# ---------------------------------------------------------------------------
+# Tests: moderation_status invariant after generate() (issue #1036)
+#
+# The AUTO/MODERATED split must produce a *consistent* moderation_status the
+# moment generation finishes — before any publish attempt. AUTO content is not
+# subject to human review, so it must skip 'pending' (which would surface it in
+# the moderation queue and, on a publish failure, strand it there forever).
+# MODERATED content must stay 'pending' until a human approves it.
+# ---------------------------------------------------------------------------
+
+
+def _make_auto_moderated_pipeline(publish_mode):
+    return ContentPipeline(
+        id=1,
+        name="Test",
+        prompt_template="prompt",
+        llm_model="m",
+        generation_backend=PipelineGenerationBackend.CHAIN,
+        publish_mode=publish_mode,
+    )
+
+
+@pytest.mark.anyio
+async def test_generate_auto_skips_pending_moderation_status():
+    """AUTO generation must return a run that has skipped 'pending'.
+
+    A pending AUTO run is internally contradictory: AUTO has no human review,
+    yet 'pending' marks it as awaiting moderation. The run must come back
+    'approved' (the publish-eligible state) with published_at still unset —
+    actual delivery (and the move to 'published') happens later in the handler.
+    """
+    engine = DummySearchEngine([_make_msg()])
+    db = FakeDB()
+    service = ContentGenerationService(db, engine)
+
+    orig = _patch_provider(_provider())
+    try:
+        run = await service.generate(_make_auto_moderated_pipeline(PipelinePublishMode.AUTO))
+    finally:
+        _restore_provider(orig)
+
+    assert run.moderation_status == "approved"
+    assert run.moderation_status != "pending"
+    # Not yet delivered: publish happens in the task handler, not in generate().
+    assert run.published_at is None
+
+
+@pytest.mark.anyio
+async def test_generate_moderated_stays_pending():
+    """MODERATED generation must stay 'pending' until a human approves it."""
+    engine = DummySearchEngine([_make_msg()])
+    db = FakeDB()
+    service = ContentGenerationService(db, engine)
+
+    orig = _patch_provider(_provider())
+    try:
+        run = await service.generate(_make_auto_moderated_pipeline(PipelinePublishMode.MODERATED))
+    finally:
+        _restore_provider(orig)
+
+    assert run.moderation_status == "pending"
+    assert run.published_at is None
+
+
+@pytest.mark.anyio
+async def test_generate_auto_respects_effective_mode_from_graph():
+    """A graph node that downgrades AUTO→MODERATED must keep the run 'pending'.
+
+    The effective publish mode can be overridden by a publish node inside the
+    DAG (PublishHandler writes publish_mode to the context). The status decision
+    must follow that effective mode, not the pipeline's declared mode.
+    """
+    engine = DummySearchEngine([_make_msg()])
+    db = FakeDB()
+    service = ContentGenerationService(db, engine)
+
+    pipeline = ContentPipeline(
+        id=1,
+        name="Test",
+        prompt_template="prompt",
+        llm_model="m",
+        generation_backend=PipelineGenerationBackend.CHAIN,
+        publish_mode=PipelinePublishMode.AUTO,
+        pipeline_json=PipelineGraph(nodes=[], edges=[]),
+    )
+
+    orig = _patch_provider(_provider())
+    from src.services import pipeline_executor
+
+    original_execute = getattr(pipeline_executor.PipelineExecutor, "execute", None)
+    pipeline_executor.PipelineExecutor.execute = AsyncMock(
+        return_value={
+            "generated_text": "text",
+            # Node overrides the declared AUTO mode down to moderated.
+            "publish_mode": PipelinePublishMode.MODERATED.value,
+        }
+    )
+    try:
+        run = await service.generate(pipeline)
+        assert run.metadata["effective_publish_mode"] == PipelinePublishMode.MODERATED.value
+        assert run.moderation_status == "pending"
+    finally:
+        _restore_provider(orig)
+        if original_execute:
+            pipeline_executor.PipelineExecutor.execute = original_execute

--- a/tests/test_content_moderation_status_invariant.py
+++ b/tests/test_content_moderation_status_invariant.py
@@ -1,0 +1,301 @@
+"""End-to-end moderation_status invariants for the content cycle (issue #1036).
+
+These tests pin the status flow against a *real* generation_runs repository
+(:memory: DB via the ``db`` fixture) and the *real* ContentGenerationService /
+ContentTaskHandler / PublishService code paths. Only the two genuine external
+edges are stubbed: the LLM provider (returns canned text) and the Telegram
+delivery (``PublishService._publish_to_target`` returns success without a
+network call). Everything that decides moderation_status runs as production code
+so the AUTO/MODERATED de-synchronisations are exercised on real SQL.
+
+Invariants (issue #1036):
+- AUTO: after handle_content_generate() the run is published and is NOT visible
+  in list_pending_moderation(); it never lingers as 'pending'.
+- MODERATED: the run stays 'pending' with no published_at and IS visible in the
+  moderation queue until a human approves it.
+- DAG publish: a graph pipeline run in AUTO mode reflects the publish in the
+  generation_run (published_at + moderation_status='published'), not stranded
+  'pending'.
+- No run is ever both 'pending' and carries a published_at.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.models import (
+    CollectionTask,
+    CollectionTaskStatus,
+    CollectionTaskType,
+    ContentGenerateTaskPayload,
+    ContentPipeline,
+    PipelineGraph,
+    PipelinePublishMode,
+    PipelineTarget,
+    SearchResult,
+)
+from src.services.content_generation_service import ContentGenerationService
+from src.services.publish_service import PublishResult, PublishService
+from src.services.task_handlers.base import TaskHandlerContext
+from src.services.task_handlers.content import ContentTaskHandler
+
+
+def _make_context(db) -> TaskHandlerContext:
+    """Assemble a TaskHandlerContext wired to the real :memory: db.
+
+    Only the fields the CONTENT_GENERATE path touches are populated; the rest
+    use MagicMock so the dataclass is satisfied without standing up a Collector.
+    """
+    tasks = MagicMock()
+    tasks.update_collection_task = AsyncMock()
+    # A real RAG generate() awaits search_engine.has_semantic_index()/search_*;
+    # stub them so the legacy (non-graph) path runs without a live index.
+    search_engine = MagicMock()
+    search_engine.has_semantic_index = AsyncMock(return_value=False)
+    empty = SearchResult(messages=[], total=0, query="")
+    search_engine.search_local = AsyncMock(return_value=empty)
+    search_engine.search_hybrid = AsyncMock(return_value=empty)
+    search_engine.search_semantic = AsyncMock(return_value=empty)
+    return TaskHandlerContext(
+        collector=MagicMock(),
+        channel_bundle=MagicMock(),
+        tasks=tasks,
+        stop_event=asyncio.Event(),
+        search_engine=search_engine,
+        pipeline_bundle=MagicMock(),
+        db=db,
+        client_pool=MagicMock(),
+    )
+
+
+def _task(pipeline_id: int = 1) -> CollectionTask:
+    return CollectionTask(
+        id=1,
+        task_type=CollectionTaskType.CONTENT_GENERATE,
+        status=CollectionTaskStatus.RUNNING,
+        payload=ContentGenerateTaskPayload(pipeline_id=pipeline_id),
+    )
+
+
+def _pipeline(
+    publish_mode: PipelinePublishMode,
+    *,
+    pipeline_id: int = 1,
+    pipeline_json: PipelineGraph | None = None,
+) -> ContentPipeline:
+    return ContentPipeline(
+        id=pipeline_id,
+        name="Test",
+        prompt_template="prompt",
+        llm_model="m",
+        publish_mode=publish_mode,
+        pipeline_json=pipeline_json,
+    )
+
+
+def _provider(text: str = "generated content"):
+    async def fn(prompt=None, **kwargs):
+        return text
+
+    return fn
+
+
+def _build_real_service(ctx) -> ContentGenerationService:
+    """Real ContentGenerationService over the real db, provider stubbed."""
+    provider_service = MagicMock()
+    provider_service.get_provider_callable = MagicMock(return_value=_provider())
+    return ContentGenerationService(
+        ctx.db,
+        ctx.search_engine,
+        provider_service=provider_service,
+    )
+
+
+async def _seed_targets(db, pipeline_id: int) -> None:
+    """Insert one publish target so PublishService.publish_run can deliver."""
+    db.repos.content_pipelines.list_targets = AsyncMock(
+        return_value=[PipelineTarget(id=1, pipeline_id=pipeline_id, phone="+100", dialog_id=-1001)]
+    )
+
+
+def _patch_handler_collaborators(db, pipeline):
+    """Patch only the real boundaries: pipeline lookup, service builder, and the
+    single Telegram delivery call. Generation + publish bookkeeping stay live."""
+    async def fake_deliver(self, run, target):
+        return PublishResult(success=True, message_id=1, phone=target.phone, dialog_id=target.dialog_id)
+
+    return (
+        patch("src.services.pipeline_service.PipelineService.get", AsyncMock(return_value=pipeline)),
+        patch(
+            "src.services.task_handlers.content.build_content_generation_service",
+            AsyncMock(side_effect=lambda c: _build_real_service(c)),
+        ),
+        patch.object(PublishService, "_publish_to_target", fake_deliver),
+    )
+
+
+@pytest.mark.anyio
+async def test_auto_run_not_in_pending_moderation_queue(db):
+    """AUTO: after handle_content_generate the run is published and absent from
+    the moderation queue. A delivered AUTO run that still shows 'pending' would
+    falsely surface in the moderator's list (issue #1036, gap A)."""
+    pipeline = _pipeline(PipelinePublishMode.AUTO)
+    await _seed_targets(db, pipeline.id)
+    handler = ContentTaskHandler(_make_context(db))
+
+    p_get, p_build, p_deliver = _patch_handler_collaborators(db, pipeline)
+    with p_get, p_build, p_deliver:
+        await handler.handle_content_generate(_task())
+
+    pending = await db.repos.generation_runs.list_pending_moderation(pipeline.id)
+    assert pending == [], "AUTO run must not appear in the moderation queue"
+
+    rows = await db.repos.generation_runs.list_by_pipeline(pipeline.id)
+    assert len(rows) == 1
+    run = rows[0]
+    assert run.moderation_status == "published"
+    assert run.published_at is not None
+    # The core invariant: no run is simultaneously pending and published.
+    assert not (run.moderation_status == "pending" and run.published_at is not None)
+
+
+@pytest.mark.anyio
+async def test_auto_run_never_pending_even_before_publish(db):
+    """AUTO: the run skips 'pending' the instant generation completes — proven by
+    blocking delivery. Even with publish failing, the run must read 'approved'
+    (publish-eligible), never 'pending' (issue #1036, gap A stranding case)."""
+    pipeline = _pipeline(PipelinePublishMode.AUTO)
+    await _seed_targets(db, pipeline.id)
+    handler = ContentTaskHandler(_make_context(db))
+
+    async def failing_deliver(self, run, target):
+        return PublishResult(success=False, error="no client")
+
+    with (
+        patch("src.services.pipeline_service.PipelineService.get", AsyncMock(return_value=pipeline)),
+        patch(
+            "src.services.task_handlers.content.build_content_generation_service",
+            AsyncMock(side_effect=lambda c: _build_real_service(c)),
+        ),
+        patch.object(PublishService, "_publish_to_target", failing_deliver),
+    ):
+        await handler.handle_content_generate(_task())
+
+    rows = await db.repos.generation_runs.list_by_pipeline(pipeline.id)
+    run = rows[0]
+    # Delivery failed, so it is not yet 'published' — but the AUTO run must NOT
+    # be stranded 'pending' (the core gap-A bug: a 'pending' AUTO run that never
+    # gets a moderation decision). It rests at 'approved' (publish-eligible), so
+    # a retry/manual re-publish can still deliver it. The forbidden state is
+    # 'pending' on an AUTO run, never reachable now.
+    assert run.moderation_status != "pending"
+    assert run.moderation_status == "approved"
+    # And it never carries a published_at while not 'published'.
+    assert not (run.moderation_status == "pending" and run.published_at is not None)
+
+
+@pytest.mark.anyio
+async def test_moderated_run_stays_pending_in_queue(db):
+    """MODERATED: the run stays 'pending' with no published_at and is visible in
+    the moderation queue until approved."""
+    pipeline = _pipeline(PipelinePublishMode.MODERATED)
+    await _seed_targets(db, pipeline.id)
+    handler = ContentTaskHandler(_make_context(db))
+
+    deliver_calls = []
+
+    async def tracking_deliver(self, run, target):
+        deliver_calls.append(run.id)
+        return PublishResult(success=True, message_id=1)
+
+    with (
+        patch("src.services.pipeline_service.PipelineService.get", AsyncMock(return_value=pipeline)),
+        patch(
+            "src.services.task_handlers.content.build_content_generation_service",
+            AsyncMock(side_effect=lambda c: _build_real_service(c)),
+        ),
+        patch.object(PublishService, "_publish_to_target", tracking_deliver),
+    ):
+        await handler.handle_content_generate(_task())
+
+    # MODERATED must NOT auto-publish.
+    assert deliver_calls == []
+
+    rows = await db.repos.generation_runs.list_by_pipeline(pipeline.id)
+    assert len(rows) == 1
+    run = rows[0]
+    assert run.moderation_status == "pending"
+    assert run.published_at is None
+
+    pending = await db.repos.generation_runs.list_pending_moderation(pipeline.id)
+    assert run.id in [r.id for r in pending], "MODERATED run must be in the moderation queue"
+
+
+@pytest.mark.anyio
+async def test_dag_auto_publish_updates_run(db):
+    """DAG publish: a graph pipeline run in AUTO mode reflects the publish in the
+    generation_run (published_at + moderation_status='published'), not stranded
+    'pending' (issue #1036, gap B — regression guard).
+
+    The graph executor only sets publish_mode in the context; actual delivery
+    goes through PublishService.publish_run which updates the run. This guards
+    against a regression where the DAG path bypasses that bookkeeping."""
+    graph = PipelineGraph(nodes=[], edges=[])
+    pipeline = _pipeline(PipelinePublishMode.AUTO, pipeline_json=graph)
+    await _seed_targets(db, pipeline.id)
+    handler = ContentTaskHandler(_make_context(db))
+
+    delivered = []
+
+    async def fake_deliver(self, run, target):
+        delivered.append(run.id)
+        return PublishResult(success=True, message_id=7, phone=target.phone, dialog_id=target.dialog_id)
+
+    # The graph executor would normally need real nodes; stub it to return text
+    # with an explicit AUTO effective mode (mirrors a publish node in AUTO).
+    with (
+        patch("src.services.pipeline_service.PipelineService.get", AsyncMock(return_value=pipeline)),
+        patch(
+            "src.services.task_handlers.content.build_content_generation_service",
+            AsyncMock(side_effect=lambda c: _build_real_service(c)),
+        ),
+        patch(
+            "src.services.pipeline_executor.PipelineExecutor.execute",
+            AsyncMock(return_value={
+                "generated_text": "graph content",
+                "publish_mode": PipelinePublishMode.AUTO.value,
+            }),
+        ),
+        patch.object(PublishService, "_publish_to_target", fake_deliver),
+    ):
+        await handler.handle_content_generate(_task())
+
+    assert delivered, "DAG AUTO run must be routed through PublishService"
+    rows = await db.repos.generation_runs.list_by_pipeline(pipeline.id)
+    run = rows[0]
+    assert run.published_at is not None
+    assert run.moderation_status == "published"
+    pending = await db.repos.generation_runs.list_pending_moderation(pipeline.id)
+    assert run.id not in [r.id for r in pending]
+
+
+@pytest.mark.anyio
+async def test_no_run_is_pending_with_published_at(db):
+    """Repo-level invariant guard: the (pending + published_at) combination is
+    impossible. set_published_at moves moderation_status to 'published'
+    atomically, so a run that has a published_at can never read back 'pending'."""
+    repo = db.repos.generation_runs
+    run_id = await repo.create_run(1, "prompt")
+    await repo.save_result(run_id, "text", {})
+    await repo.set_published_at(run_id)
+
+    run = await repo.get(run_id)
+    assert run is not None
+    assert run.published_at is not None
+    assert run.moderation_status == "published"
+    assert run.moderation_status != "pending"
+
+    pending = await repo.list_pending_moderation(1)
+    assert run_id not in [r.id for r in pending]

--- a/tests/test_cross_domain_regression_paths.py
+++ b/tests/test_cross_domain_regression_paths.py
@@ -4540,6 +4540,7 @@ class TestPublishServiceCoverage:
             pipeline_id=1,
             generated_text="test",
             moderation_status="pending",
+            status="completed",  # completed but unapproved → blocked on eligibility, not status (#1036)
         )
         pipeline = ContentPipeline(
             id=1,

--- a/tests/test_publish_service.py
+++ b/tests/test_publish_service.py
@@ -129,7 +129,10 @@ async def test_publish_service_no_text():
     pool = FakeClientPool()
     service = PublishService(db, pool)
 
-    run = GenerationRun(id=1, pipeline_id=1, generated_text=None, moderation_status="approved")
+    run = GenerationRun(
+        id=1, pipeline_id=1, generated_text=None,
+        moderation_status="approved", status="completed",
+    )
 
     results = await service.publish_run(run, make_pipeline())
 
@@ -144,7 +147,10 @@ async def test_publish_service_blocks_unapproved_run_for_moderated_pipeline():
     pool = FakeClientPool()
     service = PublishService(db, pool)
 
-    run = GenerationRun(id=1, pipeline_id=1, generated_text="Test content", moderation_status="pending")
+    run = GenerationRun(
+        id=1, pipeline_id=1, generated_text="Test content",
+        moderation_status="pending", status="completed",
+    )
 
     results = await service.publish_run(run, make_pipeline())
 
@@ -154,12 +160,49 @@ async def test_publish_service_blocks_unapproved_run_for_moderated_pipeline():
 
 
 @pytest.mark.anyio
+async def test_publish_service_blocks_non_completed_run():
+    """A run whose generation did not complete must never be delivered, even if
+    it carries generated_text and moderation_status='approved' (issue #1036
+    review, Codex). This is the service-level guard that protects EVERY publish
+    entrypoint — web/CLI moderation, the dispatcher, and the agent tool — not
+    just CONTENT_PUBLISH's SQL filter. No target is ever contacted."""
+    db = FakeDB()
+    db.repos.content_pipelines.set_targets(
+        [PipelineTarget(id=1, pipeline_id=1, phone="+1234567890", dialog_id=-1001234567890)]
+    )
+    pool = FakeClientPool(should_succeed=True)
+    service = PublishService(db, pool)
+
+    # A failed generation that nonetheless got generated_text saved (text was
+    # persisted before a later step failed) and was somehow left 'approved'.
+    run = GenerationRun(
+        id=1,
+        pipeline_id=1,
+        generated_text="Leaked content from a failed run",
+        moderation_status="approved",
+        status="failed",
+    )
+
+    results = await service.publish_run(run, make_pipeline(publish_mode=PipelinePublishMode.AUTO))
+
+    assert len(results) == 1
+    assert results[0].success is False
+    assert "not completed" in results[0].error
+    # The irreversible send was never attempted, and the run was not marked published.
+    assert pool.released == []
+    assert 1 not in db.repos.generation_runs.published_ids
+
+
+@pytest.mark.anyio
 async def test_publish_service_no_targets():
     db = FakeDB()
     pool = FakeClientPool()
     service = PublishService(db, pool)
 
-    run = GenerationRun(id=1, pipeline_id=1, generated_text="Test content", moderation_status="approved")
+    run = GenerationRun(
+        id=1, pipeline_id=1, generated_text="Test content",
+        moderation_status="approved", status="completed",
+    )
 
     results = await service.publish_run(run, make_pipeline())
 
@@ -182,6 +225,7 @@ async def test_publish_service_success():
         pipeline_id=1,
         generated_text="Test content for publishing",
         moderation_status="approved",
+        status="completed",
     )
 
     results = await service.publish_run(run, make_pipeline())
@@ -212,6 +256,7 @@ async def test_publish_service_partial_failure_records_delivered():
         pipeline_id=1,
         generated_text="Test content",
         moderation_status="approved",
+        status="completed",
     )
 
     results = await service.publish_run(run, make_pipeline())
@@ -243,6 +288,7 @@ async def test_publish_service_retry_skips_delivered_targets():
         pipeline_id=1,
         generated_text="Test content",
         moderation_status="approved",
+        status="completed",
         metadata={"published_targets": ["+1111111111:-1001"]},
     )
 
@@ -281,6 +327,7 @@ async def test_publish_service_all_targets_already_delivered():
         pipeline_id=1,
         generated_text="Test content",
         moderation_status="approved",
+        status="completed",
         metadata={"published_targets": ["+1111111111:-1001", "+2222222222:-1002"]},
     )
 
@@ -310,6 +357,7 @@ async def test_publish_service_allows_auto_pipeline_without_approval():
         pipeline_id=1,
         generated_text="Auto-publish content",
         moderation_status="pending",
+        status="completed",
     )
 
     results = await service.publish_run(
@@ -331,7 +379,10 @@ async def test_publish_service_client_unavailable():
     pool = FakeClientPool(should_succeed=False)
     service = PublishService(db, pool)
 
-    run = GenerationRun(id=1, pipeline_id=1, generated_text="Test content", moderation_status="approved")
+    run = GenerationRun(
+        id=1, pipeline_id=1, generated_text="Test content",
+        moderation_status="approved", status="completed",
+    )
 
     results = await service.publish_run(run, make_pipeline())
 
@@ -360,6 +411,7 @@ async def test_publish_service_with_image_url():
         generated_text="Content with image",
         image_url="https://example.com/image.jpg",
         moderation_status="approved",
+        status="completed",
     )
 
     results = await service.publish_run(run, make_pipeline())
@@ -395,6 +447,7 @@ async def test_publish_service_whitespace_text():
         pipeline_id=1,
         generated_text="   \n\t  ",  # Whitespace only
         moderation_status="approved",
+        status="completed",
     )
 
     results = await service.publish_run(run, make_pipeline())
@@ -424,6 +477,7 @@ async def test_publish_service_entity_resolution_fail():
         pipeline_id=1,
         generated_text="Test content",
         moderation_status="approved",
+        status="completed",
     )
 
     results = await service.publish_run(run, make_pipeline())
@@ -455,6 +509,7 @@ async def test_publish_service_timeout():
         pipeline_id=1,
         generated_text="Test content",
         moderation_status="approved",
+        status="completed",
     )
 
     results = await service.publish_run(run, make_pipeline())
@@ -471,7 +526,7 @@ async def test_publish_service_missing_run_id():
     pool = FakeClientPool()
     service = PublishService(db, pool)
 
-    run = GenerationRun(id=None, pipeline_id=1, generated_text="text", moderation_status="approved")
+    run = GenerationRun(id=None, pipeline_id=1, generated_text="text", moderation_status="approved", status="completed")
     results = await service.publish_run(run, make_pipeline())
 
     assert len(results) == 1
@@ -486,7 +541,7 @@ async def test_publish_service_missing_pipeline_id():
     pool = FakeClientPool()
     service = PublishService(db, pool)
 
-    run = GenerationRun(id=1, pipeline_id=1, generated_text="text", moderation_status="approved")
+    run = GenerationRun(id=1, pipeline_id=1, generated_text="text", moderation_status="approved", status="completed")
     results = await service.publish_run(run, make_pipeline(id=None))
 
     assert len(results) == 1
@@ -509,6 +564,7 @@ async def test_publish_service_with_reply_to():
         pipeline_id=1,
         generated_text="Reply content",
         moderation_status="approved",
+        status="completed",
         metadata={"publish_reply": True, "reply_to_message_id": 42},
     )
 
@@ -538,6 +594,7 @@ async def test_publish_service_general_exception():
         pipeline_id=1,
         generated_text="Test content",
         moderation_status="approved",
+        status="completed",
     )
 
     results = await service.publish_run(run, make_pipeline())
@@ -588,6 +645,7 @@ async def test_publish_service_resolve_entity_fallback():
     run = GenerationRun(
         id=1, pipeline_id=1, generated_text="Test",
         moderation_status="approved",
+        status="completed",
     )
 
     results = await service.publish_run(run, make_pipeline(publish_mode=PipelinePublishMode.AUTO))
@@ -622,6 +680,7 @@ async def test_publish_service_resolve_entity_no_wait_for():
         run = GenerationRun(
             id=1, pipeline_id=1, generated_text="Test",
             moderation_status="approved",
+            status="completed",
         )
         results = await service.publish_run(run, make_pipeline(publish_mode=PipelinePublishMode.AUTO))
 


### PR DESCRIPTION
## Что и зачем

Часть эпика #1025 (функция 3 — контентный цикл AI). Чинит логический рассинхрон статусов модерации в AUTO-режиме перед сквозным тестом #1038.

### Разрыв A (AUTO) — починен
`ContentGenerationService.generate()` оставлял каждый run с `moderation_status='pending'` (дефолт `create_run` / БД). Для AUTO-пайплайна это внутренне противоречиво:
- AUTO не предполагает ручного ревью, но run висел в очереди модерации (`list_pending_moderation` берёт `pending`+`approved`);
- если авто-публикация срывалась (нет таргетов / нет клиента / частичная доставка), `set_published_at()` не вызывался → run **навсегда застревал** `pending` — ложный «черновик на ревью», которого никто не трогает.

**Фикс:** единая точка в `generate()` выравнивает `moderation_status` с **эффективным** publish-режимом (учитывает override от publish-узла DAG). AUTO минует `pending` сразу в `approved` (целевое состояние, которое уже ждёт `PublishService`); успешная доставка затем переводит в `published` через `set_published_at()`. MODERATED остаётся `pending` до ручного approve. `dry_run` не трогается.

### Разрыв B (DAG publish) — уже состыкован, добавлен регресс-гард
Вопреки исходному описанию, `PublishHandler` в DAG **не шлёт в Telegram напрямую** — он только пишет publish-конфиг в контекст (`handlers.py`, «Actual publishing is handled by PublishService post-execution»). Графовые пайплайны публикуются тем же путём: `_run_graph()` → `handle_content_generate()` (AUTO) → `PublishService.publish_run()` → `set_published_at()`. Прямого обхода учёта `published_at`/`moderation_status` в `src/` нет (проверены все вызовы). Разрыв, видимо, закрыт ранее (#835/#838). Добавлен регресс-гард, чтобы рефактор не обошёл этот учёт. (Подробности — в [комментарии к issue](https://github.com/axisrow/tg_content_factory/issues/1036#issuecomment-4785639377).)

## TDD red→green
Red-тесты фиксируют инвариант, каждый ассерт **мутационно верифицирован** (ломал продкод → тест краснел):
- AUTO: `generate()` возвращает `approved`, минуя `pending`; AUTO-run не застревает `pending` даже при сбое публикации.
- MODERATED: остаётся `pending`, виден в очереди модерации до approve.
- Инвариант: ни один run не бывает одновременно `pending` + `published_at`.
- DAG AUTO: прогон обновляет `generation_run` (`published_at` + `published`).

Семантика `moderation_status` задокументирована в одном месте — docstring `set_moderation_status()`.

## Проверка
- `tests/test_content_moderation_status_invariant.py` (новый), `test_content_generation_service_edge_cases.py`, `test_content_generation_service.py` — зелёные.
- Регресс из issue: `pytest tests/test_publish_service.py tests/test_unified_dispatcher_pipeline_runs.py` — **42 passed**.
- Параллельный subset (content/publish/pipeline/dispatcher) `-n auto` — **1824 passed**; smoke — passed.
- `ruff check src/ tests/` — чисто. mypy — без новых ошибок vs baseline.

Closes #1036

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EzdrAepfqom6B5P1d2MjoE