### PR TITLE
docs(openapi): annotate REST/JSON endpoints for Swagger /docs (#1070)

### DIFF
--- a/src/web/app.py
+++ b/src/web/app.py
@@ -37,6 +37,7 @@ from src.web.panel_auth import (
 )
 from src.web.paths import TEMPLATES_DIR
 from src.web.routes.import_channels import MAX_IMPORT_FILE_BYTES
+from src.web.schemas import OPENAPI_TAGS
 from src.web.snapshot_refresher import SnapshotRefresher
 from src.web.template_globals import configure_template_globals
 
@@ -379,7 +380,16 @@ def create_app(config: AppConfig | None = None) -> FastAPI:
     if config is None:
         config = load_config()
 
-    app = FastAPI(title="TG Post Search", lifespan=lifespan)
+    app = FastAPI(
+        title="TG Post Search",
+        lifespan=lifespan,
+        description=(
+            "REST/JSON endpoints (the `/api/*`-style routes documented here) are "
+            "intended for programmatic consumers. HTML/HTMX routes that render the "
+            "human-facing web UI are omitted from this schema."
+        ),
+        openapi_tags=OPENAPI_TAGS,
+    )
     app.state.config = config
     app.state.log_buffer = build_log_buffer()
     app.state.timing_buffer = build_timing_buffer()

--- a/src/web/assembly.py
+++ b/src/web/assembly.py
@@ -11,6 +11,7 @@ from fastapi.templating import Jinja2Templates
 from src.web.container import AppContainer
 from src.web.panel_auth import get_cookie_user, sanitize_next, set_session_cookie
 from src.web.paths import DATA_IMAGE_DIR, STATIC_DIR, TEMPLATES_DIR
+from src.web.schemas.common import HealthResponse
 from src.web.session import COOKIE_NAME
 from src.web.template_globals import configure_template_globals
 
@@ -64,8 +65,19 @@ def configure_app(app: FastAPI, container: AppContainer | None) -> None:
 
 
 def register_builtin_endpoints(app: FastAPI) -> None:
-    @app.get("/health")
+    @app.get(
+        "/health",
+        response_model=HealthResponse,
+        status_code=200,
+        tags=["health"],
+        summary="Liveness/readiness probe",
+    )
     async def health_check(request: Request):
+        """Report process health: DB reachability and number of connected accounts.
+
+        Returns ``status='healthy'`` when the SQLite probe succeeds, else
+        ``'degraded'`` (still HTTP 200 — this is a liveness signal, not a gate).
+        """
         container = getattr(request.app.state, "container", None)
         if container is None:
             from src.web import deps

--- a/src/web/routes/accounts.py
+++ b/src/web/routes/accounts.py
@@ -8,6 +8,8 @@ from fastapi.responses import JSONResponse, RedirectResponse
 from src.agent.runtime_context import AgentRuntimeContext
 from src.agent.tools.accounts import get_live_account_info_text
 from src.web import deps
+from src.web.schemas.accounts import AccountInfoResponse, FloodStatusItem
+from src.web.schemas.common import ErrorResponse
 
 router = APIRouter()
 
@@ -78,8 +80,19 @@ async def set_primary_account(request: Request, account_id: int):
     return RedirectResponse(url="/settings?msg=account_set_primary", status_code=303)
 
 
-@router.get("/flood-status")
+@router.get(
+    "/flood-status",
+    response_model=list[FloodStatusItem],
+    status_code=200,
+    tags=["accounts"],
+    summary="List per-account flood-wait status",
+)
 async def flood_status(request: Request):
+    """Return flood-wait status for every account (parity with CLI `account flood-status`).
+
+    Each item is 'ok' when the account is not rate-limited, otherwise carries the
+    flood-wait expiry and remaining seconds.
+    """
     db = deps.get_db(request)
     accounts = await db.get_account_summaries()
     now = datetime.now(timezone.utc)
@@ -106,9 +119,19 @@ async def flood_status(request: Request):
     return JSONResponse(result)
 
 
-@router.get("/{account_id}/info")
+@router.get(
+    "/{account_id}/info",
+    response_model=AccountInfoResponse,
+    status_code=200,
+    tags=["accounts"],
+    summary="Account summary plus live diagnostics",
+    responses={404: {"model": ErrorResponse, "description": "Account not found"}},
+)
 async def account_info(request: Request, account_id: int):
-    """Account summary plus live diagnostics as JSON (parity with CLI `account info`)."""
+    """Account summary plus live diagnostics as JSON (parity with CLI `account info`).
+
+    Returns 404 with ``{"error": "account_not_found"}`` for an unknown id.
+    """
     db = deps.get_db(request)
     accounts = await db.get_account_summaries(active_only=False)
     acc = next((a for a in accounts if a.id == account_id), None)

--- a/src/web/routes/agent.py
+++ b/src/web/routes/agent.py
@@ -8,14 +8,27 @@ from fastapi.responses import HTMLResponse, JSONResponse
 from src.web import deps
 from src.web.agent import handlers
 from src.web.agent.responses import agent_response
+from src.web.schemas.agent import AgentChannelItem, ThreadMessagesResponse
+from src.web.schemas.common import ErrorResponse
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
-@router.get("/threads/{thread_id}/messages", response_class=JSONResponse)
+@router.get(
+    "/threads/{thread_id}/messages",
+    response_class=JSONResponse,
+    response_model=ThreadMessagesResponse,
+    status_code=200,
+    tags=["agent"],
+    summary="List agent thread messages",
+    responses={404: {"model": ErrorResponse, "description": "Thread not found"}},
+)
 async def get_thread_messages(request: Request, thread_id: int):
-    """List messages of an agent thread as JSON (parity with CLI `agent messages`)."""
+    """List messages of an agent thread as JSON (parity with CLI `agent messages`).
+
+    Returns 404 with ``{"error": "thread_not_found"}`` for an unknown thread.
+    """
     db = deps.get_db(request)
     thread = await db.get_agent_thread(thread_id)
     if thread is None:
@@ -53,8 +66,15 @@ async def rename_thread(request: Request, thread_id: int):
     return agent_response(request, await handlers.rename_thread(request, thread_id))
 
 
-@router.get("/channels-json")
+@router.get(
+    "/channels-json",
+    response_model=list[AgentChannelItem],
+    status_code=200,
+    tags=["agent"],
+    summary="List channels for the agent channel picker",
+)
 async def get_channels_json(request: Request):
+    """Return channels available to the agent (id, title, channel_type) as JSON."""
     return agent_response(request, await handlers.get_channels_json(request))
 
 

--- a/src/web/routes/analytics.py
+++ b/src/web/routes/analytics.py
@@ -10,6 +10,21 @@ from src.services.channel_analytics_service import ChannelAnalyticsService
 from src.services.content_analytics_service import ContentAnalyticsService
 from src.services.trend_service import TrendService
 from src.web import deps
+from src.web.schemas.analytics import (
+    ChannelOverviewResponse,
+    ChannelRatingItem,
+    ContentSummary,
+    ContentTypeStat,
+    DailyStat,
+    HourlyMessageItem,
+    MessageVelocityItem,
+    PeakHourItem,
+    PipelineStat,
+    TopMessageItem,
+    TrendingChannelItem,
+    TrendingEmojiItem,
+    TrendingTopicItem,
+)
 
 router = APIRouter()
 
@@ -120,15 +135,27 @@ async def fragment_content_pipelines(request: Request):
     )
 
 
-@router.get("/content/api/summary")
+@router.get(
+    "/content/api/summary",
+    response_model=ContentSummary,
+    status_code=200,
+    tags=["analytics"],
+    summary="Aggregate content generation/publication counters",
+)
 async def api_content_summary(request: Request):
-    """Get content summary statistics as JSON."""
+    """Get content summary statistics as JSON (totals across all pipelines)."""
     db = deps.get_db(request)
     analytics = ContentAnalyticsService(db)
     return JSONResponse(await analytics.get_summary())
 
 
-@router.get("/content/api/types")
+@router.get(
+    "/content/api/types",
+    response_model=list[ContentTypeStat],
+    status_code=200,
+    tags=["analytics"],
+    summary="Engagement grouped by media/content type",
+)
 async def api_content_type_stats(
     request: Request,
     date_from: str = "",
@@ -140,9 +167,15 @@ async def api_content_type_stats(
     return JSONResponse(rows)
 
 
-@router.get("/content/api/pipelines")
+@router.get(
+    "/content/api/pipelines",
+    response_model=list[PipelineStat],
+    status_code=200,
+    tags=["analytics"],
+    summary="Per-pipeline generation statistics",
+)
 async def api_pipeline_stats(request: Request, pipeline_id: int | None = None):
-    """Get pipeline statistics as JSON."""
+    """Get pipeline statistics as JSON (optionally filtered by pipeline_id)."""
     db = deps.get_db(request)
     analytics = ContentAnalyticsService(db)
     stats = await analytics.get_pipeline_stats(pipeline_id)
@@ -160,7 +193,13 @@ async def api_pipeline_stats(request: Request, pipeline_id: int | None = None):
     ])
 
 
-@router.get("/content/api/daily")
+@router.get(
+    "/content/api/daily",
+    response_model=list[DailyStat],
+    status_code=200,
+    tags=["analytics"],
+    summary="Daily generation/publication/rejection stats",
+)
 async def api_daily_stats(request: Request, days: int = 30, pipeline_id: int | None = None):
     """Get daily generation/publication/rejection stats as JSON."""
     db = deps.get_db(request)
@@ -201,7 +240,13 @@ async def fragment_trends_emojis(request: Request, days: int = 7):
     )
 
 
-@router.get("/trends/topics")
+@router.get(
+    "/trends/topics",
+    response_model=list[TrendingTopicItem],
+    status_code=200,
+    tags=["analytics"],
+    summary="Trending topics (keywords)",
+)
 async def api_trending_topics(request: Request, days: int = 7, limit: int = 20):
     """Get trending topics as JSON."""
     db = deps.get_db(request)
@@ -213,7 +258,13 @@ async def api_trending_topics(request: Request, days: int = 7, limit: int = 20):
     return JSONResponse([dataclasses.asdict(row) for row in topics])
 
 
-@router.get("/trends/channels")
+@router.get(
+    "/trends/channels",
+    response_model=list[TrendingChannelItem],
+    status_code=200,
+    tags=["analytics"],
+    summary="Trending channels by average views",
+)
 async def api_trending_channels(request: Request, days: int = 7, limit: int = 10):
     """Get trending channels as JSON."""
     db = deps.get_db(request)
@@ -225,7 +276,13 @@ async def api_trending_channels(request: Request, days: int = 7, limit: int = 10
     return JSONResponse([dataclasses.asdict(row) for row in channels])
 
 
-@router.get("/trends/emojis")
+@router.get(
+    "/trends/emojis",
+    response_model=list[TrendingEmojiItem],
+    status_code=200,
+    tags=["analytics"],
+    summary="Trending reaction emojis",
+)
 async def api_trending_emojis(request: Request, days: int = 7, limit: int = 15):
     """Get trending reaction emojis as JSON."""
     db = deps.get_db(request)
@@ -276,8 +333,15 @@ async def fragment_channel_selector(request: Request, channel_id: int = 0):
     )
 
 
-@router.get("/channels/api/overview")
+@router.get(
+    "/channels/api/overview",
+    response_model=ChannelOverviewResponse,
+    status_code=200,
+    tags=["analytics"],
+    summary="Single-channel summary card",
+)
 async def api_channel_overview(request: Request, channel_id: int, days: int = 30):
+    """Get the summary card for one channel (subscribers, ERR, post counts, averages)."""
     overview = await _svc(request).get_channel_overview(channel_id, days=max(1, days))
     return JSONResponse(dataclasses.asdict(overview))
 
@@ -286,7 +350,13 @@ def _rating_svc(request: Request) -> ChannelAnalysisService:
     return ChannelAnalysisService(deps.get_db(request))
 
 
-@router.get("/channels/api/ratings")
+@router.get(
+    "/channels/api/ratings",
+    response_model=list[ChannelRatingItem],
+    status_code=200,
+    tags=["analytics"],
+    summary="Channel quality ratings (usefulness × genre)",
+)
 async def api_channel_ratings(
     request: Request,
     useful: str | None = None,
@@ -438,7 +508,13 @@ async def api_cross_citations(
     return JSONResponse(data)
 
 
-@router.get("/messages/top")
+@router.get(
+    "/messages/top",
+    response_model=list[TopMessageItem],
+    status_code=200,
+    tags=["analytics"],
+    summary="Top messages by total reactions",
+)
 async def api_messages_top(
     request: Request, limit: int = 20, date_from: str = "", date_to: str = "",
 ):
@@ -449,7 +525,13 @@ async def api_messages_top(
     return JSONResponse(rows)
 
 
-@router.get("/messages/hourly")
+@router.get(
+    "/messages/hourly",
+    response_model=list[HourlyMessageItem],
+    status_code=200,
+    tags=["analytics"],
+    summary="Message distribution by hour-of-day",
+)
 async def api_messages_hourly(
     request: Request,
     date_from: str = "",
@@ -461,7 +543,13 @@ async def api_messages_hourly(
     return JSONResponse(rows)
 
 
-@router.get("/pipelines/stats")
+@router.get(
+    "/pipelines/stats",
+    response_model=list[PipelineStat],
+    status_code=200,
+    tags=["analytics"],
+    summary="Per-pipeline statistics (alias of /content/api/pipelines)",
+)
 async def api_pipeline_stats_alias(request: Request, pipeline_id: int | None = None):
     """Pipeline statistics (parity with CLI `analytics pipeline-stats`)."""
     db = deps.get_db(request)
@@ -469,7 +557,13 @@ async def api_pipeline_stats_alias(request: Request, pipeline_id: int | None = N
     return JSONResponse([dataclasses.asdict(s) for s in stats])
 
 
-@router.get("/messages/velocity")
+@router.get(
+    "/messages/velocity",
+    response_model=list[MessageVelocityItem],
+    status_code=200,
+    tags=["analytics"],
+    summary="Daily message velocity",
+)
 async def api_message_velocity(request: Request, days: int = 30):
     """Daily message velocity (parity with CLI `analytics velocity`)."""
     db = deps.get_db(request)
@@ -477,7 +571,13 @@ async def api_message_velocity(request: Request, days: int = 30):
     return JSONResponse([dataclasses.asdict(v) for v in data])
 
 
-@router.get("/peak-hours")
+@router.get(
+    "/peak-hours",
+    response_model=list[PeakHourItem],
+    status_code=200,
+    tags=["analytics"],
+    summary="Peak posting hours",
+)
 async def api_peak_hours(request: Request, days: int = 30):
     """Peak posting hours (parity with CLI `analytics peak-hours`)."""
     db = deps.get_db(request)

--- a/src/web/routes/calendar.py
+++ b/src/web/routes/calendar.py
@@ -6,6 +6,7 @@ from fastapi.responses import HTMLResponse, JSONResponse
 from src.services.content_calendar_service import ContentCalendarService
 from src.web import deps
 from src.web.query_params import parse_optional_int
+from src.web.schemas.calendar import CalendarDayItem, CalendarEventItem, CalendarStats
 
 router = APIRouter()
 
@@ -68,13 +69,19 @@ async def fragment_upcoming(request: Request, pipeline_id: str | None = None):
     )
 
 
-@router.get("/api/calendar")
+@router.get(
+    "/api/calendar",
+    response_model=list[CalendarDayItem],
+    status_code=200,
+    tags=["calendar"],
+    summary="Calendar grid: events grouped by day",
+)
 async def api_calendar(
     request: Request,
     days: int = Query(default=7, ge=1, le=90),
     pipeline_id: str | None = None,
 ):
-    """Get calendar data as JSON."""
+    """Get calendar data as JSON: each day with its scheduled/produced events."""
     db = deps.get_db(request)
     calendar = ContentCalendarService(db)
     selected_pipeline_id = parse_optional_int(pipeline_id)
@@ -101,13 +108,19 @@ async def api_calendar(
     ])
 
 
-@router.get("/api/upcoming")
+@router.get(
+    "/api/upcoming",
+    response_model=list[CalendarEventItem],
+    status_code=200,
+    tags=["calendar"],
+    summary="Upcoming scheduled publications",
+)
 async def api_upcoming(
     request: Request,
     limit: int = Query(default=20, ge=1, le=200),
     pipeline_id: str | None = None,
 ):
-    """Get upcoming events as JSON."""
+    """Get upcoming events as JSON, ordered by scheduled time."""
     db = deps.get_db(request)
     calendar = ContentCalendarService(db)
     selected_pipeline_id = parse_optional_int(pipeline_id)
@@ -128,9 +141,15 @@ async def api_upcoming(
     ])
 
 
-@router.get("/api/stats")
+@router.get(
+    "/api/stats",
+    response_model=CalendarStats,
+    status_code=200,
+    tags=["calendar"],
+    summary="Calendar moderation-state counters",
+)
 async def api_stats(request: Request):
-    """Get calendar statistics as JSON."""
+    """Get calendar statistics as JSON: pending/approved/published counts."""
     db = deps.get_db(request)
     calendar = ContentCalendarService(db)
     return JSONResponse(await calendar.get_stats())

--- a/src/web/routes/dialogs.py
+++ b/src/web/routes/dialogs.py
@@ -5,6 +5,8 @@ from fastapi.responses import HTMLResponse
 
 from src.web.dialogs import handlers
 from src.web.dialogs.responses import dialog_response
+from src.web.schemas.common import QueuedCommandResponse
+from src.web.schemas.dialogs import BroadcastStatsResponse, ParticipantsResponse
 
 router = APIRouter()
 
@@ -122,8 +124,21 @@ async def download_media(request: Request):
     return dialog_response(request, await handle_download_media(request))
 
 
-@router.get("/participants")
+@router.get(
+    "/participants",
+    response_model=ParticipantsResponse,
+    status_code=200,
+    tags=["dialogs"],
+    summary="List chat participants",
+    responses={202: {"model": QueuedCommandResponse, "description": "Fetch enqueued for the worker"}},
+)
 async def get_participants(request: Request):
+    """Chat participants from the cached worker snapshot (parity with CLI `dialogs participants`).
+
+    Requires ``phone`` and ``chat_id`` query params. When no snapshot is cached
+    the endpoint enqueues a worker command and returns HTTP 202 with a
+    ``{"status": "queued", "command_id": …}`` body instead.
+    """
     return dialog_response(request, await handle_get_participants(request))
 
 
@@ -142,8 +157,21 @@ async def kick_participant(request: Request):
     return dialog_response(request, await handle_kick_participant(request))
 
 
-@router.get("/broadcast-stats")
+@router.get(
+    "/broadcast-stats",
+    response_model=BroadcastStatsResponse,
+    status_code=200,
+    tags=["dialogs"],
+    summary="Channel broadcast statistics",
+    responses={202: {"model": QueuedCommandResponse, "description": "Fetch enqueued for the worker"}},
+)
 async def broadcast_stats(request: Request):
+    """Channel broadcast stats from the cached worker snapshot (parity with CLI `dialogs broadcast-stats`).
+
+    Requires ``phone`` and ``chat_id`` query params. When no snapshot is cached
+    the endpoint enqueues a worker command and returns HTTP 202 with a
+    ``{"status": "queued", "command_id": …}`` body instead.
+    """
     return dialog_response(request, await handlers.broadcast_stats(request))
 
 

--- a/src/web/routes/dialogs.py
+++ b/src/web/routes/dialogs.py
@@ -5,7 +5,7 @@ from fastapi.responses import HTMLResponse
 
 from src.web.dialogs import handlers
 from src.web.dialogs.responses import dialog_response
-from src.web.schemas.common import QueuedCommandResponse
+from src.web.schemas.common import ErrorResponse, QueuedCommandResponse
 from src.web.schemas.dialogs import BroadcastStatsResponse, ParticipantsResponse
 
 router = APIRouter()
@@ -130,7 +130,10 @@ async def download_media(request: Request):
     status_code=200,
     tags=["dialogs"],
     summary="List chat participants",
-    responses={202: {"model": QueuedCommandResponse, "description": "Fetch enqueued for the worker"}},
+    responses={
+        202: {"model": QueuedCommandResponse, "description": "Fetch enqueued for the worker"},
+        400: {"model": ErrorResponse, "description": "Missing phone or chat_id"},
+    },
 )
 async def get_participants(request: Request):
     """Chat participants from the cached worker snapshot (parity with CLI `dialogs participants`).
@@ -163,7 +166,10 @@ async def kick_participant(request: Request):
     status_code=200,
     tags=["dialogs"],
     summary="Channel broadcast statistics",
-    responses={202: {"model": QueuedCommandResponse, "description": "Fetch enqueued for the worker"}},
+    responses={
+        202: {"model": QueuedCommandResponse, "description": "Fetch enqueued for the worker"},
+        400: {"model": ErrorResponse, "description": "Missing phone or chat_id"},
+    },
 )
 async def broadcast_stats(request: Request):
     """Channel broadcast stats from the cached worker snapshot (parity with CLI `dialogs broadcast-stats`).

--- a/src/web/routes/pipelines.py
+++ b/src/web/routes/pipelines.py
@@ -18,6 +18,15 @@ from src.web.pipelines.forms import (
     form_model_dependency,
 )
 from src.web.pipelines.responses import pipeline_response
+from src.web.schemas.common import ErrorResponse
+from src.web.schemas.pipelines import (
+    ChannelSearchItem,
+    PipelineDetailResponse,
+    PipelineQueueResponse,
+    PipelineRunDetailResponse,
+    PipelineRunsResponse,
+    PipelineTemplateItem,
+)
 
 router = APIRouter()
 
@@ -34,8 +43,16 @@ PipelineTemplateCreateFormDep = Annotated[
 PipelineImportFormDep = Annotated[PipelineImportForm, Depends(form_model_dependency(PipelineImportForm))]
 
 
-@router.get("/api/channels/search", response_class=JSONResponse)
+@router.get(
+    "/api/channels/search",
+    response_class=JSONResponse,
+    response_model=list[ChannelSearchItem],
+    status_code=200,
+    tags=["pipelines"],
+    summary="Searchable channel picker",
+)
 async def api_channels_search(request: Request, q: str = ""):
+    """Return up to 50 channels matching *q* for the pipeline source/target picker."""
     return pipeline_response(request, await handlers.api_channels_search(request, q=q))
 
 
@@ -151,12 +168,32 @@ async def get_refinement_steps(request: Request, pipeline_id: int):
     return pipeline_response(request, await handlers.get_refinement_steps(request, pipeline_id))
 
 
-@router.get("/{pipeline_id}/show", response_class=JSONResponse)
+@router.get(
+    "/{pipeline_id}/show",
+    response_class=JSONResponse,
+    response_model=PipelineDetailResponse,
+    status_code=200,
+    tags=["pipelines"],
+    summary="Pipeline configuration detail",
+    responses={404: {"model": ErrorResponse, "description": "Pipeline not found"}},
+)
 async def show_pipeline(request: Request, pipeline_id: int):
+    """Pipeline details as JSON (parity with CLI `pipeline show`).
+
+    Returns 404 with ``{"error": "pipeline_not_found"}`` for an unknown id.
+    """
     return pipeline_response(request, await handlers.show_pipeline(request, pipeline_id))
 
 
-@router.get("/{pipeline_id}/runs", response_class=JSONResponse)
+@router.get(
+    "/{pipeline_id}/runs",
+    response_class=JSONResponse,
+    response_model=PipelineRunsResponse,
+    status_code=200,
+    tags=["pipelines"],
+    summary="Pipeline run history",
+    responses={404: {"model": ErrorResponse, "description": "Pipeline not found"}},
+)
 async def list_pipeline_runs(
     request: Request,
     pipeline_id: int,
@@ -165,6 +202,10 @@ async def list_pipeline_runs(
     status: str | None = None,
     moderation_status: str | None = None,
 ):
+    """Run history for a pipeline (parity with CLI `pipeline runs`).
+
+    Returns 404 with ``{"error": "pipeline_not_found"}`` for an unknown id.
+    """
     return pipeline_response(
         request,
         await handlers.list_pipeline_runs(
@@ -178,13 +219,38 @@ async def list_pipeline_runs(
     )
 
 
-@router.get("/{pipeline_id}/runs/{run_id}", response_class=JSONResponse)
+@router.get(
+    "/{pipeline_id}/runs/{run_id}",
+    response_class=JSONResponse,
+    response_model=PipelineRunDetailResponse,
+    status_code=200,
+    tags=["pipelines"],
+    summary="Single pipeline run detail",
+    responses={404: {"model": ErrorResponse, "description": "Run not found"}},
+)
 async def show_pipeline_run(request: Request, pipeline_id: int, run_id: int):
+    """Run details incl. generated text and image URL (parity with CLI `pipeline run-show`).
+
+    Returns 404 with ``{"error": "run_not_found"}`` if the run is missing or
+    belongs to another pipeline.
+    """
     return pipeline_response(request, await handlers.show_pipeline_run(request, pipeline_id, run_id))
 
 
-@router.get("/{pipeline_id}/queue", response_class=JSONResponse)
+@router.get(
+    "/{pipeline_id}/queue",
+    response_class=JSONResponse,
+    response_model=PipelineQueueResponse,
+    status_code=200,
+    tags=["pipelines"],
+    summary="Pipeline moderation queue",
+    responses={404: {"model": ErrorResponse, "description": "Pipeline not found"}},
+)
 async def pipeline_queue(request: Request, pipeline_id: int, limit: int = 50):
+    """Runs awaiting moderation for a pipeline (parity with CLI `pipeline queue`).
+
+    Returns 404 with ``{"error": "pipeline_not_found"}`` for an unknown id.
+    """
     return pipeline_response(request, await handlers.pipeline_queue(request, pipeline_id, limit=limit))
 
 
@@ -217,8 +283,16 @@ async def templates_page(request: Request):
     return pipeline_response(request, await handlers.templates_page(request))
 
 
-@router.get("/templates/json", response_class=JSONResponse)
+@router.get(
+    "/templates/json",
+    response_class=JSONResponse,
+    response_model=list[PipelineTemplateItem],
+    status_code=200,
+    tags=["pipelines"],
+    summary="List pipeline templates",
+)
 async def templates_json(request: Request):
+    """List available pipeline templates with their serialized graph as JSON."""
     return pipeline_response(request, await handlers.templates_json(request))
 
 

--- a/src/web/routes/search_queries.py
+++ b/src/web/routes/search_queries.py
@@ -1,7 +1,9 @@
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 
+from src.models import SearchQuery, SearchQueryDailyStat
 from src.web import deps
+from src.web.schemas.common import ErrorResponse
 from src.web.search_queries import handlers
 from src.web.search_queries.forms import SearchQueryForm, search_query_form
 from src.web.search_queries.responses import search_query_response
@@ -9,18 +11,40 @@ from src.web.search_queries.responses import search_query_response
 router = APIRouter()
 
 
-@router.get("/{sq_id}", response_class=JSONResponse)
+@router.get(
+    "/{sq_id}",
+    response_class=JSONResponse,
+    response_model=SearchQuery,
+    status_code=200,
+    tags=["search-queries"],
+    summary="Get one saved search query",
+    responses={404: {"model": ErrorResponse, "description": "Search query not found"}},
+)
 async def get_search_query(request: Request, sq_id: int):
-    """Get one search query as JSON (parity with CLI `search-query get`)."""
+    """Get one search query as JSON (parity with CLI `search-query get`).
+
+    Returns 404 with ``{"error": "search_query_not_found"}`` for an unknown id.
+    """
     sq = await deps.search_query_service(request).get(sq_id)
     if sq is None:
         return JSONResponse({"error": "search_query_not_found"}, status_code=404)
     return JSONResponse(sq.model_dump(mode="json"))
 
 
-@router.get("/{sq_id}/stats", response_class=JSONResponse)
+@router.get(
+    "/{sq_id}/stats",
+    response_class=JSONResponse,
+    response_model=list[SearchQueryDailyStat],
+    status_code=200,
+    tags=["search-queries"],
+    summary="Daily match stats for a saved search query",
+    responses={404: {"model": ErrorResponse, "description": "Search query not found"}},
+)
 async def get_search_query_stats(request: Request, sq_id: int, days: int = 30):
-    """Get daily match stats for a search query (parity with CLI `search-query stats`)."""
+    """Get daily match stats for a search query (parity with CLI `search-query stats`).
+
+    Returns 404 with ``{"error": "search_query_not_found"}`` for an unknown id.
+    """
     svc = deps.search_query_service(request)
     if await svc.get(sq_id) is None:
         return JSONResponse({"error": "search_query_not_found"}, status_code=404)

--- a/src/web/schemas/__init__.py
+++ b/src/web/schemas/__init__.py
@@ -1,0 +1,30 @@
+"""Pydantic response models for the FastAPI REST surface (#1070).
+
+These models describe the JSON shapes returned by the ``/api/*``-style REST
+endpoints so that ``/openapi.json`` (and therefore Swagger ``/docs`` + ReDoc)
+carries concrete request/response schemas. They are declared as ``response_model``
+on the corresponding routes.
+
+The routes themselves still return ``JSONResponse`` (raw dict/list) for backward
+compatibility and to avoid re-validating hand-built payloads on the hot path — so
+these models drive the *documentation*, not runtime serialization. They are kept
+faithful to the actual payload shapes (mostly snake_case, nullable where the
+underlying query/service can produce ``None``).
+
+The shared ``OPENAPI_TAGS`` list groups operations in Swagger.
+"""
+
+from __future__ import annotations
+
+# OpenAPI tag groups — surfaced in the Swagger sidebar. Keeping them here keeps
+# the tag vocabulary consistent across routers.
+OPENAPI_TAGS: list[dict[str, str]] = [
+    {"name": "health", "description": "Liveness/readiness probe."},
+    {"name": "accounts", "description": "Telegram account status and diagnostics (REST/JSON)."},
+    {"name": "agent", "description": "Agent threads and channel pickers (REST/JSON)."},
+    {"name": "search-queries", "description": "Saved search queries (REST/JSON)."},
+    {"name": "analytics", "description": "Content/channel/trend analytics (REST/JSON)."},
+    {"name": "calendar", "description": "Content publication calendar (REST/JSON)."},
+    {"name": "pipelines", "description": "Content pipelines: details, runs, queue (REST/JSON)."},
+    {"name": "dialogs", "description": "Telegram dialog data: participants, broadcast stats (REST/JSON)."},
+]

--- a/src/web/schemas/accounts.py
+++ b/src/web/schemas/accounts.py
@@ -1,0 +1,36 @@
+"""REST response schemas for account endpoints (#1070)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class FloodStatusItem(BaseModel):
+    """Flood-wait status of one account (``GET /settings/flood-status``)."""
+
+    phone: str
+    flood_wait_until: str = Field(
+        ...,
+        description="'ok' when not flooded, otherwise the flood-wait expiry as 'YYYY-MM-DD HH:MM:SS UTC'.",
+    )
+    remaining_seconds: int = Field(..., description="Seconds until the flood-wait clears; 0 when not flooded.")
+
+
+class AccountInfoResponse(BaseModel):
+    """Account summary plus live Telegram diagnostics (``GET /settings/{id}/info``).
+
+    The account-summary fields come from ``Account.model_dump`` and vary by
+    schema version, so they are accepted as additional properties; ``live_info``
+    is always present.
+    """
+
+    model_config = {"extra": "allow"}
+
+    live_info: str = Field(..., description="Live Telegram account diagnostics, or an error string.")
+
+    # Common summary fields (subset of Account) surfaced for documentation;
+    # the full Account.model_dump payload is merged in via extra='allow'.
+    id: int | None = None
+    phone: str | None = None
+    is_active: bool | None = None
+    is_primary: bool | None = None

--- a/src/web/schemas/agent.py
+++ b/src/web/schemas/agent.py
@@ -1,0 +1,26 @@
+"""REST response schemas for agent endpoints (#1070)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class ThreadMessagesResponse(BaseModel):
+    """Messages of an agent thread (``GET /agent/threads/{id}/messages``)."""
+
+    thread_id: int
+    title: str | None = None
+    messages: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description="Chronological agent messages (id, role, content, created_at, …).",
+    )
+
+
+class AgentChannelItem(BaseModel):
+    """A channel offered to the agent channel picker (``GET /agent/channels-json``)."""
+
+    id: int = Field(..., description="Telegram channel id.")
+    title: str
+    channel_type: str

--- a/src/web/schemas/analytics.py
+++ b/src/web/schemas/analytics.py
@@ -1,0 +1,155 @@
+"""REST response schemas for analytics endpoints (#1070).
+
+Field names mirror the JSON keys produced by ``src/web/routes/analytics.py``
+(``dataclasses.asdict`` of the analytics dataclasses, ``model_dump`` of Pydantic
+models, or hand-built dicts / raw SQL rows). Nullable where the source query can
+return ``NULL``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+# ── Content ──────────────────────────────────────────────────────────────
+
+
+class ContentSummary(BaseModel):
+    """Aggregate generation/publication counters across all pipelines."""
+
+    total_generations: int
+    total_published: int
+    total_pending: int
+    total_rejected: int
+    pipelines_count: int
+
+
+class ContentTypeStat(BaseModel):
+    """Engagement grouped by media/content type."""
+
+    content_type: str = Field(..., description="Media type, or 'text' for plain messages.")
+    message_count: int
+    avg_reactions: float
+
+
+class PipelineStat(BaseModel):
+    """Per-pipeline generation/publication statistics."""
+
+    pipeline_id: int
+    pipeline_name: str
+    total_generations: int
+    total_published: int
+    total_rejected: int
+    pending_moderation: int
+    success_rate: float
+
+
+class DailyStat(BaseModel):
+    """Daily generation/publication/rejection counts."""
+
+    date: str = Field(..., description="Day in YYYY-MM-DD form.")
+    generations: int
+    publications: int
+    rejections: int
+
+
+# ── Trends ───────────────────────────────────────────────────────────────
+
+
+class TrendingTopicItem(BaseModel):
+    keyword: str
+    count: int
+
+
+class TrendingChannelItem(BaseModel):
+    channel_id: int
+    title: str | None = None
+    username: str | None = None
+    avg_views: float
+    message_count: int
+
+
+class TrendingEmojiItem(BaseModel):
+    emoji: str
+    count: int
+
+
+# ── Channel analytics ────────────────────────────────────────────────────
+
+
+class ChannelOverviewResponse(BaseModel):
+    """Summary card for a single channel (``ChannelOverview`` dataclass)."""
+
+    channel_id: int
+    title: str | None = None
+    username: str | None = None
+    subscriber_count: int | None = None
+    subscriber_delta: int | None = None
+    subscriber_delta_week: int | None = None
+    subscriber_delta_month: int | None = None
+    err: float | None = None
+    err24: float | None = None
+    total_posts: int = 0
+    posts_today: int = 0
+    posts_week: int = 0
+    posts_month: int = 0
+    avg_views: float | None = None
+    avg_forwards: float | None = None
+    avg_reactions: float | None = None
+
+
+class ChannelRatingItem(BaseModel):
+    """One channel quality rating (``ChannelRating`` model, dumped as JSON)."""
+
+    channel_id: int
+    title: str | None = None
+    username: str | None = None
+    useful: str = Field(..., description="'useful' or 'useless'.")
+    genre: str = Field(..., description="ad | infobiz | aggregator | copy | original.")
+    confidence: float = 0.0
+    reason: str | None = None
+    emoji_trash_score: float | None = None
+    flag_count: int = 0
+    n_total: int = 0
+    updated_at: datetime | None = None
+
+
+# ── Messages / misc ──────────────────────────────────────────────────────
+
+
+class TopMessageItem(BaseModel):
+    """Top message by total reactions (raw joined row)."""
+
+    id: int = Field(..., description="DB primary key of the message row.")
+    channel_id: int
+    message_id: int = Field(..., description="Telegram message id.")
+    text: str | None = None
+    media_type: str | None = None
+    date: str | None = None
+    reactions_json: str | None = None
+    channel_title: str | None = None
+    channel_username: str | None = None
+    total_reactions: int = 0
+
+
+class HourlyMessageItem(BaseModel):
+    """Message distribution by hour-of-day."""
+
+    hour: int = Field(..., ge=0, le=23)
+    message_count: int
+    avg_reactions: float
+
+
+class MessageVelocityItem(BaseModel):
+    """Daily message count over a period."""
+
+    date: str = Field(..., description="Day in YYYY-MM-DD form.")
+    count: int
+
+
+class PeakHourItem(BaseModel):
+    """Message count per hour-of-day over a period."""
+
+    hour: int = Field(..., ge=0, le=23)
+    count: int

--- a/src/web/schemas/calendar.py
+++ b/src/web/schemas/calendar.py
@@ -1,0 +1,32 @@
+"""REST response schemas for calendar endpoints (#1070)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class CalendarEventItem(BaseModel):
+    """A scheduled/produced publication shown on the calendar."""
+
+    run_id: int
+    pipeline_id: int
+    pipeline_name: str
+    status: str
+    moderation_status: str
+    scheduled_time: str | None = Field(None, description="ISO 8601 timestamp, or null if unscheduled.")
+    preview: str
+
+
+class CalendarDayItem(BaseModel):
+    """All events for a single calendar day."""
+
+    date: str = Field(..., description="Day in YYYY-MM-DD form.")
+    events: list[CalendarEventItem]
+
+
+class CalendarStats(BaseModel):
+    """Moderation-state counters for the calendar header."""
+
+    pending: int
+    approved: int
+    published: int

--- a/src/web/schemas/common.py
+++ b/src/web/schemas/common.py
@@ -1,0 +1,31 @@
+"""Shared REST response schemas (#1070)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class ErrorResponse(BaseModel):
+    """Generic error envelope returned with a non-2xx status code."""
+
+    error: str = Field(..., description="Machine-readable error code, e.g. 'not_found'.")
+
+
+class QueuedCommandResponse(BaseModel):
+    """Returned with HTTP 202 when a live-Telegram action is enqueued for the worker.
+
+    The web process never opens Telegram connections itself; data-fetching dialog
+    endpoints either serve a cached runtime snapshot (200) or enqueue a command
+    for the worker and return this envelope (202).
+    """
+
+    status: str = Field("queued", description="Always 'queued' for an enqueued command.")
+    command_id: int | str = Field(..., description="Identifier of the enqueued worker command.")
+
+
+class HealthResponse(BaseModel):
+    """Liveness/readiness probe payload (``GET /health``)."""
+
+    status: str = Field(..., description="'healthy' when the DB probe succeeds, else 'degraded'.")
+    db: bool = Field(..., description="Whether the SQLite probe (SELECT 1) succeeded.")
+    accounts_connected: int = Field(..., description="Number of live Telegram clients in the pool.")

--- a/src/web/schemas/dialogs.py
+++ b/src/web/schemas/dialogs.py
@@ -1,0 +1,45 @@
+"""REST response schemas for dialog endpoints (#1070).
+
+The participants/broadcast-stats endpoints serve a cached worker snapshot when
+available (200) or enqueue a worker command and return
+``QueuedCommandResponse`` (202). These models document the 200 success shape.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class DialogParticipant(BaseModel):
+    """A single chat participant."""
+
+    id: int
+    first_name: str = ""
+    last_name: str = ""
+    username: str = ""
+
+
+class ParticipantsResponse(BaseModel):
+    """Chat participants snapshot (``GET /dialogs/participants``, HTTP 200).
+
+    When no snapshot is cached the endpoint instead returns HTTP 202 with a
+    ``QueuedCommandResponse`` body.
+    """
+
+    participants: list[DialogParticipant] = Field(default_factory=list)
+    total: int = 0
+
+
+class BroadcastStatsResponse(BaseModel):
+    """Channel broadcast statistics snapshot (``GET /dialogs/broadcast-stats``, HTTP 200).
+
+    The ``stats`` payload is heterogeneous (per-metric current/previous deltas,
+    period bounds, raw fallback), so it is documented as a free-form object.
+    """
+
+    stats: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Broadcast metrics: followers, views_per_post, period, etc.",
+    )

--- a/src/web/schemas/pipelines.py
+++ b/src/web/schemas/pipelines.py
@@ -37,10 +37,14 @@ class PipelineDetailResponse(BaseModel):
 
 
 class PipelineRunSummary(BaseModel):
-    """Compact run row used in run-history and queue listings."""
+    """Compact run row used in run-history and queue listings.
 
-    id: int
-    pipeline_id: int
+    ``id``/``pipeline_id`` mirror ``GenerationRun`` (``int | None``); both are
+    always set for a persisted run but kept optional to match the source model.
+    """
+
+    id: int | None = None
+    pipeline_id: int | None = None
     status: str
     moderation_status: str
     created_at: str | None = None

--- a/src/web/schemas/pipelines.py
+++ b/src/web/schemas/pipelines.py
@@ -1,0 +1,88 @@
+"""REST response schemas for pipeline endpoints (#1070).
+
+Mirrors the JSON payloads built in ``src/web/pipelines/handlers.py``. Routes
+return ``JSONResponse`` directly, so these models document — they do not
+serialize.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class ChannelSearchItem(BaseModel):
+    """One entry in the searchable channel picker (``GET /pipelines/api/channels/search``)."""
+
+    value: int = Field(..., description="Telegram channel id.")
+    title: str
+    username: str = Field("", description="Channel @username, empty when none.")
+    group: str = Field("channel", description="Picker group label.")
+
+
+class PipelineDetailResponse(BaseModel):
+    """Pipeline configuration detail (``GET /pipelines/{id}/show``)."""
+
+    id: int
+    name: str
+    is_active: bool
+    llm_model: str | None = None
+    publish_mode: str
+    generation_backend: str
+    generate_interval_minutes: int
+    source_ids: list[int] = Field(default_factory=list)
+    source_titles: list[str] = Field(default_factory=list)
+    target_refs: list[Any] = Field(default_factory=list)
+
+
+class PipelineRunSummary(BaseModel):
+    """Compact run row used in run-history and queue listings."""
+
+    id: int
+    pipeline_id: int
+    status: str
+    moderation_status: str
+    created_at: str | None = None
+    published_at: str | None = None
+
+
+class PipelineRunsResponse(BaseModel):
+    """Run history for a pipeline (``GET /pipelines/{id}/runs``)."""
+
+    pipeline_id: int
+    runs: list[PipelineRunSummary] = Field(default_factory=list)
+
+
+class PipelineRunDetailResponse(PipelineRunSummary):
+    """Full run detail (``GET /pipelines/{id}/runs/{run_id}``)."""
+
+    generated_text: str | None = None
+    image_url: str | None = Field(None, description="Image URL; re-signed for S3-backed media.")
+    quality_score: float | None = None
+
+
+class PipelineQueueItem(PipelineRunSummary):
+    """A run awaiting moderation, with a short text preview."""
+
+    preview: str = Field("", description="First 100 chars of the generated text.")
+
+
+class PipelineQueueResponse(BaseModel):
+    """Moderation queue for a pipeline (``GET /pipelines/{id}/queue``)."""
+
+    pipeline_id: int
+    queue: list[PipelineQueueItem] = Field(default_factory=list)
+
+
+class PipelineTemplateItem(BaseModel):
+    """A pipeline template definition (``GET /pipelines/templates/json``)."""
+
+    id: int | None = None
+    name: str
+    description: str | None = None
+    category: str | None = None
+    template_json: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Serialized PipelineGraph (nodes/edges).",
+    )

--- a/tests/routes/test_openapi_rest_schemas.py
+++ b/tests/routes/test_openapi_rest_schemas.py
@@ -1,0 +1,124 @@
+"""OpenAPI completeness contract for the FastAPI REST surface (#1070).
+
+The FastAPI surface (`/api/*`-style JSON/REST routes) is meant for *programmatic*
+consumers (interop with other programs), so its `/openapi.json` schema must
+describe request/response shapes — otherwise `/docs` (Swagger) shows empty
+models and the spec is useless to a client generator.
+
+This module pins, per annotated REST endpoint, that:
+
+1. The operation declares a ``200`` response whose ``application/json`` body
+   references a concrete schema component (``$ref``), not an empty/implicit
+   ``{}``. FastAPI only emits that ``$ref`` when the route carries a
+   ``response_model``; before #1070 none of these routes had one, so the schema
+   was empty and these assertions were red.
+2. The operation carries a human ``summary`` and is grouped under a ``tags``
+   entry, so Swagger lists it sensibly.
+
+HTML/HTMX routes (the human-facing Web surface, ``response_class=HTMLResponse``)
+are intentionally excluded — they need no JSON schema.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.config import AppConfig
+from src.web.app import create_app
+
+# (method, path) of every REST/JSON endpoint annotated under #1070. Paths are the
+# fully-mounted forms (router prefix + route path) as they appear in openapi.json.
+ANNOTATED_REST_ENDPOINTS: list[tuple[str, str]] = [
+    # built-in
+    ("get", "/health"),
+    # accounts (mounted under /settings)
+    ("get", "/settings/flood-status"),
+    ("get", "/settings/{account_id}/info"),
+    # agent
+    ("get", "/agent/threads/{thread_id}/messages"),
+    ("get", "/agent/channels-json"),
+    # search-queries
+    ("get", "/search-queries/{sq_id}"),
+    ("get", "/search-queries/{sq_id}/stats"),
+    # analytics — content
+    ("get", "/analytics/content/api/summary"),
+    ("get", "/analytics/content/api/types"),
+    ("get", "/analytics/content/api/pipelines"),
+    ("get", "/analytics/content/api/daily"),
+    # analytics — trends
+    ("get", "/analytics/trends/topics"),
+    ("get", "/analytics/trends/channels"),
+    ("get", "/analytics/trends/emojis"),
+    # analytics — channels
+    ("get", "/analytics/channels/api/overview"),
+    ("get", "/analytics/channels/api/ratings"),
+    # analytics — messages / misc
+    ("get", "/analytics/messages/top"),
+    ("get", "/analytics/messages/hourly"),
+    ("get", "/analytics/pipelines/stats"),
+    ("get", "/analytics/messages/velocity"),
+    ("get", "/analytics/peak-hours"),
+    # calendar
+    ("get", "/calendar/api/calendar"),
+    ("get", "/calendar/api/upcoming"),
+    ("get", "/calendar/api/stats"),
+    # pipelines (JSON-for-programs)
+    ("get", "/pipelines/api/channels/search"),
+    ("get", "/pipelines/{pipeline_id}/show"),
+    ("get", "/pipelines/{pipeline_id}/runs"),
+    ("get", "/pipelines/{pipeline_id}/runs/{run_id}"),
+    ("get", "/pipelines/{pipeline_id}/queue"),
+    ("get", "/pipelines/templates/json"),
+    # dialogs
+    ("get", "/dialogs/participants"),
+    ("get", "/dialogs/broadcast-stats"),
+]
+
+
+@pytest.fixture(scope="module")
+def openapi_spec() -> dict:
+    """Generate the OpenAPI document from route declarations alone (no DB/pool)."""
+    app = create_app(AppConfig())
+    return app.openapi()
+
+
+def _operation(spec: dict, method: str, path: str) -> dict:
+    paths = spec.get("paths", {})
+    assert path in paths, f"path {path!r} missing from openapi.json"
+    item = paths[path]
+    assert method in item, f"{method.upper()} {path} missing from openapi.json"
+    return item[method]
+
+
+@pytest.mark.parametrize("method,path", ANNOTATED_REST_ENDPOINTS)
+def test_rest_endpoint_has_response_schema(openapi_spec: dict, method: str, path: str) -> None:
+    """Every annotated REST endpoint exposes a concrete 200 JSON response schema."""
+    op = _operation(openapi_spec, method, path)
+    responses = op.get("responses", {})
+    assert "200" in responses, f"{method.upper()} {path}: no 200 response declared"
+    content = responses["200"].get("content", {})
+    assert "application/json" in content, f"{method.upper()} {path}: 200 is not application/json"
+    schema = content["application/json"].get("schema", {})
+    # A response_model produces a $ref (object/list models) or a typed schema.
+    # An un-annotated JSONResponse route produces an empty/absent schema — red.
+    has_concrete_schema = bool(schema) and (
+        "$ref" in schema
+        or schema.get("type") in {"array", "object"}
+        or "items" in schema
+        or "anyOf" in schema
+        or "allOf" in schema
+    )
+    assert has_concrete_schema, (
+        f"{method.upper()} {path}: 200 response has no concrete schema "
+        f"(response_model missing). Got: {schema!r}"
+    )
+
+
+@pytest.mark.parametrize("method,path", ANNOTATED_REST_ENDPOINTS)
+def test_rest_endpoint_has_summary_and_tags(openapi_spec: dict, method: str, path: str) -> None:
+    """Every annotated REST endpoint carries a Swagger summary and a tag group."""
+    op = _operation(openapi_spec, method, path)
+    summary = op.get("summary") or ""
+    assert summary.strip(), f"{method.upper()} {path}: missing summary"
+    tags = op.get("tags") or []
+    assert tags, f"{method.upper()} {path}: missing tags"


### PR DESCRIPTION
## Что и зачем

Часть эпика автодоки **#1022**. FastAPI-поверхность (REST `/api/*`-style JSON-роуты) предназначена для **программ** (interop), но ни один из этих роутов не нёс `response_model` — поэтому `/openapi.json` (а значит Swagger `/docs` + ReDoc) показывал **пустые** схемы request/response, бесполезные для генератора клиента.

Этот PR аннотирует каждый REST/JSON-для-программ эндпоинт из плана #1070: добавлены Pydantic `response_model`, `status_code`, `tags`, `summary` и docstring → схемы в OpenAPI заполнены.

### Почему `response_model` на роутах, которые всё ещё возвращают `JSONResponse`
Роуты продолжают отдавать сырой dict/list (обратная совместимость + не ревалидировать вручную построенный payload на горячем пути). `response_model` управляет **только документацией**. Модели лежат в новом пакете `src/web/schemas/` и точно зеркалят реальные формы payload (дампы dataclass/моделей и сырые SQL-строки). `search-queries` переиспользует существующие Pydantic-модели из `src/models.py` напрямую — чтобы не было дрейфа.

### ⚠️ HTML/HTMX-роуты не тронуты
Поверхность Web для человека (`response_class=HTMLResponse`) — JSON-схема ей не нужна, осознанно вне scope.

## Покрытие
- `/health`
- accounts: `flood-status`, `{id}/info`
- agent: thread messages, `channels-json`
- search-queries: `{id}`, `{id}/stats`
- analytics: content / trends / channels / messages / peak-hours — **14 эндпоинтов**
- calendar: `calendar` / `upcoming` / `stats`
- pipelines: `channels/search`, `show`, `runs`, run detail, `queue`, `templates/json`
- dialogs: `participants`, `broadcast-stats` (+ их 202 queued-command alt-ответ)

8 тег-групп в Swagger; 32 аннотированных операции; 65 моделей в `components.schemas`.

## TDD
`tests/routes/test_openapi_rest_schemas.py` — проверяет через `app.openapi()`, что каждый аннотированный эндпоинт имеет конкретную 200 JSON-схему + summary + tags. **64 кейса**: red до аннотации → green после. **Мутационно верифицировано**: снятие одного `response_model` роняет соответствующий кейс, возврат — снова green.

## Проверки
- ✅ `pytest tests/routes/ -n auto` — 1104 passed; serial — 5 passed; `tests/test_web.py` — 193 passed
- ✅ новый тест — 64 passed, без warnings
- ✅ `ruff check` — clean
- ✅ `mypy` — без НОВЫХ ошибок (2 ошибки в затронутых файлах — `container.pool.clients` в assembly.py и `get_daily_stats` итерация в search_queries.py — байт-идентичны main, baseline)
- ✅ `lint-imports` — контракты целы
- ✅ `/openapi.json` генерируется без ошибок end-to-end

Closes #1070

🤖 Generated with [Claude Code](https://claude.com/claude-code)
