### PR TITLE
test(speed): replace sleep(0) with Event/wait_until, mark slow tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,6 +171,7 @@ markers = [
     "codex_image_live: opt-in live Codex SDK image generation test; gate: RUN_CODEX_IMAGE_LIVE=1",
     "codex_cli_live: opt-in live Codex CLI smoke (image + agent backend via real MCP); gate: RUN_CODEX_CLI_LIVE=1",
     "e2e: end-to-end browser test using Playwright",
+    "slow: test is intrinsically slow (real timers/sleeps that can't be scaled away); excluded from the fast feedback loop with `-m 'not slow'`",
 ]
 
 [tool.coverage.run]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -6,6 +6,7 @@ import argparse
 import asyncio
 import base64
 import hashlib
+from collections.abc import Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -800,3 +801,54 @@ def make_pipeline_node_message(
     m.sender_name = sender_name
     m.date = date or datetime(2024, 1, 1, tzinfo=timezone.utc)
     return m
+
+
+# --- deterministic async synchronisation (#1091) ---------------------------
+#
+# These replace the ``await asyncio.sleep(0)`` idiom used across the suite to
+# "let a freshly-spawned task run". A bare ``sleep(0)`` yields exactly one loop
+# iteration, so it is both fragile (the awaited task may need several yields to
+# reach its blocking point) and silently slow when guessed wrong. The helpers
+# below wait for an observable *condition* instead of a fixed number of yields.
+
+
+async def wait_until(
+    predicate: Callable[[], bool],
+    *,
+    timeout: float = 1.0,
+    interval: float = 0.0,
+) -> None:
+    """Spin the event loop until ``predicate()`` is truthy or ``timeout`` elapses.
+
+    Deterministic replacement for ``await asyncio.sleep(0)`` when a test needs to
+    wait for a spawned task/callback to reach an observable state (a counter, a
+    flag, a queue mutation). Yields with ``sleep(0)`` while ``interval`` is 0 so
+    cooperatively-scheduled work runs without burning wall-clock; a positive
+    ``interval`` is only needed when progress depends on a timer firing.
+
+    Raises ``AssertionError`` (not ``TimeoutError``) on timeout so a stuck wait
+    surfaces as a clear test failure rather than a bare cancellation.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while not predicate():
+        if loop.time() >= deadline:
+            raise AssertionError(
+                f"wait_until: predicate stayed false for {timeout}s"
+            )
+        await asyncio.sleep(interval)
+
+
+async def drain_loop(rounds: int = 3) -> None:
+    """Flush pending callbacks and let already-scheduled tasks run to a yield.
+
+    For *negative* assertions ("the callback must NOT have fired") there is no
+    state to wait on, so we drain the ready queue a few times: each ``sleep(0)``
+    runs one batch of ready callbacks, and a callback that schedules a task
+    (``call_soon_threadsafe`` → ``ensure_future``) needs a couple of rounds for
+    that task to start and reach its first ``await``. Three rounds covers the
+    deepest such chain in the suite (watchdog: threadsafe-callback → spawn task →
+    task body) with margin; it is bounded and never waits on wall-clock.
+    """
+    for _ in range(rounds):
+        await asyncio.sleep(0)

--- a/tests/routes/test_pipelines_routes.py
+++ b/tests/routes/test_pipelines_routes.py
@@ -394,6 +394,7 @@ async def test_generate_stream_pipeline_not_found(client):
     assert "error=pipeline_invalid" in resp.headers["location"]
 
 
+@pytest.mark.slow  # real provider-retry backoff on the failure path (~8s)
 @pytest.mark.anyio
 async def test_generate_pipeline_success(client):
     """Test non-streaming generation success."""
@@ -422,6 +423,7 @@ async def test_generate_pipeline_success(client):
         assert resp.status_code == 200
 
 
+@pytest.mark.slow  # real provider-retry backoff on the failure path (~9s)
 @pytest.mark.anyio
 async def test_generate_pipeline_failure(client):
     """Test non-streaming generation failure."""

--- a/tests/test_agent_manager_runtime_paths.py
+++ b/tests/test_agent_manager_runtime_paths.py
@@ -1628,6 +1628,7 @@ class TestDeepagentsProbeAndRun:
         assert result.status == "supported"
         assert result.model == "gpt-4"
 
+    @pytest.mark.slow  # exercises a real probe timeout (~10s)
     @pytest.mark.anyio
     async def test_probe_config_timeout(self, mock_db):
         """probe_config returns 'unknown' on timeout."""

--- a/tests/test_client_pool.py
+++ b/tests/test_client_pool.py
@@ -496,14 +496,19 @@ async def test_warm_overall_budget_exhausted(real_pool_harness_factory, monkeypa
     import asyncio
     import time
 
-    monkeypatch.setattr("src.telegram.pool_dialogs.WARM_SINGLE_PHONE_TIMEOUT_SEC", 2.0)
-    monkeypatch.setattr("src.telegram.pool_dialogs.WARM_ALL_PHONES_TOTAL_SEC", 3.0)
+    # Timings scaled down 10× from 2.0/3.0s (#1091): the test only needs the
+    # *relative* shape — per-phone dialog work == single-phone timeout, and the
+    # overall budget between 1× and 2× that — so the first phone consumes the
+    # budget and the second is the last to start before it runs out. Smaller
+    # absolute values keep the same assertions while cutting ~4s → ~0.4s.
+    monkeypatch.setattr("src.telegram.pool_dialogs.WARM_SINGLE_PHONE_TIMEOUT_SEC", 0.2)
+    monkeypatch.setattr("src.telegram.pool_dialogs.WARM_ALL_PHONES_TOTAL_SEC", 0.3)
     monkeypatch.setattr("src.telegram.pool_dialogs.WARM_STAGGER_DELAY_SEC", 0.0)
 
     harness = real_pool_harness_factory()
 
     async def _slow_dialogs():
-        await asyncio.sleep(2.0)
+        await asyncio.sleep(0.2)
         return []
 
     clients = {}
@@ -518,7 +523,7 @@ async def test_warm_overall_budget_exhausted(real_pool_harness_factory, monkeypa
     await harness.pool.warm_all_dialogs()
     elapsed = time.monotonic() - t0
 
-    # Budget 3s: first phone takes 2s, second starts but budget runs out
+    # Budget 0.3s: first phone takes 0.2s, second starts but budget runs out.
     assert elapsed < 8.0, f"warm took {elapsed:.1f}s, budget should cap it"
     # Not all 4 phones should have been called
     called_count = sum(1 for c in clients.values() if c.get_dialogs.await_count > 0)
@@ -530,7 +535,9 @@ async def test_warm_stagger_between_phones(real_pool_harness_factory, monkeypatc
     """Phones are staggered with a small delay between them."""
     import time
 
-    stagger = 0.3
+    # 0.1s stagger (was 0.3s, #1091): still comfortably above the ±0.05s
+    # measurement tolerance below, but a third of the wall-clock.
+    stagger = 0.1
     monkeypatch.setattr("src.telegram.pool_dialogs.WARM_STAGGER_DELAY_SEC", stagger)
     monkeypatch.setattr("src.telegram.pool_dialogs.WARM_SINGLE_PHONE_TIMEOUT_SEC", 5.0)
 

--- a/tests/test_client_pool.py
+++ b/tests/test_client_pool.py
@@ -535,9 +535,9 @@ async def test_warm_stagger_between_phones(real_pool_harness_factory, monkeypatc
     """Phones are staggered with a small delay between them."""
     import time
 
-    # 0.1s stagger (was 0.3s, #1091): still comfortably above the ±0.05s
-    # measurement tolerance below, but a third of the wall-clock.
-    stagger = 0.1
+    # 0.15s stagger (was 0.3s, #1091): 3× tolerance floor (0.05s) keeps
+    # margin at 33% — robust on loaded CI runners without adding wall-clock.
+    stagger = 0.15
     monkeypatch.setattr("src.telegram.pool_dialogs.WARM_STAGGER_DELAY_SEC", stagger)
     monkeypatch.setattr("src.telegram.pool_dialogs.WARM_SINGLE_PHONE_TIMEOUT_SEC", 5.0)
 

--- a/tests/test_collection_queue_db_pull.py
+++ b/tests/test_collection_queue_db_pull.py
@@ -20,6 +20,7 @@ from src.telegram.collector import (
     UsernameResolveFloodWaitDeferredError,
     UsernameResolveRateLimitedError,
 )
+from tests.helpers import wait_until
 
 
 class _FakeCollector:
@@ -413,7 +414,9 @@ async def test_delayed_requeue_queue_full_releases_known_task_id(tmp_path, monke
             full=True,
             run_after=datetime.fromtimestamp(0, tz=timezone.utc),
         )
-        await asyncio.sleep(0)
+        # The requeue task runs immediately (run_after in the past), finds the
+        # queue full, and drops the task id so it can be re-ingested later.
+        await wait_until(lambda: task_id not in queue._known_task_ids)
 
         assert task_id not in queue._known_task_ids
         queue._queue.get_nowait()

--- a/tests/test_content_generation_service_edge_cases.py
+++ b/tests/test_content_generation_service_edge_cases.py
@@ -830,6 +830,7 @@ async def test_generate_run_not_found_after_save():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.slow  # real provider-retry backoff on the exception path (~9s)
 @pytest.mark.anyio
 async def test_generate_exception_sets_failed():
     """Any exception during generation should mark run as failed."""

--- a/tests/test_cross_domain_regression_paths.py
+++ b/tests/test_cross_domain_regression_paths.py
@@ -4252,6 +4252,7 @@ class TestQualityScoringServiceCoverage:
             # Should get defaults when no JSON found
             assert score.relevance == 0.5
 
+    @pytest.mark.slow  # real provider-retry backoff on the exception path (~8s)
     async def test_score_content_os_error(self):
         """Lines 117-119: OSError during scoring."""
         from src.services.quality_scoring_service import QualityScoringService
@@ -4267,6 +4268,7 @@ class TestQualityScoringServiceCoverage:
             score = await svc.score_content("test text", model="test")
             assert score.overall == 0.5
 
+    @pytest.mark.slow  # real provider-retry backoff on the exception path (~9s)
     async def test_score_content_unexpected_error(self):
         """Lines 120-122: unexpected error during scoring."""
         from src.services.quality_scoring_service import QualityScoringService

--- a/tests/test_database_pool.py
+++ b/tests/test_database_pool.py
@@ -13,6 +13,7 @@ import pytest
 
 from src.database.connection import open_connection
 from src.database.pool import BufferedCursor, ReadConnectionPool, ReadPoolProxy
+from tests.helpers import wait_until
 
 # A heavy pure-SQL query: a recursive CTE that SQLite evaluates in C, so it occupies
 # its connection's worker thread WITHOUT holding the Python GIL (a time.sleep UDF would
@@ -46,7 +47,9 @@ async def test_long_select_does_not_block_other_reads(tmp_path):
             await proxy.execute(_HEAVY_SQL)
 
         heavy_task = asyncio.create_task(heavy())
-        await asyncio.sleep(0.05)  # let the heavy query grab its connection first
+        # Wait until the heavy query has actually grabbed a pooled connection
+        # (the pool starts with `size` idle conns) instead of guessing a delay.
+        await wait_until(lambda: pool._queue.qsize() < 2)
 
         # The quick SELECT runs on the *other* pooled connection while heavy is busy.
         t0 = time.perf_counter()

--- a/tests/test_generation_service.py
+++ b/tests/test_generation_service.py
@@ -246,6 +246,7 @@ async def test_generation_service_sync_iterator_provider():
     assert chunks[-1]["generated_text"] == "chunk1chunk2chunk3"
 
 
+@pytest.mark.slow  # real provider-retry backoff on the exception path (~8s)
 async def test_generation_service_provider_exception():
     """Test generation handles provider exception."""
 

--- a/tests/test_integration_generation.py
+++ b/tests/test_integration_generation.py
@@ -5,6 +5,7 @@ import pytest
 # pipeline_client fixture is shared from tests/conftest.py (deduped).
 
 
+@pytest.mark.slow  # real provider-retry backoff on the success path (~8s)
 @pytest.mark.anyio
 async def test_pipeline_generate_and_publish(pipeline_client, monkeypatch):
     # Mock LLM provider service so the Generate button is shown in the template

--- a/tests/test_live_runtime_pause.py
+++ b/tests/test_live_runtime_pause.py
@@ -5,6 +5,7 @@ from src.config import SchedulerConfig
 from src.live_runtime_pause import LiveRuntimePauseGate
 from src.scheduler.service import SchedulerManager
 from src.services.telegram_command_dispatcher import TelegramCommandDispatcher
+from tests.helpers import drain_loop
 
 
 def test_live_runtime_pause_gate_waits_until_all_agent_requests_release():
@@ -16,7 +17,7 @@ def test_live_runtime_pause_gate_waits_until_all_agent_requests_release():
             assert gate.active_agent_requests == 1
 
             waiter = asyncio.create_task(gate.wait_if_paused())
-            await asyncio.sleep(0)
+            await drain_loop()
             assert not waiter.done()
 
             async with gate.agent_request():
@@ -58,7 +59,7 @@ def test_scheduler_waits_to_run_background_collection_while_agent_uses_live_runt
 
         async with gate.agent_request():
             background_task = asyncio.create_task(manager._run_collection())
-            await asyncio.sleep(0)
+            await drain_loop()
             assert enqueuer.calls == 0
             manual_result = await manager.trigger_now()
         background_result = await asyncio.wait_for(background_task, timeout=0.5)
@@ -96,7 +97,7 @@ def test_scheduler_stop_interrupts_paused_background_collection_wait():
 
         async with gate.agent_request():
             background_task = asyncio.create_task(manager._run_collection())
-            await asyncio.sleep(0)
+            await drain_loop()
             assert enqueuer.calls == 0
             await manager.stop()
             background_result = await asyncio.wait_for(background_task, timeout=0.5)
@@ -132,7 +133,7 @@ def test_telegram_command_dispatcher_does_not_claim_while_agent_uses_live_runtim
         async with gate.agent_request():
             dispatcher._stop_event.clear()
             task = asyncio.create_task(dispatcher._run_loop())
-            await asyncio.sleep(0)
+            await drain_loop()
             assert db.repos.telegram_commands.claims == 0
             dispatcher._stop_event.set()
             await asyncio.wait_for(task, timeout=1.5)

--- a/tests/test_mtproto_watchdog.py
+++ b/tests/test_mtproto_watchdog.py
@@ -23,6 +23,7 @@ from src.telegram.mtproto_watchdog import (
     MTProtoSecurityWatchdog,
     bind_telethon_base_logger,
 )
+from tests.helpers import drain_loop, wait_until
 
 PHONE_A = "+70001112233"
 PHONE_B = "+70002223344"
@@ -59,9 +60,9 @@ class TestEmitFiltering:
                 base = wd.register_phone(PHONE_A)
                 for _ in range(6):
                     wd.emit(_security_record(base))
-                # Let call_soon_threadsafe callbacks and the spawned task run.
-                await asyncio.sleep(0)
-                await asyncio.sleep(0)
+                # Wait for the call_soon_threadsafe callback to spawn the
+                # reconnect task and that task to invoke the callback.
+                await wait_until(lambda: cb.await_count >= 1)
                 cb.assert_awaited_once_with(PHONE_A)
             finally:
                 wd.uninstall()
@@ -76,7 +77,7 @@ class TestEmitFiltering:
                 base = wd.register_phone(PHONE_A)
                 wd.emit(_security_record(base))
                 wd.emit(_security_record(base))
-                await asyncio.sleep(0)
+                await drain_loop()
                 cb.assert_not_awaited()
             finally:
                 wd.uninstall()
@@ -93,7 +94,7 @@ class TestEmitFiltering:
                 wd.emit(_security_record(base_a))
                 wd.emit(_security_record(base_a))
                 wd.emit(_security_record(base_b))
-                await asyncio.sleep(0)
+                await drain_loop()
                 # Neither phone reached 3 on its own.
                 cb.assert_not_awaited()
             finally:
@@ -123,7 +124,7 @@ class TestEmitFiltering:
                     exc_info=None,
                 )
                 wd.emit(rec2)
-                await asyncio.sleep(0)
+                await drain_loop()
                 cb.assert_not_awaited()
             finally:
                 wd.uninstall()
@@ -138,7 +139,7 @@ class TestEmitFiltering:
                 base = wd.register_phone(PHONE_A)
                 wd.unregister_phone(PHONE_A)
                 wd.emit(_security_record(base))
-                await asyncio.sleep(0)
+                await drain_loop()
                 cb.assert_not_awaited()
             finally:
                 wd.uninstall()
@@ -153,8 +154,7 @@ class TestEmitFiltering:
                 base = wd.register_phone(PHONE_A)
                 wd.emit(_security_record(base))
                 wd.emit(_security_record(base))
-                await asyncio.sleep(0)
-                await asyncio.sleep(0)
+                await wait_until(lambda: cb.await_count >= 1)
                 cb.assert_awaited_once()
             finally:
                 wd.uninstall()
@@ -184,8 +184,7 @@ class TestPropagationThroughLoggingTree:
                     "Security error while unpacking a received message: %s",
                     "Too many messages had to be ignored consecutively",
                 )
-                await asyncio.sleep(0)
-                await asyncio.sleep(0)
+                await wait_until(lambda: cb.await_count >= 1)
                 cb.assert_awaited_once_with(PHONE_A)
             finally:
                 wd.uninstall()

--- a/tests/test_notifier_delivery_paths.py
+++ b/tests/test_notifier_delivery_paths.py
@@ -12,6 +12,7 @@ import pytest
 from src.database.bundles import NotificationBundle
 from src.models import NotificationBot
 from src.telegram.notifier import Notifier, _send_via_bot_api
+from tests.helpers import wait_until
 
 
 @pytest.fixture
@@ -583,7 +584,11 @@ class TestNotifierCircuitBreaker:
             before = mock_target_service.use_client.call_count
             task_a = asyncio.create_task(notifier.notify("x"))
             task_b = asyncio.create_task(notifier.notify("x"))
-            await asyncio.sleep(0)  # let task_a grab the lock and block in send
+            # Wait until the first caller has grabbed the lock and reached the
+            # send (use_client opened) — then it is parked on gate.wait().
+            await wait_until(
+                lambda: mock_target_service.use_client.call_count > before
+            )
             gate.set()  # release the blocked probe
             results = await asyncio.gather(task_a, task_b)
             after = mock_target_service.use_client.call_count

--- a/tests/test_registry_and_quality.py
+++ b/tests/test_registry_and_quality.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from src.agent.tools._registry import (
     _text_response,
     normalize_phone,
@@ -204,6 +206,7 @@ async def test_quality_scoring_passes():
     assert svc.passes_threshold(score, threshold=0.9) is False
 
 
+@pytest.mark.slow  # real provider-retry backoff on the exception path (~8s)
 async def test_quality_scoring_no_provider():
     from src.services.quality_scoring_service import QualityScoringService
 

--- a/tests/test_telegram_client_pool_collector.py
+++ b/tests/test_telegram_client_pool_collector.py
@@ -54,6 +54,7 @@ from tests.helpers import (
     AsyncIterMessages,
     make_mock_message,
     make_mock_pool,
+    wait_until,
 )
 
 # ---------------------------------------------------------------------------
@@ -239,8 +240,11 @@ async def test_wait_for_warm_no_task(pool):
 
 @pytest.mark.anyio
 async def test_wait_for_warm_completed_task(pool):
-    pool._warming_task = asyncio.create_task(asyncio.sleep(0))
-    await asyncio.sleep(0.05)
+    async def _noop() -> None:
+        return None
+
+    pool._warming_task = asyncio.create_task(_noop())
+    await wait_until(lambda: pool._warming_task.done())
     await pool.wait_for_warm(timeout=1.0)
 
 

--- a/tests/test_test_levels.py
+++ b/tests/test_test_levels.py
@@ -159,6 +159,7 @@ def test_ast_scan_flags_only_db_building_tests(tmp_path) -> None:
 # --- structural invariants over the real collection ------------------------
 
 
+@pytest.mark.slow  # forks a full pytest collection in a subprocess (~14s)
 @pytest.mark.integration  # forks a full pytest collection in a subprocess
 def test_collection_invariants_hold_over_real_suite() -> None:
     """End-to-end gate: every collected test gets exactly one level.

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -38,7 +38,7 @@ from src.web.app import create_app
 from src.web.routes.channel_collection import _COLLECT_ALL_BTN, _COLLECT_ALL_FORM
 from src.web.session import COOKIE_NAME, create_session_token
 from src.web.template_globals import PYPROJECT_PATH, _agent_available_for_request, get_app_version
-from tests.helpers import build_web_app, make_auth_client, make_test_config
+from tests.helpers import build_web_app, drain_loop, make_auth_client, make_test_config
 
 
 @pytest.fixture
@@ -1351,12 +1351,17 @@ async def test_settings_bulk_test_exports_catalog(client, monkeypatch, tmp_path)
     payload = resp.json()
     assert payload["ok"] is True
     assert payload["started"] is True
-    await asyncio.sleep(0)
 
-    status_resp = await client.get("/settings/agent-providers/test-all/status")
-
-    assert status_resp.status_code == 200
-    status_payload = status_resp.json()
+    # The POST spawns the bulk-test job as a background task; poll the status
+    # endpoint until that job has run (deterministic, no fixed sleep).
+    status_payload: dict = {}
+    for _ in range(50):
+        await drain_loop()
+        status_resp = await client.get("/settings/agent-providers/test-all/status")
+        assert status_resp.status_code == 200
+        status_payload = status_resp.json()
+        if status_payload.get("summary", {}).get("supported") == 2:
+            break
     assert status_payload["summary"]["supported"] == 2
     assert status_payload["providers"]["openai"]["summary"]["supported"] == 2
     assert status_payload["catalog_path"] == str(export_path)


### PR DESCRIPTION
## Summary

- **Заменяет `asyncio.sleep(0)` на детерминированные хелперы** (`wait_until`, `drain_loop`) в 7 файлах (~17 вхождений) — тесты теперь ждут конкретного условия вместо гонки с event loop
- **Масштабирует реальные тайминги** warm-budget теста `test_client_pool.py` (÷10, 4.01s → 0.42s) без потери покрытия относительных инвариантов
- **Маркирует 10 тестов `@pytest.mark.slow`** (корень: `ErrorRecoveryService.for_llm()` retry backoff ~7-10s; subprocess fork ~14s; real probe timeout ~10s) — можно исключить из быстрого прогона `-m 'not slow'`
- Добавляет определение `slow` маркера в `pyproject.toml`

## Детали

| Файл | До | После | Механизм |
|------|-----|-------|---------|
| `test_mtproto_watchdog.py` | 11× `sleep(0)` | `wait_until` / `drain_loop` | мутация watchdog → 3 FAILED ✓ |
| `test_live_runtime_pause.py` | 4× `sleep(0)` | `drain_loop` | мутация gate → 4 FAILED ✓ |
| `test_collection_queue_db_pull.py` | `sleep(0)` | `wait_until(_known_task_ids)` | мутация discard → FAILED ✓ |
| `test_notifier_delivery_paths.py` | `sleep(0)` | `wait_until(call_count)` | мутация lock → FAILED ✓ |
| `test_database_pool.py` | `sleep(0.05)` | `wait_until(qsize)` | pool queue observable |
| `test_web.py` | `sleep(0)` | polling on job status | endpoint observable |
| `test_client_pool.py` | `sleep(2.0)`, 3.0s budget | ÷10 = 0.2s, 0.3s budget | 4.01s → 0.42s |

**Serial suite (AFTER):** 937 tests, 26.21s, топ-10 ≤ 0.43s  
**Parallel suite:** 8631 passed, 0 failures  
**Ruff:** clean  

Closes #1091