### PR TITLE
docs(autodoc): mkdocstrings — API reference from docstrings (#1071)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,16 @@ jobs:
         continue-on-error: true
         run: python scripts/doc_coverage.py --path src
 
+      # Гейт строгой сборки доков (#1071). Тестовые job'ы ставят только [dev],
+      # где нет mkdocs/mkdocstrings, поэтому build-тест в test_docs_api_reference.py
+      # там пропускается — strict-сборка не была бы PR-гейтом, а ловилась бы лишь
+      # post-merge в docs.yml. Ставим [docs] здесь и гоняем `mkdocs build --strict`
+      # напрямую, чтобы битые ссылки / нерезолвленные autoref'ы валили PR заранее.
+      - name: Docs build (strict)
+        run: |
+          pip install -e ".[docs]"
+          mkdocs build --strict
+
       - name: Enforce pytest warnings as errors
         run: |
           python - <<'PY'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - "docs/**"
       - "mkdocs.yml"
+      # autodoc (mkdocstrings) рендерит API-страницы из docstring в src/,
+      # поэтому изменения кода тоже должны пере-деплоить доки (#1071).
+      - "src/**"
+      - ".github/workflows/docs.yml"
   workflow_dispatch:
 
 permissions:
@@ -30,11 +34,15 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install mkdocs-material
-        run: pip install mkdocs-material
+      - name: Install docs dependencies
+        # mkdocstrings[python] нужен для autodoc API-страниц из docstring (#1071);
+        # держим список в синхроне с pyproject.toml [project.optional-dependencies].docs.
+        run: pip install mkdocs-material 'mkdocstrings[python]>=0.25.0'
 
       - name: Build docs
-        run: mkdocs build
+        # --strict: падать на любых warning (битые ссылки, нерезолвленные
+        # autoref'ы mkdocstrings) — autodoc API-страниц обязан собираться чисто.
+        run: mkdocs build --strict
 
       - uses: actions/upload-pages-artifact@v5
         with:

--- a/docs/reference/api/agent-tools-api.md
+++ b/docs/reference/api/agent-tools-api.md
@@ -1,0 +1,53 @@
+# Agent Tools API
+
+Инструменты AI-агента (`src/agent/tools/`) — модульные файлы, каждый из которых
+регистрирует группу `@tool()`-функций через `register()`. Декларации категорий
+(`TOOL_GROUPS`) — единый источник истины для прав доступа (READ/WRITE/DELETE),
+из которого `permissions.py` выводит ACL.
+
+!!! note
+    Описания самих инструментов задаются строковыми аргументами декоратора
+    `@tool("name", "description", ...)`, а не Python docstring, поэтому autodoc
+    показывает структуру модуля (`register`, `TOOL_GROUPS`), а полный
+    человекочитаемый каталог инструментов — в
+    [Agent Tools Reference](../agent-tools.md).
+
+## Каналы
+
+::: src.agent.tools.channels
+
+## Поиск
+
+::: src.agent.tools.search
+
+## Контент-пайплайны
+
+::: src.agent.tools.pipelines
+
+## Изображения
+
+::: src.agent.tools.images
+
+## Сообщения
+
+::: src.agent.tools.messaging
+
+## Коллекция
+
+::: src.agent.tools.collection
+
+## Аналитика
+
+::: src.agent.tools.analytics
+
+## Модерация
+
+::: src.agent.tools.moderation
+
+## Фильтры
+
+::: src.agent.tools.filters
+
+## Права доступа
+
+::: src.agent.tools.permissions

--- a/docs/reference/api/cli-internals.md
+++ b/docs/reference/api/cli-internals.md
@@ -1,0 +1,41 @@
+# CLI Internals
+
+Внутренности CLI (`src/cli/`) — обвязка runtime (логирование, PII-редакция),
+разбор аргументов и обработчики команд. Человекочитаемый справочник команд —
+в [CLI Reference](../cli.md); эта страница документирует Python-API из docstring.
+
+!!! note
+    Многие обработчики команд и парсеры пока без docstring — autodoc показывает
+    их сигнатуры, описания появятся по мере наполнения (issue #1072).
+
+## Runtime
+
+Логирование и PII-редакция вывода CLI.
+
+::: src.cli.runtime
+
+## Разбор аргументов
+
+::: src.cli.parser
+
+## Точка входа
+
+::: src.cli.main
+
+## Обработчики команд
+
+### Каналы
+
+::: src.cli.commands.channel
+
+### Сбор
+
+::: src.cli.commands.collect
+
+### Пайплайны
+
+::: src.cli.commands.pipeline
+
+### Поиск
+
+::: src.cli.commands.search

--- a/docs/reference/api/index.md
+++ b/docs/reference/api/index.md
@@ -1,0 +1,23 @@
+# API Reference
+
+Автоматически сгенерированная документация Python-API из docstring через
+[mkdocstrings](https://mkdocstrings.github.io/). Эти страницы покрывают
+**не-FastAPI поверхности**, которые не попадают в FastAPI `/docs`
+(см. [parity-матрицу](../parity.md)):
+
+- **[Services](services.md)** — сервисный слой (`src/services/`): оркестрация
+  сбора, пайплайнов, генерации контента, изображений, уведомлений, провайдеров.
+- **[Agent Tools](agent-tools-api.md)** — инструменты AI-агента
+  (`src/agent/tools/`): каналы, поиск, пайплайны, изображения и др.
+- **[CLI Internals](cli-internals.md)** — внутренности CLI (`src/cli/`):
+  runtime-обвязка и обработчики команд.
+
+!!! note "Покрытие docstring"
+    Страницы рендерят и символы без docstring (`show_if_no_docstring`), поэтому
+    список API полон, но описания появляются по мере наполнения docstring.
+    Поднятие покрытия отслеживается отдельно — interrogate, issue #1072.
+
+!!! tip "Где смотреть REST API"
+    HTTP-эндпоинты FastAPI документируются автоматически в Swagger UI по адресу
+    `/docs` запущенного веб-сервера; ручной обзор — в
+    [Web API Reference](../web-api.md).

--- a/docs/reference/api/services.md
+++ b/docs/reference/api/services.md
@@ -1,0 +1,59 @@
+# Services
+
+Сервисный слой (`src/services/`) — оркестрация между CLI/Web и доменной логикой
+(Telegram, поиск, БД). Каждый раздел рендерит публичные классы и методы сервиса
+из docstring.
+
+## Сбор сообщений
+
+::: src.services.collection_service
+
+## Контент-пайплайны
+
+::: src.services.pipeline_service
+
+::: src.services.pipeline_executor
+
+## Генерация контента
+
+::: src.services.content_generation_service
+
+::: src.services.generation_service
+
+## Генерация изображений
+
+::: src.services.image_generation_service
+
+## Провайдеры
+
+::: src.services.provider_service
+
+## Каналы
+
+::: src.services.channel_service
+
+## Уведомления
+
+::: src.services.notification_service
+
+## Поиск
+
+::: src.services.search_service
+
+## Эмбеддинги
+
+::: src.services.embedding_service
+
+## Экспорт
+
+::: src.services.export_service
+
+## Публикация фото
+
+::: src.services.photo_publish_service
+
+::: src.services.photo_auto_upload_service
+
+## Диспетчеризация задач
+
+::: src.services.unified_dispatcher

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,25 @@ theme:
 
 plugins:
   - search
+  # Авто-генерация API-страниц из Python docstring для не-FastAPI поверхностей
+  # (сервисы, agent-tools, CLI-internals) — закрывает дыру parity-матрицы #1048.
+  # show_if_no_docstring=true: рендерим символы и без docstring, чтобы сборка не
+  # падала на ещё недокументированных модулях (поднятие покрытия — отдельно, #1072).
+  - mkdocstrings:
+      default_handler: python
+      handlers:
+        python:
+          paths: [.]
+          options:
+            docstring_style: google
+            show_source: false
+            show_if_no_docstring: true
+            show_root_heading: true
+            show_root_full_path: true
+            members_order: source
+            separate_signature: true
+            merge_init_into_class: true
+            show_submodules: false
 
 markdown_extensions:
   - tables
@@ -70,6 +89,11 @@ nav:
     - Agent Tools: reference/agent-tools.md
     - RSS / Atom Feeds: reference/rss-feeds.md
     - Doc-coverage: reference/doc-coverage.md
+  - API Reference:
+    - Overview: reference/api/index.md
+    - Services: reference/api/services.md
+    - Agent Tools: reference/api/agent-tools-api.md
+    - CLI Internals: reference/api/cli-internals.md
   - Architecture: architecture.md
   - Service Map: feature-map.md
   - Parity Matrix: parity-matrix.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ dev = [
     "playwright>=1.59.0",
     "pytest-playwright>=0.8.0",
 ]
-docs = ["mkdocs-material>=9.7.6"]
+docs = ["mkdocs-material>=9.7.6", "mkdocstrings[python]>=0.25.0"]
 # Codex SDK image provider + agent backend. Optional: all imports are lazy, so
 # without this group the codex provider/backend simply don't register.
 codex = ["openai-codex>=0.1.0b2"]

--- a/tests/test_docs_api_reference.py
+++ b/tests/test_docs_api_reference.py
@@ -38,12 +38,15 @@ _EXPECTED_PAGES = {
     "cli-internals.md": ["src.cli.runtime", "src.cli.commands.channel"],
 }
 
-# Символы, которые должны попасть в собранный HTML (доказывает, что griffe
-# действительно прошёл модули, а не просто срендерил пустой заголовок).
+# Anchor-id отрендеренных символов, которые griffe обязан вытащить из каждой из
+# трёх поверхностей (сервисы + agent-tools). Проверяем именно `id="..."` heading,
+# а не просто вхождение имени: имя могло бы случайно встретиться в подсвеченном
+# исходнике (напр. строка-ключ словаря), что доказывало бы не то. Эти три —
+# настоящие documented-символы (класс / module-level переменная).
 _EXPECTED_RENDERED_SYMBOLS = [
-    "CollectionService",
-    "PipelineService",
-    "list_channels",
+    'id="src.services.collection_service.CollectionService"',
+    'id="src.services.pipeline_service.PipelineService"',
+    'id="src.agent.tools.channels.TOOL_GROUPS"',
 ]
 
 

--- a/tests/test_docs_api_reference.py
+++ b/tests/test_docs_api_reference.py
@@ -1,0 +1,181 @@
+"""Тесты автодоков API-reference через mkdocstrings (#1071, эпик #1022).
+
+mkdocstrings подключён к mkdocs, чтобы генерировать API-страницы из Python
+docstring для не-FastAPI поверхностей (сервисы, agent-tools, CLI-internals).
+Эти тесты — TDD-якорь конфиг-задачи: они фиксируют, что
+
+  1. mkdocs.yml включает handler mkdocstrings и nav-секцию «API Reference»;
+  2. reference-страницы существуют и ссылаются на ожидаемые модули через
+     `::: src.<module>` синтаксис;
+  3. `mkdocs build` проходит без ошибок и реально рендерит ожидаемые символы
+     (классы/функции) в собранный site/ — то есть autodoc-pipeline жив.
+
+Сборку (шаг 3) гоняем один раз в самом тяжёлом тесте: он помечен медленным и
+изолированным, потому что поднимает griffe-обход всего пакета src/.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+_ROOT = Path(__file__).resolve().parents[1]
+_MKDOCS_YML = _ROOT / "mkdocs.yml"
+_API_DIR = _ROOT / "docs" / "reference" / "api"
+
+# Страницы фасадов и символы, которые на них обязаны отрендериться. Опираемся на
+# хорошо документированные поверхности (agent-tools, сервисы), чтобы autodoc
+# имел что показывать; конкретные имена — публичные точки входа, которые вряд ли
+# исчезнут без сознательного рефакторинга (и тогда тест справедливо упадёт).
+_EXPECTED_PAGES = {
+    "services.md": ["src.services.collection_service", "src.services.pipeline_service"],
+    "agent-tools-api.md": ["src.agent.tools.channels", "src.agent.tools.search"],
+    "cli-internals.md": ["src.cli.runtime", "src.cli.commands.channel"],
+}
+
+# Символы, которые должны попасть в собранный HTML (доказывает, что griffe
+# действительно прошёл модули, а не просто срендерил пустой заголовок).
+_EXPECTED_RENDERED_SYMBOLS = [
+    "CollectionService",
+    "PipelineService",
+    "list_channels",
+]
+
+
+def _load_mkdocs_config() -> dict:
+    # mkdocs.yml содержит !!python/name-теги material — грузим небезопасным
+    # загрузчиком, как это делает сам mkdocs.
+    with _MKDOCS_YML.open(encoding="utf-8") as fh:
+        return yaml.unsafe_load(fh)
+
+
+def _plugins_list(config: dict) -> list:
+    return config.get("plugins") or []
+
+
+def _mkdocstrings_entry(config: dict):
+    for plugin in _plugins_list(config):
+        if isinstance(plugin, dict) and "mkdocstrings" in plugin:
+            return plugin["mkdocstrings"]
+        if plugin == "mkdocstrings":
+            return {}
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# mkdocs.yml — плагин и nav
+# --------------------------------------------------------------------------- #
+
+
+def test_mkdocstrings_plugin_enabled() -> None:
+    config = _load_mkdocs_config()
+    assert _mkdocstrings_entry(config) is not None, "mkdocstrings не подключён в mkdocs.yml plugins"
+
+
+def test_mkdocstrings_uses_python_handler() -> None:
+    config = _load_mkdocs_config()
+    entry = _mkdocstrings_entry(config)
+    assert isinstance(entry, dict)
+    handlers = entry.get("handlers", {})
+    assert "python" in handlers, "не настроен python-handler mkdocstrings"
+
+
+def test_mkdocstrings_tolerates_missing_docstrings() -> None:
+    """show_if_no_docstring=true — autodoc рендерит символы и без docstring.
+
+    Без этого `mkdocs build` упал бы на сотнях недокументированных символов;
+    дописывание docstring до 100% — отдельная задача #1072 (interrogate).
+    """
+    config = _load_mkdocs_config()
+    entry = _mkdocstrings_entry(config)
+    assert isinstance(entry, dict)
+    options = entry["handlers"]["python"].get("options", {})
+    assert options.get("show_if_no_docstring") is True
+
+
+def test_api_reference_section_in_nav() -> None:
+    config = _load_mkdocs_config()
+
+    def _walk(node) -> bool:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if key == "API Reference":
+                    return True
+                if _walk(value):
+                    return True
+        elif isinstance(node, list):
+            return any(_walk(item) for item in node)
+        return False
+
+    assert _walk(config.get("nav", [])), "в nav нет секции «API Reference»"
+
+
+# --------------------------------------------------------------------------- #
+# reference-страницы существуют и ссылаются на модули
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("page", sorted(_EXPECTED_PAGES))
+def test_api_page_exists(page: str) -> None:
+    assert (_API_DIR / page).is_file(), f"нет страницы автодоков docs/reference/api/{page}"
+
+
+@pytest.mark.parametrize(("page", "modules"), sorted(_EXPECTED_PAGES.items()))
+def test_api_page_references_modules(page: str, modules: list[str]) -> None:
+    text = (_API_DIR / page).read_text(encoding="utf-8")
+    for module in modules:
+        assert f"::: {module}" in text, f"в {page} нет директивы `::: {module}`"
+
+
+def test_api_pages_wired_into_nav() -> None:
+    """Каждая api-страница присутствует в nav (иначе она не попадёт в сборку)."""
+    config = _load_mkdocs_config()
+    nav_text = yaml.safe_dump(config.get("nav", []), allow_unicode=True)
+    for page in _EXPECTED_PAGES:
+        assert f"reference/api/{page}" in nav_text, f"{page} не подключена в nav"
+
+
+# --------------------------------------------------------------------------- #
+# end-to-end: mkdocs build зелёный и рендерит символы
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.integration
+def test_mkdocs_build_renders_api_symbols(tmp_path: Path) -> None:
+    """`mkdocs build --strict` проходит и autodoc рендерит ожидаемые символы.
+
+    --strict — критерий приёмки #1071: сборка обязана быть чистой от warning
+    (битые ссылки, нерезолвленные autoref'ы). Дорогой тест: griffe обходит весь
+    пакет src/. Гоняем в изолированный site-dir внутри tmp_path, чтобы не трогать
+    рабочую site/.
+    """
+    pytest.importorskip("mkdocstrings")
+    pytest.importorskip("mkdocstrings_handlers.python", reason="нужен python-handler mkdocstrings")
+
+    if shutil.which("mkdocs") is None:
+        pytest.skip("mkdocs CLI недоступен")
+
+    site_dir = tmp_path / "site"
+    result = subprocess.run(
+        [sys.executable, "-m", "mkdocs", "build", "--strict", "--site-dir", str(site_dir)],
+        cwd=_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert result.returncode == 0, f"mkdocs build --strict упал:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+
+    # Собранные api-страницы существуют и содержат отрендеренные символы.
+    rendered = ""
+    for page in _EXPECTED_PAGES:
+        html = site_dir / "reference" / "api" / page.replace(".md", "") / "index.html"
+        assert html.is_file(), f"страница {page} не собралась в site/"
+        rendered += html.read_text(encoding="utf-8")
+
+    for symbol in _EXPECTED_RENDERED_SYMBOLS:
+        assert symbol in rendered, f"символ {symbol} не отрендерился в собранных api-страницах"


### PR DESCRIPTION
## Что и зачем

Часть эпика автодоков **#1022**. Подключает [mkdocstrings](https://mkdocstrings.github.io/) к существующему mkdocs для авто-генерации API-страниц из Python docstring для **не-FastAPI поверхностей**: сервисы, agent-tools, CLI-internals. Закрывает дыру [parity-матрицы #1048](https://github.com/axisrow/tg_content_factory/issues/1048) — то, что НЕ попадает в FastAPI `/docs`.

## Изменения

| Файл | Что |
|------|-----|
| `pyproject.toml` `[docs]` | `+ mkdocstrings[python]>=0.25.0` |
| `mkdocs.yml` | плагин mkdocstrings (python-handler, google-style) + nav-секция **API Reference** |
| `docs/reference/api/{index,services,agent-tools-api,cli-internals}.md` | фасады `::: src.<module>` |
| `.github/workflows/docs.yml` | установка mkdocstrings; `mkdocs build --strict`; триггер расширен на `src/**` |
| `tests/test_docs_api_reference.py` | TDD-якорь (12 тестов) |

## Ключевые решения

- **`show_if_no_docstring: true`** — autodoc рендерит символы и без docstring, поэтому сборка не падает на ещё недокументированных модулях. Покрытие docstring (interrogate) — отдельная задача **#1072**, не смешиваем.
- **`--strict` в CI**: сборка проходит чисто (0 warnings), поэтому включаем strict-режим как гарантию против битых ссылок и нерезолвленных autoref'ов. Это критерий приёмки issue.
- **Триггер `docs.yml` += `src/**`**: раз autodoc читает docstring из `src/`, изменения кода теперь пере-деплоят доки.

## Verification

- `mkdocs build --strict` — зелёный, 0 warnings.
- Отрендерено **257** уникальных символов; docstring-описания реально видны (ContentGenerationService, image `provider:model_id`, export «offline orchestration», agent `Register …`, CLI PII-redact).
- `tests/test_docs_api_reference.py` — 12 passed (включая e2e build-тест под `--strict`).
- `ruff check src/ tests/ conftest.py` — чисто. Smoke gate — зелёный.

Closes #1071

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVVpxHKdndJCfg2kwE72ey