### PR TITLE
test(ai-gen): SSE-стриминг, RAG-контекст, ошибки провайдера (TDD) (#1034)

### DIFF
--- a/src/cli/commands/pipeline.py
+++ b/src/cli/commands/pipeline.py
@@ -536,6 +536,20 @@ def run(args: argparse.Namespace) -> None:
                             ),
                             flush=True,
                         )
+                    # A mid-stream provider failure ends the generator gracefully
+                    # (partial text printed) but flags stream_error — it is NOT a
+                    # successful run. Persist it as failed with the error recorded
+                    # instead of saving truncated text as completed (issue #1034,
+                    # cycle-review).
+                    if last and last.get("stream_error"):
+                        await db.repos.generation_runs.set_status(
+                            run_id, "failed", metadata={"stream_error": last["stream_error"]}
+                        )
+                        print(
+                            safe_json_dumps({"event": "error", "error": last["stream_error"]}),
+                            flush=True,
+                        )
+                        return
                     final_text = last.get("generated_text") if last else ""
                     metadata = {"citations": last.get("citations", []) if last else []}
                     await db.repos.generation_runs.save_result(run_id, final_text, metadata)

--- a/src/services/generation_service.py
+++ b/src/services/generation_service.py
@@ -67,6 +67,22 @@ class GenerationService:
         result = await self._search.search_local(query, channel_id=channel_id, limit=limit)
         return result.messages
 
+    @staticmethod
+    def _extract_delta(chunk: Any) -> str:
+        """Coerce a streaming chunk into its text delta, mapping "empty" to "".
+
+        Returns ``""`` for ``None`` and for dict chunks whose text fields are all
+        absent/``None`` so callers can skip them — this prevents the literal
+        ``"None"`` (from ``str(None)``) from leaking into the generated text and
+        avoids emitting do-nothing deltas (issue #1034).
+        """
+        if chunk is None:
+            return ""
+        if isinstance(chunk, dict):
+            text = chunk.get("text") or chunk.get("content") or chunk.get("generated_text")
+            return text if isinstance(text, str) else ""
+        return str(chunk)
+
     def _build_source_messages(self, messages: List[Message]) -> str:
         parts: List[str] = []
         for m in messages:
@@ -77,6 +93,33 @@ class GenerationService:
             when = m.date.isoformat() if isinstance(m.date, datetime) else str(m.date)
             parts.append(f"[{header}] {text} (id:{m.message_id} date:{when})")
         return "\n\n".join(parts)
+
+    @staticmethod
+    def _build_citations(messages: List[Message]) -> List[Dict[str, Any]]:
+        """Bake citations from retrieved messages, deduplicated in retrieval order.
+
+        Hybrid + FTS retrieval can surface the same message twice, which used to
+        emit duplicate citations (issue #1034). Dedup on ``(channel_id,
+        message_id)`` — ``message_id`` is only unique per channel, so the channel
+        must be part of the key to keep same-id messages from different channels
+        distinct. First occurrence wins, preserving retrieval order.
+        """
+        citations: List[Dict[str, Any]] = []
+        seen: set[tuple[int | None, int]] = set()
+        for m in messages:
+            key = (m.channel_id, m.message_id)
+            if key in seen:
+                continue
+            seen.add(key)
+            citations.append(
+                {
+                    "channel_title": (m.channel_title or m.channel_username or ""),
+                    "message_id": m.message_id,
+                    "text": (m.text or "")[:512],
+                    "date": m.date.isoformat() if isinstance(m.date, datetime) else str(m.date),
+                }
+            )
+        return citations
 
     async def generate_stream(
         self,
@@ -112,16 +155,8 @@ class GenerationService:
         if provider is None:
             raise RuntimeError("No provider callable configured for generation")
 
-        # Citations baked from retrieved messages
-        citations = [
-            {
-                "channel_title": (m.channel_title or m.channel_username or ""),
-                "message_id": m.message_id,
-                "text": (m.text or "")[:512],
-                "date": m.date.isoformat() if isinstance(m.date, datetime) else str(m.date),
-            }
-            for m in messages
-        ]
+        # Citations baked from retrieved messages (deduplicated, see #1034)
+        citations = self._build_citations(messages)
 
         # Call the provider with stream=True. The provider may return:
         #  - an async generator directly (async def with yield)
@@ -146,23 +181,39 @@ class GenerationService:
 
         # If it's an async iterable (async generator), iterate and yield
         if hasattr(result, "__aiter__"):
+            import logging
+
             buffer = ""
-            async for chunk in result:  # type: ignore
-                if isinstance(chunk, dict):
-                    delta = (
-                        chunk.get("text")
-                        or chunk.get("content")
-                        or chunk.get("generated_text")
-                        or str(chunk)
-                    )
-                else:
-                    delta = str(chunk)
-                buffer += delta
+            try:
+                async for chunk in result:  # type: ignore
+                    delta = self._extract_delta(chunk)
+                    if not delta:
+                        # Empty/None chunks carry no text — skip so they neither
+                        # pollute the buffer (``str(None)`` → ``"None"``) nor emit
+                        # a do-nothing delta downstream (issue #1034).
+                        continue
+                    buffer += delta
+                    yield {
+                        "prompt": rendered_prompt,
+                        "generated_text": buffer,
+                        "delta": delta,
+                        "citations": citations,
+                    }
+            except Exception as exc:
+                # Provider closed the connection mid-stream / timed out. Return the
+                # partial text gracefully instead of losing it (owner decision,
+                # issue #1034). A trailing update carries the accumulated buffer
+                # plus the error markers so consumers can persist what arrived.
+                logging.getLogger(__name__).warning(
+                    "Streaming provider failed mid-stream (%s); returning partial text", exc
+                )
                 yield {
                     "prompt": rendered_prompt,
                     "generated_text": buffer,
-                    "delta": delta,
+                    "delta": "",
                     "citations": citations,
+                    "partial": True,
+                    "stream_error": str(exc) or exc.__class__.__name__,
                 }
             return
 
@@ -170,16 +221,9 @@ class GenerationService:
         if hasattr(result, "__iter__") and not isinstance(result, (str, bytes)):
             buffer = ""
             for chunk in result:  # type: ignore
-                delta = (
-                    str(chunk)
-                    if not isinstance(chunk, dict)
-                    else (
-                        chunk.get("text")
-                        or chunk.get("content")
-                        or chunk.get("generated_text")
-                        or str(chunk)
-                    )
-                )
+                delta = self._extract_delta(chunk)
+                if not delta:
+                    continue
                 buffer += delta
                 yield {
                     "prompt": rendered_prompt,
@@ -271,15 +315,7 @@ class GenerationService:
             stream=False,
         )
 
-        citations = [
-            {
-                "channel_title": (m.channel_title or m.channel_username or ""),
-                "message_id": m.message_id,
-                "text": (m.text or "")[:512],
-                "date": m.date.isoformat() if isinstance(m.date, datetime) else str(m.date),
-            }
-            for m in messages
-        ]
+        citations = self._build_citations(messages)
 
         return {
             "prompt": rendered_prompt,

--- a/src/services/generation_service.py
+++ b/src/services/generation_service.py
@@ -288,6 +288,14 @@ class GenerationService:
                     "generated_text": "",
                     "citations": [],
                 }
+            if last.get("stream_error"):
+                # The stream ended on a mid-stream provider failure. generate_stream
+                # surfaces partial text gracefully for interactive consumers, but this
+                # aggregating API must NOT report a truncated run as success — raise so
+                # callers (e.g. ContentGenerationService) mark the run failed rather
+                # than persisting partial text as a completed generation (issue #1034,
+                # cycle-review).
+                raise RuntimeError(f"Streaming generation failed: {last['stream_error']}")
             return {
                 "prompt": last["prompt"],
                 "generated_text": last["generated_text"],

--- a/src/services/provider_adapters.py
+++ b/src/services/provider_adapters.py
@@ -228,7 +228,18 @@ def make_generic_http_adapter(
                     if resp.status != 200:
                         text = await resp.text()
                         raise RuntimeError(f"Provider error {resp.status}: {text}")
-                    data = await resp.json()
+                    try:
+                        data = await resp.json()
+                    except aiohttp.ContentTypeError as exc:
+                        # 200 OK but a non-JSON body (HTML error page, SSE stream,
+                        # captcha). Surface a provider-context RuntimeError instead
+                        # of leaking the raw aiohttp error to callers (issue #1034).
+                        content_type = getattr(resp, "content_type", "") or "unknown"
+                        body_preview = (await resp.text())[:200]
+                        raise RuntimeError(
+                            f"Provider returned 200 with unexpected content-type "
+                            f"{content_type}: {body_preview}"
+                        ) from exc
                     return await _parse_json_for_text(data)
         except Exception:
             raise

--- a/src/web/pipelines/handlers.py
+++ b/src/web/pipelines/handlers.py
@@ -529,6 +529,17 @@ async def generate_stream(
                 }
                 yield f"data: {safe_json_dumps(data)}\n\n"
 
+            # A mid-stream provider failure ends the generator gracefully (partial
+            # text preserved for the UI) but flags partial/stream_error — it is NOT
+            # a successful run. Persist it as failed with the error recorded instead
+            # of saving truncated text as completed (issue #1034, cycle-review).
+            if last and last.get("stream_error"):
+                await db.repos.generation_runs.set_status(
+                    run_id, "failed", metadata={"stream_error": last["stream_error"]}
+                )
+                yield f"event: error\ndata: {safe_json_dumps({'error': 'Generation interrupted'})}\n\n"
+                return
+
             # finished successfully
             final_text = last.get("generated_text") if last else ""
             metadata = {"citations": last.get("citations", []) if last else []}

--- a/tests/routes/test_pipelines_routes.py
+++ b/tests/routes/test_pipelines_routes.py
@@ -346,6 +346,47 @@ async def test_generate_stream_success(client):
 
 
 @pytest.mark.anyio
+async def test_generate_stream_midstream_break_marks_run_failed(client):
+    """A provider that drops mid-stream must NOT persist a 'completed' run.
+
+    Regression for issue #1034 (cycle-review): generate_stream now returns partial
+    text gracefully (partial/stream_error flags) instead of raising. The SSE handler
+    must honor those flags and persist the run as 'failed' with the error recorded —
+    otherwise a truncated generation is silently saved as a successful completed run.
+    Exercises the REAL GenerationService (provider fails after one chunk), not a mock.
+    """
+    await client.post("/pipelines/add", data=_ADD_DATA)
+
+    async def failing_provider(prompt="", **kwargs):
+        async def _gen():
+            yield "partial text "
+            raise ConnectionError("provider dropped mid-stream")
+
+        return _gen()
+
+    mock_provider_instance = MagicMock()
+    mock_provider_instance.has_providers = MagicMock(return_value=True)
+    mock_provider_instance.get_provider_callable = MagicMock(return_value=failing_provider)
+
+    app = client._transport.app  # type: ignore
+    app.state.llm_provider_service = mock_provider_instance
+    db = app.state.db
+
+    resp = await client.get("/pipelines/1/generate-stream")
+    assert resp.status_code == 200
+    # The interrupted stream surfaces an error event, not a done event.
+    assert "event: error" in resp.text
+    assert "event: done" not in resp.text
+
+    # The run must be persisted as failed, not completed (the core regression).
+    runs = await db.repos.generation_runs.list_by_pipeline(1)
+    assert runs, "a generation run should have been created"
+    latest = runs[0]
+    assert latest.status == "failed"
+    assert latest.status != "completed"
+
+
+@pytest.mark.anyio
 async def test_generate_stream_pipeline_not_found(client):
     """Test SSE streaming with invalid pipeline."""
     resp = await client.get("/pipelines/999999/generate-stream", follow_redirects=False)

--- a/tests/test_cli_pipeline_commands.py
+++ b/tests/test_cli_pipeline_commands.py
@@ -996,6 +996,61 @@ class TestPipelineGenerateStream:
         assert status == "completed"
         assert generated == "Hello world"
 
+    def test_midstream_break_marks_run_failed_not_completed(self, tmp_path, cli_init_patch, capsys):
+        """A graceful mid-stream break (partial/stream_error final update) must
+        persist the run as 'failed', not 'completed' (issue #1034, cycle-review).
+
+        The real generate_stream no longer raises on a provider drop — it yields a
+        final update flagged stream_error. The CLI handler must honor that flag and
+        flip the run to failed, otherwise truncated text is saved as a completed run.
+        The fake mirrors that exact output shape.
+        """
+
+        class _BreakingGenerationService:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def generate_stream(self, *args, **kwargs):
+                yield {"delta": "partial", "generated_text": "partial", "citations": []}
+                yield {
+                    "delta": "",
+                    "generated_text": "partial",
+                    "citations": [],
+                    "partial": True,
+                    "stream_error": "provider dropped mid-stream",
+                }
+
+        db_path = _empty_db_path(tmp_path, "pipeline_gen_stream_break.db")
+        pid = _seed_pipeline_with_graph(db_path, name="BreakDAG")
+
+        provider = MagicMock()
+        provider.load_db_providers = AsyncMock()
+        provider.has_providers = MagicMock(return_value=True)
+        provider.get_provider_callable = MagicMock(return_value=AsyncMock())
+
+        db = _open_db(db_path)
+        try:
+            with cli_init_patch(db, _PIPELINE_INIT_DB_TARGET, fresh_database=True), patch(
+                "src.services.provider_service.RuntimeProviderRegistry",
+                return_value=provider,
+            ), patch(
+                "src.services.generation_service.GenerationService",
+                _BreakingGenerationService,
+            ):
+                run(_gen_stream_ns(id=pid))
+        finally:
+            _close_db(db)
+
+        out = capsys.readouterr().out
+        lines = [json.loads(ln) for ln in out.strip().splitlines() if ln.strip()]
+        assert lines[-1]["event"] == "error"
+        assert "done" not in {ln.get("event") for ln in lines}
+
+        run_id = _max_run_id(db_path)
+        assert run_id is not None
+        status, _ = _read_run_status(db_path, run_id)
+        assert status == "failed"
+
     def test_cancellation_marks_run_failed(self, tmp_path, cli_init_patch, capsys):
         """Ctrl+C raises CancelledError (a BaseException, not Exception). The run
         must be flipped to "failed" and the exception re-raised, not left dangling

--- a/tests/test_generation_service_live.py
+++ b/tests/test_generation_service_live.py
@@ -1,0 +1,99 @@
+"""Live (opt-in) provider smoke for the RAG generation path (issue #1034).
+
+These tests make REAL LLM calls and are billed, so they are skipped unless both
+``RUN_REAL_PROVIDER_SMOKE=1`` and a provider API key are set — the same gate the
+existing provider smoke uses (``test_provider_runtime_integration.py``). They
+prove the fake-provider streaming/RAG flow holds against a real provider; the
+fake-provider tests in ``test_generation_service_streaming_edge_cases.py`` and
+``test_generation_service_rag_context.py`` are the mandatory CI coverage.
+
+Live runs are owner-consent only and should target a safe model with a tiny
+``max_tokens`` budget — no Telegram side effects are involved here, this only
+exercises the generation service against the provider HTTP API.
+"""
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+
+import pytest
+
+from src.models import Message, SearchResult
+from src.services.generation_service import GenerationService
+from src.services.provider_service import RuntimeProviderRegistry as RuntimeProviderService
+
+_LIVE_GATE = os.environ.get("RUN_REAL_PROVIDER_SMOKE") != "1" or not os.environ.get("ZAI_API_KEY")
+_LIVE_REASON = "Set RUN_REAL_PROVIDER_SMOKE=1 and ZAI_API_KEY to run live generation smoke."
+
+
+class _StaticSearchEngine:
+    """Returns a fixed context message so retrieval is deterministic for the smoke."""
+
+    def __init__(self, messages):
+        self._messages = messages
+
+    async def search_hybrid(self, query: str, **kwargs) -> SearchResult:
+        return SearchResult(messages=self._messages, total=len(self._messages), query=query)
+
+
+def _context_message() -> Message:
+    return Message(
+        id=1,
+        channel_id=10,
+        message_id=42,
+        sender_id=None,
+        sender_name="Author",
+        text="The capital of France is Paris.",
+        date=datetime.now(timezone.utc),
+        collected_at=None,
+        channel_title="Facts",
+        channel_username="facts",
+    )
+
+
+@pytest.mark.real_provider_smoke
+@pytest.mark.skipif(_LIVE_GATE, reason=_LIVE_REASON)
+@pytest.mark.anyio
+async def test_live_generation_non_stream_smoke():
+    """A real provider returns non-empty generated text plus deduped citations."""
+    service = RuntimeProviderService(env={"ZAI_API_KEY": os.environ["ZAI_API_KEY"]})
+    provider = service.get_provider_callable("zai")
+
+    gen = GenerationService(_StaticSearchEngine([_context_message()]), provider_callable=provider)
+    out = await gen.generate(
+        query="What is the capital of France?",
+        prompt_template="Context:\n{source_messages}\n\nAnswer briefly.",
+        model="glm-5-turbo",
+        max_tokens=32,
+        temperature=0,
+    )
+
+    assert isinstance(out["generated_text"], str)
+    assert out["generated_text"].strip()
+    assert len(out["citations"]) == 1
+
+
+@pytest.mark.real_provider_smoke
+@pytest.mark.skipif(_LIVE_GATE, reason=_LIVE_REASON)
+@pytest.mark.anyio
+async def test_live_generation_stream_smoke():
+    """The streaming path accumulates a non-empty final text against a real provider."""
+    service = RuntimeProviderService(env={"ZAI_API_KEY": os.environ["ZAI_API_KEY"]})
+    provider = service.get_provider_callable("zai")
+
+    gen = GenerationService(_StaticSearchEngine([_context_message()]), provider_callable=provider)
+
+    last = None
+    async for update in gen.generate_stream(
+        query="What is the capital of France?",
+        prompt_template="Context:\n{source_messages}\n\nAnswer briefly.",
+        model="glm-5-turbo",
+        max_tokens=32,
+        temperature=0,
+    ):
+        last = update
+
+    assert last is not None
+    assert last["generated_text"].strip()
+    # A clean live stream must not be flagged partial (the mid-stream-break path).
+    assert last.get("partial") in (None, False)

--- a/tests/test_generation_service_rag_context.py
+++ b/tests/test_generation_service_rag_context.py
@@ -1,0 +1,216 @@
+"""RAG-context coverage for ``GenerationService`` and ``resolve_retrieval_scope`` (issue #1034).
+
+Tier-2 bug-hunt, retrieval side:
+  * citation deduplication — the same message returned twice used to produce
+    duplicate citation entries (bug, fixed here);
+  * null ``Message`` fields (``channel_title=None``/``channel_username=None``)
+    must degrade gracefully — regression guard, proven by mutation;
+  * ``resolve_retrieval_scope`` must fail closed: a scope lookup error and a
+    multi-source pipeline must both leave ``channel_id=None`` so retrieval never
+    leaks across channels — regression guards (cf. #1037/#1077 fail-closed).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from src.models import (
+    ContentPipeline,
+    Message,
+    PipelineGenerationBackend,
+    PipelinePublishMode,
+    SearchResult,
+)
+from src.services.generation_service import GenerationService
+from src.services.pipeline_service import resolve_retrieval_scope
+
+
+class DummySearchEngine:
+    def __init__(self, messages):
+        self._messages = messages
+
+    async def search_hybrid(self, query: str, **kwargs) -> SearchResult:
+        return SearchResult(messages=self._messages, total=len(self._messages), query=query)
+
+
+def _msg(
+    message_id: int = 42,
+    *,
+    channel_id: int = 10,
+    title: str | None = "C",
+    username: str | None = "u",
+    text: str = "hi",
+) -> Message:
+    return Message(
+        id=1,
+        channel_id=channel_id,
+        message_id=message_id,
+        sender_id=None,
+        sender_name="A",
+        text=text,
+        date=datetime.now(timezone.utc),
+        collected_at=None,
+        channel_title=title,
+        channel_username=username,
+    )
+
+
+async def _provider(**kwargs) -> str:
+    return "ok"
+
+
+# ---------------------------------------------------------------------------
+# Bug C: citation deduplication
+# ---------------------------------------------------------------------------
+
+
+async def test_citations_deduplicated_for_repeated_message():
+    """The same (channel_id, message_id) returned twice yields ONE citation.
+
+    Pre-fix retrieval that returned the same message twice (hybrid+FTS overlap)
+    produced two identical citation entries. The exact count assertion (``== 1``)
+    is deliberate — a ``>= 1`` would pass on the buggy two-citation output.
+    """
+    same = [_msg(message_id=42), _msg(message_id=42)]
+    svc = GenerationService(DummySearchEngine(same), provider_callable=_provider)
+
+    out = await svc.generate(query="q", prompt_template="Use {source_messages}")
+
+    assert len(out["citations"]) == 1, "duplicate message must not duplicate the citation"
+    assert out["citations"][0]["message_id"] == 42
+
+
+async def test_citations_keep_distinct_messages_in_order():
+    """Distinct messages stay distinct and keep retrieval order (no over-dedup).
+
+    Guards against a fix that collapses *different* messages — mutating the dedup
+    key to a constant would shrink this to one citation and fail.
+    """
+    msgs = [_msg(message_id=1), _msg(message_id=2), _msg(message_id=3)]
+    svc = GenerationService(DummySearchEngine(msgs), provider_callable=_provider)
+
+    out = await svc.generate(query="q", prompt_template="Use {source_messages}")
+
+    assert [c["message_id"] for c in out["citations"]] == [1, 2, 3]
+
+
+async def test_citations_distinguish_same_id_across_channels():
+    """Same message_id in different channels are NOT collapsed.
+
+    message_id is only unique per channel, so the dedup key must include
+    channel_id — otherwise cross-channel citations would be lost.
+    """
+    msgs = [_msg(message_id=7, channel_id=100), _msg(message_id=7, channel_id=200)]
+    svc = GenerationService(DummySearchEngine(msgs), provider_callable=_provider)
+
+    out = await svc.generate(query="q", prompt_template="Use {source_messages}")
+
+    assert len(out["citations"]) == 2
+
+
+async def test_streaming_citations_also_deduplicated():
+    """The streaming path bakes the same citations, so dedup must apply there too."""
+    same = [_msg(message_id=42), _msg(message_id=42)]
+
+    async def streaming_provider(prompt: str = "", **kwargs):
+        async def _gen():
+            yield "chunk"
+
+        return _gen()
+
+    svc = GenerationService(DummySearchEngine(same), provider_callable=streaming_provider)
+
+    last = None
+    async for update in svc.generate_stream(query="q", prompt_template="Use {source_messages}"):
+        last = update
+
+    assert last is not None
+    assert len(last["citations"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Regression guard: null Message fields degrade gracefully
+# ---------------------------------------------------------------------------
+
+
+async def test_null_channel_fields_do_not_crash():
+    """A message with channel_title=None AND channel_username=None is handled.
+
+    The ``or ""`` fallbacks in citation/source building keep this graceful;
+    mutating them away would surface ``None`` into the citation and (for the
+    prompt) crash the f-string join. The assertions pin both behaviours.
+    """
+    msg = _msg(title=None, username=None, text="content here")
+    svc = GenerationService(DummySearchEngine([msg]), provider_callable=_provider)
+
+    out = await svc.generate(query="q", prompt_template="Use {source_messages}")
+
+    assert out["citations"][0]["channel_title"] == ""
+    assert "content here" in out["prompt"]
+
+
+# ---------------------------------------------------------------------------
+# Regression guards: resolve_retrieval_scope fails closed
+# ---------------------------------------------------------------------------
+
+
+def _pipeline() -> ContentPipeline:
+    return ContentPipeline(
+        id=7,
+        name="MyPipe",
+        prompt_template="p",
+        llm_model="m",
+        generation_backend=PipelineGenerationBackend.CHAIN,
+        publish_mode=PipelinePublishMode.MODERATED,
+    )
+
+
+class _Source:
+    def __init__(self, channel_id: int) -> None:
+        self.channel_id = channel_id
+
+
+async def test_scope_lookup_error_falls_back_without_channel():
+    """A failing list_sources must not raise — scope degrades to channel_id=None."""
+
+    async def failing_list_sources(pipeline_id: int):
+        raise RuntimeError("DB scope lookup failed")
+
+    scope = await resolve_retrieval_scope(_pipeline(), failing_list_sources)
+
+    assert scope.query == "MyPipe"
+    assert scope.channel_id is None
+
+
+async def test_scope_single_source_sets_channel():
+    """A single source scopes retrieval to that channel (positive control)."""
+
+    async def one_source(pipeline_id: int):
+        return [_Source(555)]
+
+    scope = await resolve_retrieval_scope(_pipeline(), one_source)
+
+    assert scope.channel_id == 555
+
+
+async def test_scope_multi_source_fails_closed():
+    """Multiple sources must leave channel_id=None — no cross-channel leak.
+
+    Fail-closed scoping (cf. #1037/#1077): with >1 source there is no single
+    channel to scope to, so retrieval must stay unscoped rather than silently
+    pick one source's channel.
+    """
+
+    async def two_sources(pipeline_id: int):
+        return [_Source(111), _Source(222)]
+
+    scope = await resolve_retrieval_scope(_pipeline(), two_sources)
+
+    assert scope.channel_id is None
+
+
+async def test_scope_no_list_sources_returns_query_only():
+    """Without a list_sources callable, scope is query-only (channel_id=None)."""
+    scope = await resolve_retrieval_scope(_pipeline(), None)
+
+    assert scope.query == "MyPipe"
+    assert scope.channel_id is None

--- a/tests/test_generation_service_streaming_edge_cases.py
+++ b/tests/test_generation_service_streaming_edge_cases.py
@@ -1,0 +1,205 @@
+"""Streaming edge-case coverage for ``GenerationService.generate_stream`` (issue #1034).
+
+Tier-2 bug-hunt: SSE streaming edge cases that the happy-path tests in
+``test_generation_service_streaming.py`` never exercised.
+
+Each test here was written red-first against the pre-fix code:
+  * mid-stream break (provider closes the connection / ``asyncio.TimeoutError``)
+    used to propagate the raw exception and DROP the partial text;
+  * ``None``/non-string chunks used to leak the literal ``"None"`` into the
+    generated text and emit empty deltas;
+  * citation building used to duplicate citations for a message returned twice.
+
+Fakes deliberately mirror the real provider contract from
+``generation_service.generate_stream`` (a coroutine resolving to an async
+generator), so the tests stay faithful to production behaviour.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+import pytest
+
+from src.models import Message, SearchResult
+from src.services.generation_service import GenerationService
+
+
+class DummySearchEngine:
+    """Returns a fixed message list from ``search_hybrid`` (matches existing fakes)."""
+
+    def __init__(self, messages):
+        self._messages = messages
+
+    async def search_hybrid(self, query: str, **kwargs) -> SearchResult:
+        return SearchResult(messages=self._messages, total=len(self._messages), query=query)
+
+
+def _msg(message_id: int = 42, *, channel_id: int = 10, title: str | None = "C", text: str = "hi") -> Message:
+    return Message(
+        id=1,
+        channel_id=channel_id,
+        message_id=message_id,
+        sender_id=None,
+        sender_name="A",
+        text=text,
+        date=datetime.now(timezone.utc),
+        collected_at=None,
+        channel_title=title,
+        channel_username="u",
+    )
+
+
+async def _drain(svc: GenerationService, **kwargs) -> list[dict]:
+    updates: list[dict] = []
+    async for update in svc.generate_stream(query="q", prompt_template="Use {source_messages}", **kwargs):
+        updates.append(update)
+    return updates
+
+
+# ---------------------------------------------------------------------------
+# Bug A: mid-stream break — provider closes connection / TimeoutError
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raised",
+    [ConnectionError("provider closed connection mid-stream"), asyncio.TimeoutError()],
+    ids=["connection_error", "timeout_error"],
+)
+async def test_midstream_break_returns_partial_text(raised):
+    """Provider raising mid-iteration must NOT lose the already-streamed text.
+
+    Pre-fix the raw exception propagated out of ``generate_stream`` and the
+    partial buffer (``part1 part2 ``) was lost. The fix catches the exception,
+    yields a final update flagged ``partial=True``/``stream_error``, and returns.
+    """
+
+    async def provider(prompt: str = "", **kwargs):
+        async def _gen():
+            yield "part1 "
+            yield "part2 "
+            raise raised
+
+        return _gen()
+
+    svc = GenerationService(DummySearchEngine([_msg()]), provider_callable=provider)
+
+    updates = await _drain(svc)
+
+    # The stream completed gracefully (no exception escaped _drain).
+    assert updates, "expected at least the partial updates"
+    final = updates[-1]
+    assert final["generated_text"] == "part1 part2 ", "partial text must be preserved"
+    assert final["partial"] is True
+    assert final["stream_error"], "stream_error must describe the failure"
+
+
+async def test_midstream_break_first_chunk_yields_error_marker():
+    """A provider that fails on the very first chunk still terminates gracefully."""
+
+    async def provider(prompt: str = "", **kwargs):
+        async def _gen():
+            raise ConnectionError("dropped before first chunk")
+            yield  # pragma: no cover - makes this an async generator
+
+        return _gen()
+
+    svc = GenerationService(DummySearchEngine([_msg()]), provider_callable=provider)
+
+    updates = await _drain(svc)
+
+    assert len(updates) == 1
+    assert updates[0]["generated_text"] == ""
+    assert updates[0]["partial"] is True
+    assert updates[0]["stream_error"]
+
+
+async def test_successful_stream_has_no_partial_flag():
+    """Regression guard: a clean stream must NOT be flagged partial.
+
+    Mutating the fix to always set ``partial=True`` would turn every successful
+    generation into a "partial" one — this pins the happy path.
+    """
+
+    async def provider(prompt: str = "", **kwargs):
+        async def _gen():
+            yield "all "
+            yield "good"
+
+        return _gen()
+
+    svc = GenerationService(DummySearchEngine([_msg()]), provider_callable=provider)
+
+    updates = await _drain(svc)
+
+    assert updates[-1]["generated_text"] == "all good"
+    assert updates[-1].get("partial") in (None, False)
+    assert not updates[-1].get("stream_error")
+
+
+# ---------------------------------------------------------------------------
+# Bug B: None / empty chunks must not pollute the generated text
+# ---------------------------------------------------------------------------
+
+
+async def test_none_chunks_do_not_leak_literal_none():
+    """A ``None`` chunk must be skipped, not coerced to the string ``"None"``.
+
+    Pre-fix ``str(None)`` produced ``"None"`` inside ``generated_text``
+    (``"aNoneb"``) and an empty chunk produced a do-nothing delta.
+    """
+
+    async def provider(prompt: str = "", **kwargs):
+        async def _gen():
+            yield "a"
+            yield None
+            yield ""
+            yield "b"
+
+        return _gen()
+
+    svc = GenerationService(DummySearchEngine([_msg()]), provider_callable=provider)
+
+    updates = await _drain(svc)
+
+    assert updates[-1]["generated_text"] == "ab", "None/empty chunks must not enter the text"
+    # No update should carry an empty or "None" delta.
+    deltas = [u["delta"] for u in updates]
+    assert "None" not in deltas
+    assert "" not in deltas
+    assert deltas == ["a", "b"]
+
+
+async def test_dict_chunk_with_none_text_is_skipped():
+    """A dict chunk whose text fields are all ``None`` must not leak ``"None"``."""
+
+    async def provider(prompt: str = "", **kwargs):
+        async def _gen():
+            yield {"text": "x"}
+            yield {"text": None, "content": None, "generated_text": None}
+            yield {"content": "y"}
+
+        return _gen()
+
+    svc = GenerationService(DummySearchEngine([_msg()]), provider_callable=provider)
+
+    updates = await _drain(svc)
+
+    assert updates[-1]["generated_text"] == "xy"
+    assert all(u["delta"] for u in updates)
+    assert "None" not in updates[-1]["generated_text"]
+
+
+async def test_sync_iterator_none_chunks_skipped():
+    """The synchronous-iterator branch must also drop ``None``/empty chunks."""
+
+    def provider(prompt: str = "", **kwargs):
+        return iter(["x", None, "", "y"])
+
+    svc = GenerationService(DummySearchEngine([_msg()]), provider_callable=provider)
+
+    updates = await _drain(svc)
+
+    assert updates[-1]["generated_text"] == "xy"
+    assert [u["delta"] for u in updates] == ["x", "y"]

--- a/tests/test_generation_service_streaming_edge_cases.py
+++ b/tests/test_generation_service_streaming_edge_cases.py
@@ -115,6 +115,45 @@ async def test_midstream_break_first_chunk_yields_error_marker():
     assert updates[0]["stream_error"]
 
 
+async def test_generate_stream_true_raises_on_midstream_break():
+    """``generate(stream=True)`` must NOT report a truncated run as success.
+
+    ``generate_stream`` surfaces partial text gracefully for interactive consumers,
+    but the aggregating ``generate(stream=True)`` API is consumed by
+    ``ContentGenerationService`` which persists its return value as a completed run.
+    A mid-stream failure there must raise so the run is marked failed, not saved as
+    a completed generation with truncated text (issue #1034, cycle-review).
+    """
+
+    async def provider(prompt: str = "", **kwargs):
+        async def _gen():
+            yield "partial "
+            raise ConnectionError("dropped mid-stream")
+
+        return _gen()
+
+    svc = GenerationService(DummySearchEngine([_msg()]), provider_callable=provider)
+
+    with pytest.raises(RuntimeError, match="Streaming generation failed"):
+        await svc.generate(query="q", prompt_template="Use {source_messages}", stream=True)
+
+
+async def test_generate_stream_true_succeeds_without_break():
+    """Regression guard: a clean stream still returns the aggregated text."""
+
+    async def provider(prompt: str = "", **kwargs):
+        async def _gen():
+            yield "all "
+            yield "good"
+
+        return _gen()
+
+    svc = GenerationService(DummySearchEngine([_msg()]), provider_callable=provider)
+
+    out = await svc.generate(query="q", prompt_template="Use {source_messages}", stream=True)
+    assert out["generated_text"] == "all good"
+
+
 async def test_successful_stream_has_no_partial_flag():
     """Regression guard: a clean stream must NOT be flagged partial.
 

--- a/tests/test_provider_adapters.py
+++ b/tests/test_provider_adapters.py
@@ -412,6 +412,80 @@ async def test_generic_http_adapter_error(monkeypatch):
     assert "502" in str(exc_info.value)
 
 
+# === 200-with-unexpected-content-type guard (issue #1034) ===
+#
+# A provider can answer 200 OK but with a non-JSON body (an HTML error page, an
+# SSE stream, a captcha). ``resp.json()`` then raises ``aiohttp.ContentTypeError``,
+# which used to escape the adapter raw — leaking aiohttp internals to callers and
+# carrying no provider context. The adapter must wrap it in a RuntimeError that
+# names the unexpected content-type and includes a body preview, matching how the
+# non-200 path already surfaces ``RuntimeError(f"Provider error {status}: ...")``.
+
+
+class _NonJSONResp:
+    """200 OK whose ``.json()`` raises ContentTypeError (non-JSON body)."""
+
+    def __init__(self, body: str, content_type: str = "text/html"):
+        self.status = 200
+        self.content_type = content_type
+        self._body = body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def text(self):
+        return self._body
+
+    async def json(self):
+        from multidict import CIMultiDict, CIMultiDictProxy
+        from yarl import URL
+
+        request_info = aiohttp.RequestInfo(
+            url=URL("https://api.example.com/generate"),
+            method="POST",
+            headers=CIMultiDictProxy(CIMultiDict()),
+            real_url=URL("https://api.example.com/generate"),
+        )
+        raise aiohttp.ContentTypeError(
+            request_info=request_info,
+            history=(),
+            message=f"Attempt to decode JSON with unexpected mimetype: {self.content_type}",
+        )
+
+
+@pytest.mark.anyio
+async def test_generic_http_adapter_200_non_json_content_type(monkeypatch):
+    """200 OK with a non-JSON body surfaces a RuntimeError, not a raw ContentTypeError."""
+    resp = _NonJSONResp("<html><body>error page</body></html>", content_type="text/html")
+    monkeypatch.setattr("aiohttp.ClientSession", fake_client_session_factory(resp))
+    adapter = make_generic_http_adapter("https://api.example.com/generate")
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await adapter("prompt")
+
+    # Must NOT be the raw aiohttp error; must carry provider context.
+    assert not isinstance(exc_info.value, aiohttp.ContentTypeError)
+    msg = str(exc_info.value)
+    assert "text/html" in msg, "the unexpected content-type should be reported"
+
+
+@pytest.mark.anyio
+async def test_generic_http_adapter_200_sse_content_type(monkeypatch):
+    """An SSE 200 body (text/event-stream) is also wrapped cleanly."""
+    resp = _NonJSONResp("data: chunk\n\n", content_type="text/event-stream")
+    monkeypatch.setattr("aiohttp.ClientSession", fake_client_session_factory(resp))
+    adapter = make_generic_http_adapter("https://api.example.com/generate")
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await adapter("prompt")
+
+    assert not isinstance(exc_info.value, aiohttp.ContentTypeError)
+    assert "text/event-stream" in str(exc_info.value)
+
+
 # === Retry/billing regression guards: raw-HTTP adapters issue exactly one POST ===
 #
 # The image/LLM POST is non-idempotent and billed per request, so a transient


### PR DESCRIPTION
## Что и зачем

Тир-2 баг-хант (эпик #1024). Покрыл AI-генерацию контента падающими тестами и починил **4 реальных бага**. Каждый фикс: red → green → доказан **мутацией продкода** (тест краснеет при поломке фикса, не false-confidence).

### Найденные и исправленные баги

| # | Баг | Файл | Issue п. |
|---|-----|------|----------|
| **A** | Обрыв потока mid-stream (`ConnectionError`/`asyncio.TimeoutError`) пробрасывал исключение и **терял частичный текст** | `generation_service.py` | 1 |
| **B** | `None`/пустые чанки → литерал `"None"` попадал в `generated_text` (`"aNoneb"`) | `generation_service.py` | 1 |
| **C** | Одно сообщение дважды (hybrid+FTS overlap) → **дублирующиеся цитаты** | `generation_service.py` | 3 |
| **D** | 200 с не-JSON content-type → сырой `aiohttp.ContentTypeError` утекал к вызывающему | `provider_adapters.py` | 2 |

**Фиксы:**
- **A** — `try/except` вокруг `async for`; при обрыве отдаётся финальный update с `partial=True`/`stream_error`, накопленный буфер сохраняется. _Дизайн-развилка решена владельцем — graceful recovery (возврат частичного текста)._
- **B** — статик-хелпер `_extract_delta(chunk)`: `None`/пустые → пропуск в **обеих** ветках (async + sync iterator).
- **C** — `_build_citations(messages)` дедуп по `(channel_id, message_id)` с сохранением порядка (channel обязателен в ключе — `message_id` уникален только в рамках канала).
- **D** — `except aiohttp.ContentTypeError` → `RuntimeError` с content-type и превью тела, симметрично существующему non-200 пути.

### Регресс-гарды (поведение уже корректно — src не тронут, доказано мутацией)
- null-поля `Message` (`channel_title=None`) degrade gracefully;
- `resolve_retrieval_scope` **fail-closed**: ошибка scope → `channel_id=None`; multi-source → `channel_id=None` (нет cross-channel leak, ср. #1037/#1077).

### Live-часть
`tests/test_generation_service_live.py` — opt-in за `RUN_REAL_PROVIDER_SMOKE=1` + ключ, маркер `real_provider_smoke`, **скипается без гейта**. Реальные API-вызовы в CI не делаются; живой LLM-прогон не запускался (нет согласия владельца в этой задаче).

## Тесты
- Новые: `test_generation_service_streaming_edge_cases.py`, `test_generation_service_rag_context.py`, `test_generation_service_live.py` + доп. в `test_provider_adapters.py`.
- Полный прогон: **8559 passed** (parallel-safe) + **934 passed** (serial), 0 failed. ruff чисто, новых mypy-ошибок в изменённых src нет.

Closes #1034

🤖 Generated with [Claude Code](https://claude.com/claude-code)