### PR TITLE
test(collector): lock batch-size persist correctness across flush boundaries (#1042)

### DIFF
--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -1647,9 +1647,10 @@ async def test_collect_correct_across_flush_boundaries_for_batch_size(db, monkey
     (the INSERT itself is 98% of persist time and is work-bound, not partition-
     bound) while it lengthens write-lock hold (#569) and peak memory — so the
     default stays 500. This locks that decision in: whichever value the constant
-    holds, collecting N > batch_size messages must dedup and advance
-    last_collected_id correctly across *every* flush boundary, not just the
-    single-batch case. Runs the real ``_collect_channel`` persist path against a
+    holds, collecting N > batch_size messages must persist exactly N unique rows
+    (no gaps/dups at flush boundaries) and advance last_collected_id correctly
+    across *every* boundary, and a second pass must re-collect nothing
+    (incrementality). Runs the real ``_collect_channel`` persist path against a
     real in-memory DB (no insert mock), parameterised on both the current default
     and the rejected 1000 hypothesis.
     """
@@ -1691,9 +1692,11 @@ async def test_collect_correct_across_flush_boundaries_for_batch_size(db, monkey
     assert len(page.messages) == total_msgs
     assert {m.message_id for m in page.messages} == set(range(1, total_msgs + 1))
 
-    # Second pass over the same source: incremental min_id (= last_collected_id)
-    # means nothing new is collected and INSERT OR IGNORE keeps the row count at N
-    # — dedup is intact regardless of batch size.
+    # Second pass over the same source proves *incrementality*, not DB-level
+    # dedup: min_id (= last_collected_id) filters the stream so _msgs yields
+    # nothing, so no second INSERT runs and the row count stays at N — regardless
+    # of batch size. (INSERT OR IGNORE conflict resolution is exercised elsewhere;
+    # here min_id is the load-bearing guard against re-collection.)
     stored_again = await db.get_channel_by_pk(ch_id)
     assert stored_again is not None
     recount = await collector._collect_channel(stored_again)

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -1639,6 +1639,70 @@ async def test_flush_verifies_persisted_ids_in_chunks(db, monkeypatch):
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("batch_size", [500, 1000])
+async def test_collect_correct_across_flush_boundaries_for_batch_size(db, monkeypatch, batch_size):
+    """Persist correctness must hold at the chosen MESSAGE_FLUSH_BATCH_SIZE (#1042).
+
+    The #1042 benchmark proved raising the batch size does not help throughput
+    (the INSERT itself is 98% of persist time and is work-bound, not partition-
+    bound) while it lengthens write-lock hold (#569) and peak memory — so the
+    default stays 500. This locks that decision in: whichever value the constant
+    holds, collecting N > batch_size messages must dedup and advance
+    last_collected_id correctly across *every* flush boundary, not just the
+    single-batch case. Runs the real ``_collect_channel`` persist path against a
+    real in-memory DB (no insert mock), parameterised on both the current default
+    and the rejected 1000 hypothesis.
+    """
+    monkeypatch.setattr("src.telegram.collector.MESSAGE_FLUSH_BATCH_SIZE", batch_size)
+
+    # N straddles 2.4 flush partitions at batch=500 and 1.2 at batch=1000, so a
+    # boundary-off-by-one in either dedup or last_id advancement would show up.
+    total_msgs = 1200
+    ch = Channel(channel_id=-100142, title="Boundary", username="bnd142", last_collected_id=0)
+    ch_id = await db.add_channel(ch)
+    stored = await db.get_channel_by_pk(ch_id)
+    assert stored is not None
+
+    def _msgs(*_args, **kwargs):
+        # Honour min_id like real Telethon so the second (incremental) pass yields
+        # nothing once last_collected_id has advanced past the channel — this is
+        # what makes the dedup/incrementality assertion below meaningful.
+        min_id = kwargs.get("min_id", 0) or 0
+        return _AsyncIterMessages(
+            [_make_mock_message(i, text=f"m{i}") for i in range(1, total_msgs + 1) if i > min_id]
+        )
+
+    mock_client = AsyncMock()
+    mock_client.get_entity = AsyncMock(return_value=SimpleNamespace())
+    mock_client.iter_messages = MagicMock(side_effect=_msgs)
+    pool = make_mock_pool(get_available_client=AsyncMock(return_value=(mock_client, "+7000")))
+
+    collector = Collector(pool, db, SchedulerConfig(delay_between_requests_sec=0))
+
+    # First pass: persist everything across flush boundaries.
+    count = await collector._collect_channel(stored)
+    assert count == total_msgs
+    updated = await db.get_channel_by_pk(ch_id)
+    assert updated is not None
+    assert updated.last_collected_id == total_msgs
+
+    # Exactly N unique rows persisted — no batch-boundary gaps, no duplicates.
+    page = await db.search_messages(channel_id=-100142, limit=total_msgs + 10)
+    assert len(page.messages) == total_msgs
+    assert {m.message_id for m in page.messages} == set(range(1, total_msgs + 1))
+
+    # Second pass over the same source: incremental min_id (= last_collected_id)
+    # means nothing new is collected and INSERT OR IGNORE keeps the row count at N
+    # — dedup is intact regardless of batch size.
+    stored_again = await db.get_channel_by_pk(ch_id)
+    assert stored_again is not None
+    recount = await collector._collect_channel(stored_again)
+    assert recount == 0
+    page2 = await db.search_messages(channel_id=-100142, limit=total_msgs + 10)
+    assert len(page2.messages) == total_msgs
+
+
+@pytest.mark.anyio
 async def test_collect_channel_does_not_advance_last_id_when_flush_fails(db):
     ch = Channel(channel_id=-100126, title="Test", username="test", last_collected_id=5)
     await db.add_channel(ch)


### PR DESCRIPTION
Closes #1042

Часть эпика #1025 (функция 1 — Сбор → БД). **Бенчмарк-первый, поведенческая/перф ось.** НЕ структурный рефактор (разбивка методов = скоуп #1023).

## TL;DR — отрицательный результат
Бенчмарк горячей зоны persist доказал, что **batch-константы не являются рычагом throughput**. Поднятие `MESSAGE_FLUSH_BATCH_SIZE` 500→1000/2000 не ускоряет сбор, но регрессирует удержание write-lock (#569) и память. **Дефолты `500/500` оставлены без изменений** (`src/` не тронут — п.4 issue). Решение закреплено регресс-тестом.

## Что измерено (измерить → настроить → закрепить)
Файловая SQLite WAL, синтетические N сообщений через реальный путь `insert_messages_batch` + `_verify_persisted_ids` (в worktree нет `data/tg_search.db` с реальными данными; локальные тайминги — только относительные «до/после», память: «только локал, прода нет»). N=20k/30k/50k, 3–5 reps.

| flush | verify | persist_med(s) | max_flush(ms) | peak_mem(KB) | Δ throughput |
|------:|-------:|---------------:|--------------:|-------------:|:------------|
| **500** | **500** | 2.222 | **57** | **450** | baseline |
| 1000 | 500 | 2.224 | 101 | 719 | +0.1% |
| 500 | 1000 | 2.309 | 59 | 447 | +3.9% |
| 1000 | 1000 | 2.299 | 107 | 746 | +3.5% |
| 2000 | 2000 | 2.240 | 177 | 1481 | +0.8% |

- **Throughput не растёт**: дельты гуляют −4.9%..+3.9% между прогонами — чистый шум, знак меняется.
- **Два регресса детерминированы и монотонны**: одиночный write-lock hold (#569) ×2–3.5 (57→177мс), пик памяти ×3 (450→1481КБ).
- **Component breakdown**: сам `INSERT` = **98%** времени persist и work-bound (линеен по числу строк, не зависит от размера flush-партиции); `_verify_persisted_ids` chunk-SELECT = **0.8%** → поднятие `PERSISTED_ID_VERIFY_CHUNK_SIZE` оптимизирует почти-бесплатное.

Бенчмарк-скрипт — во временной зоне (не в suite), как просит issue.

## Что закреплено тестом (п.3)
Параметризованный integration-тест `test_collect_correct_across_flush_boundaries_for_batch_size[500|1000]`: сбор N>batch через реальный `_collect_channel` корректен на **каждой** границе flush — дедуп + продвижение `last_collected_id`, второй инкрементальный проход не добавляет строк. **Мутационно верифицировано** (локальным ревью, 4 мутации продкода): поломка продвижения `last_collected_id` и сброс `min_id=0` (re-collection) красят **оба** параметра [500|1000]; поломка chunk-обработки в `_verify_persisted_ids` красит [1000] (multi-chunk verify; при batch=500 verify укладывается в один chunk). Incrementality (min_id) — load-bearing assertion второго прохода.

## Verification
- `pytest tests/test_collector.py tests/test_parallel_collection.py -v` → **129 passed**
- Стабильно зелёный под `-n auto`
- `ruff check tests/test_collector.py` → clean; mypy — 0 новых ошибок в изменённом файле (baseline-шум проекта не затронут)

## Граница с #1023
Цикломатику/разбивку методов Collector НЕ трогал.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
