### PR TITLE
docs: fix wrong localhost:8000 port to 8080

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -68,4 +68,4 @@ python -m src.main serve
 python -m src.main serve --web-pass mysecret
 ```
 
-Откройте `http://localhost:8000` и войдите через Settings → Auth для добавления Telegram аккаунта.
+Откройте `http://localhost:8080` и войдите через Settings → Auth для добавления Telegram аккаунта.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -7,7 +7,7 @@
 Или через CLI (интерактивно в браузере):
 
 ```
-http://localhost:8000/auth/login
+http://localhost:8080/auth/login
 ```
 
 ## 2. Добавить каналы

--- a/docs/reference/web-api.md
+++ b/docs/reference/web-api.md
@@ -1,6 +1,6 @@
 # Web API Reference
 
-Базовый URL: `http://localhost:8000`
+Базовый URL: `http://localhost:8080`
 
 ## Auth
 


### PR DESCRIPTION
## What

Fixes the documented Web UI URL: docs said `http://localhost:8000`, but the default `serve` port is **8080** (`src/config.py:21` → `port: int = 8080`). A user following the quickstart would hit the wrong port — a bad first impression.

## Why

The default port is `8080`, not `8000`. The docs were simply wrong, sending new users to a dead URL on their very first step.

## Changes (3 replacements `8000` → `8080`)

- `docs/getting-started/configuration.md:71`
- `docs/getting-started/quickstart.md:10`
- `docs/reference/web-api.md:3`

Note: the issue listed 4 files, but `docs/index.md:32` was already corrected on `main` (`8080` + a `WebConfig.port` note), so only 3 edits were needed.

## Intentionally NOT touched

- `docs/plans/csrf-starlette-csrf-investigation.md:22` — `[::1]:8000` is an IPv6-parsing example (an abstract port), not a user instruction.

## Verification

- `grep -rn 'localhost:8000' docs/` → empty after the fix.
- `grep -rn ':8000' docs/` → only the CSRF IPv6 example remains.
- `8080` now matches `src/config.py` default port.
- `mkdocs build --strict` succeeds (built in 0.57s; only non-blocking "not in nav" INFO warnings, unrelated to this change).

Closes #1027

🤖 Generated with [Claude Code](https://claude.com/claude-code)