### PR TITLE
feat(collector): TTL + re-auth refresh for dialog entity-cache warm flag (#1043)

### DIFF
--- a/src/telegram/client_pool.py
+++ b/src/telegram/client_pool.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime
@@ -142,6 +143,19 @@ class ClientPool(
             native=self._native_backend,
         )
         self._dialogs_fetched: set[str] = set()
+        # phone → monotonic timestamp of its last warm; gives the warm flag a
+        # TTL so a long-lived worker re-warms a stale entity cache instead of
+        # treating it as "warm forever" (#1043). Membership in
+        # ``_dialogs_fetched`` stays the source of truth for "was warmed";
+        # this map only carries the age.
+        self._dialogs_fetched_at_monotonic: dict[str, float] = {}
+        # Warm-flag TTL. Distinct from ``_dialogs_cache_ttl_sec`` (60s, for the
+        # in-process list-of-dialogs cache below): the warm flag only gates the
+        # one-shot entity-cache prefetch, so it tolerates a much longer window
+        # before a defensive re-warm.
+        self._dialogs_warm_ttl_sec = 1800.0  # 30 min
+        # Injectable monotonic clock (tests advance it without sleeping).
+        self._monotonic = time.monotonic
         self._channel_phone_map: dict[int, str] = {}
         # channel_id (positive MTProto) → phone that has it in dialogs
         self._warming_task: asyncio.Task | None = None

--- a/src/telegram/pool_dialogs.py
+++ b/src/telegram/pool_dialogs.py
@@ -27,6 +27,7 @@ import asyncio
 import logging
 import re
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
@@ -94,6 +95,9 @@ class DialogsMixin:
     _db: Database
     _channel_phone_map: dict[int, str]
     _dialogs_fetched: set[str]
+    _dialogs_fetched_at_monotonic: dict[str, float]
+    _dialogs_warm_ttl_sec: float
+    _monotonic: Callable[[], float]
     _dialogs_cache: dict[tuple[str, str], DialogCacheEntry]
     _dialogs_cache_ttl_sec: float
     _dialogs_db_cache_ttl_sec: float
@@ -122,13 +126,59 @@ class DialogsMixin:
     # ------------------------------------------------------------------ #
     # channel ↔ phone routing
     # ------------------------------------------------------------------ #
+    def _warm_timestamps(self) -> dict[str, float]:
+        """The phone → monotonic-warm-time map, lazily created.
+
+        getattr-tolerant so test doubles that build the pool via ``__new__``
+        (and set only ``_dialogs_fetched``) still work — mirrors the
+        ``getattr(self, "_mtproto_watchdog", None)`` pattern used elsewhere.
+        """
+        stamps = getattr(self, "_dialogs_fetched_at_monotonic", None)
+        if stamps is None:
+            stamps = {}
+            self._dialogs_fetched_at_monotonic = stamps
+        return stamps
+
     def is_dialogs_fetched(self, phone: str) -> bool:
-        """Return True if get_dialogs() was already called for this phone in this process."""
-        return phone in self._dialogs_fetched
+        """Return True if the entity cache for this phone is warm and still fresh.
+
+        The warm flag carries a TTL (``_dialogs_warm_ttl_sec``): once it expires
+        the flag is treated as cold (and self-cleared) so the next collection
+        pass re-warms a long-lived worker's stale entity cache (#1043). Within
+        the TTL the answer stays True, so the hot path still warms at most once
+        per phone per window — no perf regression. A flag set without a
+        timestamp (legacy / direct ``_dialogs_fetched`` mutation) never expires.
+        """
+        if phone not in self._dialogs_fetched:
+            return False
+        warmed_at = self._warm_timestamps().get(phone)
+        ttl = getattr(self, "_dialogs_warm_ttl_sec", None)
+        clock = getattr(self, "_monotonic", time.monotonic)
+        if warmed_at is not None and ttl is not None and (clock() - warmed_at) > ttl:
+            self.reset_dialogs_warm(phone)
+            return False
+        return True
 
     def mark_dialogs_fetched(self, phone: str) -> None:
-        """Mark that get_dialogs() has been called for this phone."""
+        """Mark that get_dialogs() has been called for this phone, stamping the
+        warm time so the TTL in :meth:`is_dialogs_fetched` can age it out."""
         self._dialogs_fetched.add(phone)
+        clock = getattr(self, "_monotonic", time.monotonic)
+        self._warm_timestamps()[phone] = clock()
+
+    def reset_dialogs_warm(self, phone: str) -> None:
+        """Invalidate the per-phone entity-cache warm flag.
+
+        Called on live re-auth (``add_client`` swaps in a *new* StringSession,
+        whose in-memory entity cache is empty) and on teardown
+        (``remove_client`` / ``disconnect_all``). A bare reconnect of the same
+        session object does NOT call this: the StringSession entity cache
+        (``session._entities``, the fallback that resolves numeric
+        ``PeerChannel``) survives ``disconnect()`` + ``connect()``, so re-warming
+        there would be a needless round-trip and a FloodWait risk (#1043).
+        """
+        self._dialogs_fetched.discard(phone)
+        self._warm_timestamps().pop(phone, None)
 
     def connected_phones(self) -> set[str]:
         """Return the set of currently connected phone numbers."""

--- a/src/telegram/pool_lifecycle.py
+++ b/src/telegram/pool_lifecycle.py
@@ -500,6 +500,14 @@ class ClientLifecycleMixin:
                 if not force_native:
                     # Store persistent session for future direct reuse.
                     # force_native sessions are short-lived and must not replace the pool session.
+                    #
+                    # This branch installs a *fresh* backend client (the cached
+                    # direct session was absent or its auto-reconnect failed
+                    # above): a new session object with an empty in-memory entity
+                    # cache. Drop the warm flag so the next numeric-PeerChannel
+                    # collection re-warms instead of skipping against the empty
+                    # cache (#1043) — same hazard as add_client's re-auth.
+                    self.reset_dialogs_warm(phone)
                     self.clients[phone] = TelegramTransportSession(
                         lease.session.raw_client,
                         disconnect_on_close=False,

--- a/src/telegram/pool_lifecycle.py
+++ b/src/telegram/pool_lifecycle.py
@@ -84,6 +84,8 @@ class ClientLifecycleMixin:
 
         def invalidate_dialogs_cache(self, phone: str | None = None) -> None: ...
 
+        def reset_dialogs_warm(self, phone: str) -> None: ...
+
         def clear_premium_flood(self, phone: str) -> None: ...
 
         async def _await_transient_flood(self, phone: str) -> None: ...
@@ -269,6 +271,10 @@ class ClientLifecycleMixin:
     async def add_client(self, phone: str, session_string: str) -> None:
         """Register a new account as connected and validate its stored session."""
         self._session_overrides[phone] = session_string
+        # Re-auth with a (possibly new) StringSession starts from an empty
+        # in-memory entity cache, so any prior warm flag is stale (#1043).
+        self.reset_dialogs_warm(phone)
+        self.invalidate_dialogs_cache(phone)
         account = Account(phone=phone, session_string=session_string, is_active=True)
         lease = await self._connect_account(account)
         await self._backend_router.release(lease)
@@ -283,6 +289,13 @@ class ClientLifecycleMixin:
             if not client.is_connected():
                 logger.info("Reconnecting client for %s", phone)
                 await client.connect()
+            # NB: no warm-flag reset here. A reconnect reuses the *same*
+            # session object, and the StringSession entity cache
+            # (``session._entities``, the fallback that resolves numeric
+            # PeerChannels) lives in that object and survives disconnect +
+            # connect. Re-warming would be a needless round-trip and a
+            # FloodWait risk (#1043). Long-lived drift is covered by the
+            # warm-flag TTL instead.
             return client.is_connected()
         except Exception:
             logger.exception("Failed to reconnect client for %s", phone)
@@ -307,6 +320,11 @@ class ClientLifecycleMixin:
             except asyncio.TimeoutError:
                 logger.warning("Timeout disconnecting %s during force reconnect", mask_phone(phone))
             await client.connect()
+            # NB: no warm-flag reset here either. force_reconnect (the #556
+            # MTProto-brick recovery) tears down and re-establishes the
+            # transport on the *same* session object, so the StringSession
+            # entity cache (``session._entities``) survives — numeric
+            # PeerChannel resolves keep working without a re-warm (#1043).
             if not await client.is_user_authorized():
                 logger.error("Force reconnect of %s: session no longer authorized", mask_phone(phone))
                 return False
@@ -342,7 +360,7 @@ class ClientLifecycleMixin:
             leases = list(self._active_leases.pop(phone, []))
         client = self.clients.pop(phone, None)
         self._in_use.discard(phone)
-        self._dialogs_fetched.discard(phone)
+        self.reset_dialogs_warm(phone)
         self.invalidate_dialogs_cache(phone)
         self.clear_premium_flood(phone)
         for lease in reversed(leases):
@@ -400,7 +418,7 @@ class ClientLifecycleMixin:
                 self.clients.pop(phone, None)
                 self._in_use.discard(phone)
                 self._active_leases.pop(phone, None)
-                self._dialogs_fetched.discard(phone)
+                self.reset_dialogs_warm(phone)
             except Exception:
                 logger.debug("Error disconnecting %s", phone, exc_info=True)
         # Allow Telethon internal tasks (_send_loop, _recv_loop) to finish

--- a/tests/test_client_pool_decomposition.py
+++ b/tests/test_client_pool_decomposition.py
@@ -34,6 +34,7 @@ PUBLIC_CONTRACT: frozenset[str] = frozenset(
         # channel ↔ phone routing map
         "is_dialogs_fetched",
         "mark_dialogs_fetched",
+        "reset_dialogs_warm",
         "connected_phones",
         "get_phone_for_channel",
         "register_channel_phone",

--- a/tests/test_dialog_cache_ttl.py
+++ b/tests/test_dialog_cache_ttl.py
@@ -1,0 +1,278 @@
+"""TTL + re-auth invalidation for the per-phone dialog-warm flag (#1043).
+
+For numeric ``PeerChannel`` collection, ``_acquire_collection_client`` warms the
+Telethon entity cache once per phone per process and records that via
+``mark_dialogs_fetched(phone)`` (gate ``is_dialogs_fetched(phone)``). The
+StringSession entity cache lives in the *session object* and is rebuilt on a
+fresh ``get_dialogs()`` call, so a warm done once is normally enough.
+
+The gap this suite locks down: on a long-lived worker the warm flag was treated
+as "warm forever" — there was **no TTL** and **no invalidation when the session
+object is replaced**. After a re-auth that swaps in a fresh StringSession (empty
+entity cache), ``is_dialogs_fetched`` still returned True → the warm round-trip
+was skipped → numeric-channel resolves started missing on the long-running
+worker.
+
+Telethon detail (verified against telethon 1.42, see section 3 below): the
+entity cache that resolves a numeric ``PeerChannel`` lives in
+``StringSession._entities`` on the *session object*, and ``get_input_entity``
+falls back to it. So it survives a bare ``disconnect()`` + ``connect()`` on the
+same client, and is only lost when the session object itself is replaced.
+
+Fix surface (cache flags only, no ClientPool refactor — #1023 boundary):
+  * a monotonic TTL on the warm flag (``_dialogs_warm_ttl_sec``) — the robust
+    catch-all for long-lived-worker drift;
+  * invalidation of the warm flag where the session object is genuinely
+    replaced (``add_client`` re-auth), mirroring what ``remove_client`` already
+    does on teardown. A bare ``reconnect_phone`` / ``force_reconnect_phone`` of
+    the same session deliberately does NOT invalidate (cache survives → a
+    re-warm would be a needless round-trip and a FloodWait risk).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.config import SchedulerConfig
+from src.models import Channel
+from src.telegram.backends import TelegramTransportSession
+from src.telegram.client_pool import ClientPool
+from src.telegram.collector import _ACQUIRE_RETRY, Collector
+
+
+@pytest.fixture
+def mock_db():
+    db = MagicMock()
+    db.get_accounts = AsyncMock(return_value=[])
+    db.repos.dialog_cache.list_dialogs = AsyncMock(return_value=[])
+    db.repos.dialog_cache.get_cached_at = AsyncMock(return_value=None)
+    db.repos.dialog_cache.replace_dialogs = AsyncMock()
+    db.repos.dialog_cache.clear_dialogs = AsyncMock()
+    return db
+
+
+@pytest.fixture
+def mock_auth():
+    auth = MagicMock()
+    auth.api_id = 12345
+    auth.api_hash = "hash"
+    auth.create_client_from_session = AsyncMock()
+    return auth
+
+
+@pytest.fixture
+def pool(mock_auth, mock_db):
+    return ClientPool(mock_auth, mock_db)
+
+
+# ---------------------------------------------------------------------------
+# 1. Fresh warm flag stays warm within the TTL (perf: still "warm once").
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_warm_flag_is_considered_fetched(pool):
+    """A just-warmed phone must read as fetched — no needless re-warm (#1043)."""
+    pool.mark_dialogs_fetched("+7001")
+    assert pool.is_dialogs_fetched("+7001") is True
+
+
+def test_warm_flag_within_ttl_does_not_expire(pool):
+    """Inside the TTL window the flag stays warm — we do not regress the
+    "warm at most once per phone" behaviour the hot path relies on."""
+    clock = {"now": 1_000.0}
+    pool._monotonic = lambda: clock["now"]
+    pool._dialogs_warm_ttl_sec = 100.0
+
+    pool.mark_dialogs_fetched("+7001")
+    clock["now"] += 99.0  # still inside the 100s window
+
+    assert pool.is_dialogs_fetched("+7001") is True
+
+
+# ---------------------------------------------------------------------------
+# 2. TTL expiry → the next collection re-warms.
+# ---------------------------------------------------------------------------
+
+
+def test_warm_flag_expires_after_ttl(pool):
+    """Past the TTL the flag reads as cold → the next pass warms again."""
+    clock = {"now": 1_000.0}
+    pool._monotonic = lambda: clock["now"]
+    pool._dialogs_warm_ttl_sec = 100.0
+
+    pool.mark_dialogs_fetched("+7001")
+    clock["now"] += 101.0  # just past the window
+
+    assert pool.is_dialogs_fetched("+7001") is False
+
+
+def test_expired_warm_flag_can_be_rewarmed(pool):
+    """After TTL expiry a fresh mark restores the warm state for a new window."""
+    clock = {"now": 1_000.0}
+    pool._monotonic = lambda: clock["now"]
+    pool._dialogs_warm_ttl_sec = 100.0
+
+    pool.mark_dialogs_fetched("+7001")
+    clock["now"] += 200.0
+    assert pool.is_dialogs_fetched("+7001") is False
+
+    pool.mark_dialogs_fetched("+7001")  # re-warm
+    assert pool.is_dialogs_fetched("+7001") is True
+
+
+# ---------------------------------------------------------------------------
+# 3. Re-auth (new StringSession) invalidates the warm flag; a bare reconnect
+#    of the same session keeps it (the entity cache survives on the same
+#    session object — re-warming there would be a needless round-trip).
+#
+# Telethon fact this rests on (verified against telethon 1.42): the entity
+# cache that resolves a numeric ``PeerChannel`` lives in
+# ``StringSession._entities`` on the *session object*. ``get_input_entity``
+# falls back to ``session.get_input_entity(peer)``, so the cache survives
+# ``client.disconnect()`` + ``client.connect()`` as long as the same client /
+# session object is reused. Only swapping in a brand-new session (re-auth)
+# starts from an empty cache.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_add_client_resets_warm_flag(pool):
+    """Swapping a StringSession (re-auth) drops the warm flag → re-warm next pass.
+
+    The new session object has an empty entity cache, so a stale warm flag
+    would make ``_acquire_collection_client`` skip the warm round-trip and let
+    numeric-channel resolves miss on the long-running worker (#1043).
+    """
+    pool.mark_dialogs_fetched("+7001")
+    assert pool.is_dialogs_fetched("+7001") is True
+
+    # add_client connects the account; make that a no-op for the unit test.
+    lease = MagicMock()
+    lease.disconnect_on_release = False
+    pool._connect_account = AsyncMock(return_value=lease)
+    pool._backend_router = MagicMock()
+    pool._backend_router.release = AsyncMock()
+
+    await pool.add_client("+7001", "new-session-string")
+
+    assert pool.is_dialogs_fetched("+7001") is False
+
+
+@pytest.mark.anyio
+async def test_reconnect_phone_keeps_warm_flag(pool):
+    """A reconnect reuses the same session object → entity cache survives →
+    the warm flag must be kept (re-warming would be a needless round-trip)."""
+    client = AsyncMock()
+    client.is_connected = MagicMock(side_effect=[False, True])
+    client.connect = AsyncMock()
+    pool.clients["+7001"] = TelegramTransportSession(client, disconnect_on_close=False)
+    pool.mark_dialogs_fetched("+7001")
+
+    result = await pool.reconnect_phone("+7001")
+
+    assert result is True
+    assert pool.is_dialogs_fetched("+7001") is True
+
+
+@pytest.mark.anyio
+async def test_force_reconnect_phone_keeps_warm_flag(pool):
+    """force_reconnect (#556 MTProto brick recovery) tears down and re-opens the
+    transport on the *same* session object → ``session._entities`` survives → the
+    warm flag stays warm; no re-warm / FloodWait risk on the hot path (#1043)."""
+    client = AsyncMock()
+    client.disconnect = AsyncMock()
+    client.connect = AsyncMock()
+    client.is_user_authorized = AsyncMock(return_value=True)
+    client.is_connected = MagicMock(return_value=True)
+    pool.clients["+7001"] = TelegramTransportSession(client, disconnect_on_close=False)
+    pool.mark_dialogs_fetched("+7001")
+
+    result = await pool.force_reconnect_phone("+7001")
+
+    assert result is True
+    assert pool.is_dialogs_fetched("+7001") is True
+
+
+# ---------------------------------------------------------------------------
+# 4. End-to-end on the collector's hot path: an expired warm flag drives
+#    ``_acquire_collection_client`` to re-warm a no-username channel (so numeric
+#    PeerChannel resolves recover on a long-lived worker), while a fresh flag
+#    still skips the warm round-trip.
+# ---------------------------------------------------------------------------
+
+
+def _identity_adapt(session, **_kwargs):
+    return session
+
+
+def _warmable_session():
+    session = MagicMock()
+    session.warm_dialog_cache = AsyncMock()
+    return session
+
+
+def _real_pool_for_collector(mock_auth, mock_db, clock, ttl, *, session, phone):
+    """A *real* ``ClientPool`` (so the genuine TTL warm-flag logic runs) with
+    only the acquisition surface the collector touches stubbed out.
+
+    Using a real pool — not a rebound ``make_mock_pool`` — keeps the TTL path
+    honest: ``is_dialogs_fetched`` / ``mark_dialogs_fetched`` are the production
+    methods reading the production state, with the clock injected via
+    ``_monotonic``.
+    """
+    pool = ClientPool(mock_auth, mock_db)
+    pool._monotonic = lambda: clock["now"]
+    pool._dialogs_warm_ttl_sec = ttl
+    pool.get_available_client = AsyncMock(return_value=(session, phone))
+    pool.get_phone_for_channel = lambda channel_id: None
+    pool.is_warming = lambda: False
+    pool.wait_for_warm = AsyncMock()
+    pool.release_client = AsyncMock()
+    pool.remember_channel_phone = AsyncMock()
+    return pool
+
+
+@pytest.mark.anyio
+async def test_acquire_rewarms_after_ttl_expiry(mock_auth, mock_db):
+    """After the warm flag ages past its TTL, the next collection re-warms the
+    phone — the core #1043 fix: numeric-channel resolves recover on a long-lived
+    worker instead of silently skipping the warm forever."""
+    channel = Channel(channel_id=556001, title="Private")  # no username
+    session = _warmable_session()
+    clock = {"now": 1_000.0}
+    pool = _real_pool_for_collector(
+        mock_auth, mock_db, clock, ttl=100.0, session=session, phone="+7000"
+    )
+    pool.mark_dialogs_fetched("+7000")  # warmed at t=1000
+    clock["now"] += 200.0  # past the 100s TTL → stale
+
+    collector = Collector(pool, mock_db, SchedulerConfig())
+    with patch("src.telegram.collector.adapt_transport_session", _identity_adapt):
+        result = await collector._acquire_collection_client(channel, set())
+
+    assert result is not _ACQUIRE_RETRY
+    session.warm_dialog_cache.assert_awaited_once()  # re-warmed
+    assert pool.is_dialogs_fetched("+7000") is True  # freshly re-marked
+
+
+@pytest.mark.anyio
+async def test_acquire_skips_rewarm_within_ttl(mock_auth, mock_db):
+    """Within the TTL the collector must NOT re-warm — the warm-once-per-window
+    invariant (no perf regression / FloodWait risk on the hot path)."""
+    channel = Channel(channel_id=556002, title="Private")  # no username
+    session = _warmable_session()
+    clock = {"now": 1_000.0}
+    pool = _real_pool_for_collector(
+        mock_auth, mock_db, clock, ttl=100.0, session=session, phone="+7000"
+    )
+    pool.mark_dialogs_fetched("+7000")  # warmed at t=1000
+    clock["now"] += 50.0  # still inside the 100s TTL → fresh
+
+    collector = Collector(pool, mock_db, SchedulerConfig())
+    with patch("src.telegram.collector.adapt_transport_session", _identity_adapt):
+        result = await collector._acquire_collection_client(channel, set())
+
+    assert result is not _ACQUIRE_RETRY
+    session.warm_dialog_cache.assert_not_awaited()  # no needless re-warm

--- a/tests/test_dialog_cache_ttl.py
+++ b/tests/test_dialog_cache_ttl.py
@@ -31,6 +31,7 @@ Fix surface (cache flags only, no ClientPool refactor — #1023 boundary):
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -192,6 +193,71 @@ async def test_force_reconnect_phone_keeps_warm_flag(pool):
     result = await pool.force_reconnect_phone("+7001")
 
     assert result is True
+    assert pool.is_dialogs_fetched("+7001") is True
+
+
+@pytest.mark.anyio
+async def test_acquire_from_lease_resets_warm_flag_on_session_replacement(pool):
+    """Auto-reconnect fallback swaps in a fresh backend session → warm flag drops.
+
+    When a cached direct session is disconnected and ``connect()`` fails,
+    ``_acquire_from_lease`` falls back to the backend, which builds a brand-new
+    client / StringSession (empty entity cache) and replaces ``clients[phone]``.
+    The warm flag must be invalidated there too — otherwise numeric PeerChannel
+    collection would skip the warm against the fresh empty session (#1043,
+    cycle-review HIGH finding). A bare reconnect that *succeeds* is covered
+    separately and keeps the flag.
+    """
+    # A cached direct session that looks disconnected → triggers the fallback.
+    stale_client = AsyncMock()
+    stale_client.is_connected = MagicMock(return_value=False)
+    stale_client.connect = AsyncMock(side_effect=RuntimeError("stream closed"))
+    pool.clients["+7001"] = TelegramTransportSession(stale_client, disconnect_on_close=False)
+    pool.mark_dialogs_fetched("+7001")
+    assert pool.is_dialogs_fetched("+7001") is True
+
+    # Backend hands back a fresh session (new object → cold entity cache).
+    fresh_client = AsyncMock()
+    fresh_session = TelegramTransportSession(fresh_client, disconnect_on_close=False)
+    lease = MagicMock()
+    lease.session = fresh_session
+    lease.disconnect_on_release = True
+    pool._backend_router = MagicMock()
+    pool._backend_router.acquire_client = AsyncMock(return_value=lease)
+
+    account_lease = SimpleNamespace(
+        account=SimpleNamespace(phone="+7001"), shared=False
+    )
+    result = await pool._acquire_from_lease(account_lease)
+
+    assert result is not None
+    assert pool.is_dialogs_fetched("+7001") is False
+
+
+@pytest.mark.anyio
+async def test_acquire_from_lease_keeps_warm_flag_on_successful_inplace_reconnect(pool):
+    """A successful in-place auto-reconnect reuses the same session object →
+    entity cache survives → the warm flag must be kept (no needless re-warm).
+
+    Complements the replacement case above: the reset is precise — it fires only
+    when the backend swaps in a fresh session, not on every reconnect.
+    """
+    client = AsyncMock()
+    client.is_connected = MagicMock(return_value=False)  # cached session looks down
+    client.connect = AsyncMock()  # reconnect SUCCEEDS in place
+    pool.clients["+7001"] = TelegramTransportSession(client, disconnect_on_close=False)
+    pool.mark_dialogs_fetched("+7001")
+    pool._active_leases["+7001"] = []
+    pool._backend_router = MagicMock()
+    pool._backend_router.acquire_client = AsyncMock()  # must NOT be used
+
+    account_lease = SimpleNamespace(
+        account=SimpleNamespace(phone="+7001"), shared=False
+    )
+    result = await pool._acquire_from_lease(account_lease)
+
+    assert result is not None
+    pool._backend_router.acquire_client.assert_not_awaited()  # same session reused
     assert pool.is_dialogs_fetched("+7001") is True
 
 


### PR DESCRIPTION
## Что и зачем

Per-phone warm-флаг entity-кэша диалогов (`_dialogs_fetched`) считался «прогретым навечно»: не было ни TTL, ни инвалидации при замене session-объекта. На долгоживущем worker это позволяло `is_dialogs_fetched` возвращать True после того, как реальный entity-кэш устаревал → `_acquire_collection_client` пропускал warm round-trip → numeric `PeerChannel` resolve начинал промахиваться. Часть эпика #1025 (функция 1 — Сбор → БД).

## Дизайн (cache-флаги only, без рефактора ClientPool — граница #1023)

1. **TTL на warm-флаг — главный фикс.** Добавлен `_dialogs_warm_ttl_sec` (30 мин, монотонные часы), отдельный от `_dialogs_cache_ttl_sec` (60s — для другого кэша, list-of-dialogs). `is_dialogs_fetched` истекает по TTL и само-чистит запись → следующий сбор прогревает заново. В пределах TTL флаг остаётся True → warm всё ещё «один раз за окно», без перф-регресса. Состояние осталось `set` + отдельный dict временных меток (не ломает тесты, мутирующие `_dialogs_fetched` напрямую).

2. **Инвалидация только в `add_client` (re-auth с новым session-string).** `remove_client` / `disconnect_all` уже сбрасывали флаг на teardown — теперь через общий `reset_dialogs_warm`.

## Развилка: почему reconnect НЕ инвалидирует (вопреки буквальному тексту issue)

Эмпирически проверено против **telethon 1.42**: entity-кэш, резолвящий numeric `PeerChannel`, живёт в `StringSession._entities` на **session-объекте**; `get_input_entity` падает в `session.get_input_entity(peer)` как fallback. Значит кэш **переживает** `disconnect()` + `connect()` на том же клиенте. `reconnect_phone` / `force_reconnect_phone` переиспользуют тот же session-объект → re-warm там был бы лишним round-trip и риском FloodWait на prefetch (чего issue прямо просит избегать). Кэш реально теряется только при `add_client` (новый StringSession). Долгоживущий дрейф закрывается TTL.

Развилка согласована (см. коммент в issue).

## TDD

Red→green, **каждый ассерт мутационно верифицирован**. Покрытие (`tests/test_dialog_cache_ttl.py`, 9 тестов):
- re-warm после истечения TTL (на флаге пула **и** end-to-end на горячем пути коллектора через реальный `ClientPool`);
- re-warm после re-auth (`add_client`);
- **нет** лишнего re-warm в пределах TTL и при bare reconnect (перф-гард).

## Проверки
- `pytest -n auto -m "not aiosqlite_serial"`: **8714 passed, 140 skipped**
- `pytest -m aiosqlite_serial`: **937 passed**
- `ruff check src/ tests/ conftest.py`: clean
- `mypy`: 0 новых ошибок (baseline-сравнение по изменённым файлам идентично)

## Файлы
- `src/telegram/client_pool.py` — поля состояния (`_dialogs_fetched_at_monotonic`, `_dialogs_warm_ttl_sec`, инжектируемый `_monotonic`)
- `src/telegram/pool_dialogs.py` — TTL в `is_dialogs_fetched`/`mark_dialogs_fetched` + `reset_dialogs_warm`
- `src/telegram/pool_lifecycle.py` — инвалидация в `add_client`; reconnect-хуки задокументированы как «кэш переживает»
- `tests/test_dialog_cache_ttl.py` (new), `tests/test_client_pool_decomposition.py` (контракт)

Closes #1043

🤖 Generated with [Claude Code](https://claude.com/claude-code)