### PR TITLE
feat(pipeline): fail-closed on DAG cycles and source-scope lookup errors (#1077)

### DIFF
--- a/src/cli/commands/pipeline.py
+++ b/src/cli/commands/pipeline.py
@@ -13,6 +13,7 @@ from src.services.pipeline_llm_requirements import pipeline_needs_llm
 from src.services.pipeline_refs import parse_pipeline_target_refs
 from src.services.pipeline_result import result_kind_label
 from src.services.pipeline_service import (
+    PipelineScopeError,
     PipelineService,
     PipelineTargetRef,
     PipelineValidationError,
@@ -508,7 +509,13 @@ def run(args: argparse.Namespace) -> None:
                 provider_callable = provider_service.get_provider_callable(pipeline.llm_model)
                 engine = SearchEngine(db)
                 gen = GenerationService(engine, provider_callable=provider_callable)
-                scope = await svc.get_retrieval_scope(pipeline)
+                # Fail-closed (#1077): never widen a failed source-scope lookup to
+                # an all-channels retrieval. Abort before creating a run.
+                try:
+                    scope = await svc.get_retrieval_scope(pipeline)
+                except PipelineScopeError as exc:
+                    print(safe_json_dumps({"event": "error", "error": str(exc)}), flush=True)
+                    return
 
                 run_id = await db.repos.generation_runs.create_run(
                     pipeline.id, pipeline.prompt_template
@@ -961,7 +968,12 @@ def run(args: argparse.Namespace) -> None:
 
             elif args.pipeline_action == "edge":
                 if args.edge_action == "add":
-                    ok = await svc.add_edge(args.pipeline_id, args.from_node, args.to_node)
+                    try:
+                        ok = await svc.add_edge(args.pipeline_id, args.from_node, args.to_node)
+                    except PipelineValidationError as exc:
+                        # Fail-closed (#1077): a cycle-creating edge is rejected.
+                        print(f"Error: {exc}")
+                        return
                     if ok:
                         print(f"Added edge {args.from_node} -> {args.to_node}")
                     else:

--- a/src/cli/commands/pipeline.py
+++ b/src/cli/commands/pipeline.py
@@ -77,6 +77,20 @@ def _format_filter_config(config: dict) -> list[str]:
     ]
 
 
+async def _safe_add_edge(svc: PipelineService, pipeline_id: int, from_node: str, to_node: str) -> bool:
+    """Add a rewiring edge, skipping it if it would create a cycle (#1077).
+
+    The filter-node splice/unsplice helpers reconnect edges around a node; that
+    rewiring must never silently build a cyclic graph, but a cycle-creating edge
+    here also must not crash the whole ``pipeline filter`` command with an
+    uncaught ``PipelineValidationError``. Skip the offending edge instead — the
+    rest of the rewire stays intact and the graph remains acyclic."""
+    try:
+        return await svc.add_edge(pipeline_id, from_node, to_node)
+    except PipelineValidationError:
+        return False
+
+
 async def _upsert_filter_node(svc: PipelineService, pipeline_id: int, config: dict) -> bool:
     graph = await svc.get_graph(pipeline_id)
     if graph is None:
@@ -113,10 +127,10 @@ async def _upsert_filter_node(svc: PipelineService, pipeline_id: int, config: di
     for downstream_id in downstream_ids:
         await svc.remove_edge(pipeline_id, upstream_id, downstream_id)
     if upstream_id:
-        await svc.add_edge(pipeline_id, upstream_id, "filter_1")
+        await _safe_add_edge(svc, pipeline_id, upstream_id, "filter_1")
     for downstream_id in downstream_ids:
         if downstream_id != "filter_1":
-            await svc.add_edge(pipeline_id, "filter_1", downstream_id)
+            await _safe_add_edge(svc, pipeline_id, "filter_1", downstream_id)
     return True
 
 
@@ -134,7 +148,7 @@ async def _clear_filter_node(svc: PipelineService, pipeline_id: int) -> bool:
         return False
     for source in incoming:
         for target in outgoing:
-            await svc.add_edge(pipeline_id, source, target)
+            await _safe_add_edge(svc, pipeline_id, source, target)
     return True
 
 

--- a/src/services/pipeline_executor.py
+++ b/src/services/pipeline_executor.py
@@ -12,8 +12,22 @@ from src.services.pipeline_result import get_action_counts, summarize_result
 logger = logging.getLogger(__name__)
 
 
+class PipelineCycleError(ValueError):
+    """Raised when a pipeline graph contains a cycle and cannot be scheduled.
+
+    A cyclic graph has unsatisfiable dependencies: for side-effecting nodes
+    (publish/delete/react) running them in authoring order could fire an action
+    before its prerequisite. We therefore reject cycles fail-closed (#1077)
+    instead of falling back to authoring order and executing them anyway.
+    """
+
+
 def _topological_sort(graph: PipelineGraph) -> list[PipelineNode]:
-    """Return nodes in topological order (Kahn's algorithm)."""
+    """Return nodes in topological order (Kahn's algorithm).
+
+    Raises :class:`PipelineCycleError` if the graph contains a cycle — there is
+    no safe authoring-order fallback for a cyclic DAG (#1077, fail-closed).
+    """
     nodes_by_id = {n.id: n for n in graph.nodes}
     in_degree: dict[str, int] = {n.id: 0 for n in graph.nodes}
     adj: dict[str, list[str]] = defaultdict(list)
@@ -35,8 +49,15 @@ def _topological_sort(graph: PipelineGraph) -> list[PipelineNode]:
                 queue.append(neighbor)
 
     if len(order) != len(graph.nodes):
-        logger.warning("Pipeline graph has a cycle; using original node order as fallback")
-        return list(graph.nodes)
+        # Every node that never reached in_degree 0 is part of (or fed by) the
+        # cycle; report them so an operator can locate the unschedulable region.
+        ordered_ids = {n.id for n in order}
+        cyclic = [n.id for n in graph.nodes if n.id not in ordered_ids]
+        logger.error("Pipeline graph has a cycle involving nodes %s; rejecting run", cyclic)
+        raise PipelineCycleError(
+            f"Pipeline graph contains a cycle and cannot be executed; "
+            f"nodes still in the cycle: {cyclic}"
+        )
 
     return order
 

--- a/src/services/pipeline_service.py
+++ b/src/services/pipeline_service.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import re
+from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable
 
@@ -57,25 +58,49 @@ class PipelineRetrievalScope:
     channel_id: int | None
 
 
+class PipelineScopeError(RuntimeError):
+    """Raised when a pipeline's source scope cannot be resolved.
+
+    Fail-closed for content isolation (#1077): a ``channel_id`` of ``None``
+    means UNSCOPED retrieval across ALL channels. The old code swallowed a
+    failed source lookup and returned ``channel_id=None``, silently widening a
+    single-source pipeline into a cross-channel search on a transient DB blip —
+    content could then be generated/published from channels outside the
+    configured sources (a trust-boundary breach). We therefore abort the run
+    instead of widening the scope.
+    """
+
+
 async def resolve_retrieval_scope(
     pipeline: ContentPipeline,
     list_sources: Callable[[int], Awaitable[list[Any]]] | None = None,
 ) -> PipelineRetrievalScope:
-    """Return retrieval query and optional single-source scope for a pipeline."""
+    """Return retrieval query and optional single-source scope for a pipeline.
+
+    Raises :class:`PipelineScopeError` if the source lookup fails — we must not
+    fall back to an unscoped (all-channels) retrieval on a transient failure
+    (#1077, fail-closed). A genuinely unscoped pipeline (no ``list_sources``, or
+    zero/multiple configured sources) still returns ``channel_id=None``; only an
+    *errored* lookup is rejected.
+    """
     query = pipeline.name or ""
     channel_id: int | None = None
     if list_sources is None:
         return PipelineRetrievalScope(query=query, channel_id=channel_id)
     try:
         sources = await list_sources(pipeline.id)
-        if len(sources) == 1:
-            channel_id = sources[0].channel_id
-    except Exception:
-        logger.warning(
-            "Failed to load pipeline sources for %s, continuing without channel scoping",
+    except Exception as exc:
+        logger.error(
+            "Failed to load pipeline sources for %s; refusing to widen scope to all channels",
             pipeline.id,
             exc_info=True,
         )
+        raise PipelineScopeError(
+            f"Could not resolve source scope for pipeline {pipeline.id}; "
+            "aborting to avoid cross-channel retrieval"
+        ) from exc
+    if len(sources) == 1:
+        channel_id = sources[0].channel_id
     return PipelineRetrievalScope(query=query, channel_id=channel_id)
 
 
@@ -742,8 +767,39 @@ class PipelineService:
         await self._bundle.content_pipelines.set_pipeline_json(pipeline_id, graph)
         return True
 
+    @staticmethod
+    def _edge_creates_cycle(graph: PipelineGraph, from_node: str, to_node: str) -> bool:
+        """Return True if adding ``from_node -> to_node`` would create a cycle.
+
+        A new edge closes a cycle iff ``to_node`` can already reach ``from_node``
+        through the existing edges (or it is a self-loop). Reject such edges up
+        front so a cyclic graph never reaches the executor (#1077, defence in
+        depth — the executor also rejects cycles at run time)."""
+        if from_node == to_node:
+            return True
+        adj: dict[str, list[str]] = defaultdict(list)
+        for edge in graph.edges:
+            adj[edge.from_node].append(edge.to_node)
+        # DFS from to_node; if we reach from_node, the edge would close a loop.
+        stack = [to_node]
+        seen: set[str] = set()
+        while stack:
+            current = stack.pop()
+            if current == from_node:
+                return True
+            if current in seen:
+                continue
+            seen.add(current)
+            stack.extend(adj[current])
+        return False
+
     async def add_edge(self, pipeline_id: int, from_node: str, to_node: str) -> bool:
-        """Add an edge to the pipeline's graph. Returns False if pipeline/graph not found or endpoints don't exist."""
+        """Add an edge to the pipeline's graph.
+
+        Returns False if pipeline/graph not found or endpoints don't exist.
+        Raises :class:`PipelineValidationError` if the edge would create a cycle
+        (#1077, fail-closed) — a cyclic graph cannot be executed safely.
+        """
         graph = await self.get_graph(pipeline_id)
         if graph is None:
             return False
@@ -753,6 +809,10 @@ class PipelineService:
         # Idempotent: don't add duplicate edges
         existing = {(e.from_node, e.to_node) for e in graph.edges}
         if (from_node, to_node) not in existing:
+            if self._edge_creates_cycle(graph, from_node, to_node):
+                raise PipelineValidationError(
+                    f"Edge {from_node} -> {to_node} would create a cycle in the pipeline graph."
+                )
             graph.edges.append(PipelineEdge(from_node=from_node, to_node=to_node))
             await self._bundle.content_pipelines.set_pipeline_json(pipeline_id, graph)
         return True

--- a/src/web/pipelines/handlers.py
+++ b/src/web/pipelines/handlers.py
@@ -15,6 +15,7 @@ from src.services.pipeline_llm_requirements import (
     pipeline_needs_publish_mode,
 )
 from src.services.pipeline_service import (
+    PipelineScopeError,
     PipelineService,
     PipelineValidationError,
 )
@@ -501,7 +502,12 @@ async def generate_stream(
     from src.services.generation_service import GenerationService
 
     gen = GenerationService(engine, provider_callable=provider_callable)
-    scope = await svc.get_retrieval_scope(pipeline)
+    # Fail-closed (#1077): a source-scope resolution failure must not silently
+    # widen the retrieval to all channels. Abort the run cleanly instead.
+    try:
+        scope = await svc.get_retrieval_scope(pipeline)
+    except PipelineScopeError as exc:
+        return _pipeline_redirect(str(exc), error=True)
 
     # persist run
     run_id = await db.repos.generation_runs.create_run(pipeline_id, pipeline.prompt_template)

--- a/tests/routes/test_pipelines_routes.py
+++ b/tests/routes/test_pipelines_routes.py
@@ -395,6 +395,42 @@ async def test_generate_stream_pipeline_not_found(client):
 
 
 @pytest.mark.anyio
+async def test_generate_stream_scope_error_fails_closed(client):
+    """Fail-closed (#1077): a source-scope resolution failure must abort the run
+    with a clean error redirect — NOT a 500 and NOT a stream that silently runs
+    unscoped (cross-channel) retrieval. A transient source-lookup blip must never
+    widen a single-source pipeline to all channels."""
+    from unittest.mock import patch
+
+    from src.services.pipeline_service import PipelineScopeError
+
+    await client.post("/pipelines/add", data=_ADD_DATA)
+
+    mock_provider_instance = MagicMock()
+    mock_provider_instance.has_providers = MagicMock(return_value=True)
+    mock_provider_instance.get_provider_callable = MagicMock(return_value=lambda: None)
+    app = client._transport.app  # type: ignore
+    app.state.llm_provider_service = mock_provider_instance
+    db = app.state.db
+
+    async def boom(_pipeline):
+        raise PipelineScopeError("source lookup failed")
+
+    with patch(
+        "src.services.pipeline_service.PipelineService.get_retrieval_scope",
+        side_effect=boom,
+    ):
+        resp = await client.get("/pipelines/1/generate-stream", follow_redirects=False)
+
+    # Clean fail-closed redirect, not a 200 stream and not a 500.
+    assert resp.status_code == 303
+    assert "error=" in resp.headers["location"]
+    # No run should have been created — the abort happens before persistence.
+    runs = await db.repos.generation_runs.list_by_pipeline(1)
+    assert runs == []
+
+
+@pytest.mark.anyio
 async def test_generate_pipeline_success(client):
     """Test non-streaming generation success."""
     from unittest.mock import patch

--- a/tests/test_cli_pipeline_commands.py
+++ b/tests/test_cli_pipeline_commands.py
@@ -955,6 +955,34 @@ class TestPipelineEdgeRW:
         graph = json.loads(row["pipeline_json"])
         assert ("publish_0", "source_0") not in _edge_pairs(graph)
 
+    def test_safe_add_edge_skips_cycle_without_raising(self, tmp_path):
+        """The filter-rewiring helper (#1077): _safe_add_edge must NOT crash the
+        `pipeline filter` command when a reconnection would close a cycle — it
+        skips the offending edge (returns False) instead of propagating
+        PipelineValidationError, while a legitimate edge is still added."""
+        from src.cli.commands.pipeline import _safe_add_edge
+        from src.services.pipeline_service import PipelineService
+
+        db_path = _empty_db_path(tmp_path, "pipeline_safe_edge.db")
+        pid = _seed_pipeline_with_graph(db_path)  # source_0 -> llm_generate_0 -> publish_0
+        db = _open_db(db_path)
+        try:
+            svc = PipelineService(db)
+            # A cycle-closing edge is skipped gracefully (no raise, returns False).
+            skipped = asyncio.run(_safe_add_edge(svc, pid, "publish_0", "source_0"))
+            assert skipped is False
+            # A legitimate forward shortcut is still added (returns True).
+            added = asyncio.run(_safe_add_edge(svc, pid, "source_0", "publish_0"))
+            assert added is True
+        finally:
+            _close_db(db)
+
+        row = _read_pipeline_row(db_path, pid)
+        graph = json.loads(row["pipeline_json"])
+        pairs = _edge_pairs(graph)
+        assert ("publish_0", "source_0") not in pairs  # cycle skipped
+        assert ("source_0", "publish_0") in pairs       # valid edge persisted
+
 
 class TestPipelineExportRW:
     def test_export_writes_new_file(self, tmp_path, cli_init_patch, capsys):

--- a/tests/test_cli_pipeline_commands.py
+++ b/tests/test_cli_pipeline_commands.py
@@ -928,6 +928,33 @@ class TestPipelineEdgeRW:
         assert ("llm_generate_0", new_node["id"]) not in _edge_pairs(graph3)
         assert "Removed edge" in capsys.readouterr().out
 
+    def test_edge_add_rejecting_cycle_fails_closed(self, tmp_path, cli_init_patch, capsys):
+        """Fail-closed (#1077): the seeded graph is source_0 -> llm_generate_0 ->
+        publish_0. Adding publish_0 -> source_0 would close a cycle, so the CLI
+        must reject it with an Error message and NOT persist the back-edge."""
+        db_path = _empty_db_path(tmp_path, "pipeline_edge_cycle.db")
+        pid = _seed_pipeline_with_graph(db_path)
+
+        _pipeline_cli_run(
+            db_path,
+            cli_init_patch,
+            _pipeline_ns(
+                "edge",
+                pipeline_id=pid,
+                edge_action="add",
+                from_node="publish_0",
+                to_node="source_0",
+            ),
+        )
+
+        out = capsys.readouterr().out
+        assert "Error" in out
+        assert "Added edge" not in out
+        # The back-edge must NOT be persisted — the graph stays acyclic.
+        row = _read_pipeline_row(db_path, pid)
+        graph = json.loads(row["pipeline_json"])
+        assert ("publish_0", "source_0") not in _edge_pairs(graph)
+
 
 class TestPipelineExportRW:
     def test_export_writes_new_file(self, tmp_path, cli_init_patch, capsys):

--- a/tests/test_generation_service_rag_context.py
+++ b/tests/test_generation_service_rag_context.py
@@ -5,13 +5,16 @@ Tier-2 bug-hunt, retrieval side:
     duplicate citation entries (bug, fixed here);
   * null ``Message`` fields (``channel_title=None``/``channel_username=None``)
     must degrade gracefully — regression guard, proven by mutation;
-  * ``resolve_retrieval_scope`` must fail closed: a scope lookup error and a
-    multi-source pipeline must both leave ``channel_id=None`` so retrieval never
-    leaks across channels — regression guards (cf. #1037/#1077 fail-closed).
+  * ``resolve_retrieval_scope`` must fail closed (#1077): a scope lookup error
+    raises ``PipelineScopeError`` (never silently widens to all channels), and a
+    multi-source pipeline legitimately leaves ``channel_id=None`` — regression
+    guards (cf. #1037/#1077 fail-closed).
 """
 from __future__ import annotations
 
 from datetime import datetime, timezone
+
+import pytest
 
 from src.models import (
     ContentPipeline,
@@ -169,16 +172,18 @@ class _Source:
         self.channel_id = channel_id
 
 
-async def test_scope_lookup_error_falls_back_without_channel():
-    """A failing list_sources must not raise — scope degrades to channel_id=None."""
+async def test_scope_lookup_error_fails_closed():
+    """A failing list_sources must FAIL CLOSED with PipelineScopeError — never
+    degrade to channel_id=None (which is unscoped retrieval across ALL channels,
+    a content-isolation breach). #1077 changes the old swallow-and-widen
+    behaviour this test previously documented."""
+    from src.services.pipeline_service import PipelineScopeError
 
     async def failing_list_sources(pipeline_id: int):
         raise RuntimeError("DB scope lookup failed")
 
-    scope = await resolve_retrieval_scope(_pipeline(), failing_list_sources)
-
-    assert scope.query == "MyPipe"
-    assert scope.channel_id is None
+    with pytest.raises(PipelineScopeError):
+        await resolve_retrieval_scope(_pipeline(), failing_list_sources)
 
 
 async def test_scope_single_source_sets_channel():

--- a/tests/test_pipeline_executor.py
+++ b/tests/test_pipeline_executor.py
@@ -13,7 +13,11 @@ from src.models import (
     PipelineNodeType,
     PipelinePublishMode,
 )
-from src.services.pipeline_executor import PipelineExecutor, _topological_sort
+from src.services.pipeline_executor import (
+    PipelineCycleError,
+    PipelineExecutor,
+    _topological_sort,
+)
 from src.services.pipeline_nodes.base import NodeContext
 
 # ---------------------------------------------------------------------------
@@ -81,19 +85,52 @@ class TestTopologicalSortDiamond:
 
 
 # ---------------------------------------------------------------------------
-# 3. _topological_sort — cycle falls back to original order
+# 3. _topological_sort — a cycle is rejected fail-closed (#1077)
+#
+# Previously (#1075) a cycle silently fell back to authoring order and the
+# executor ran every node anyway — for side-effecting nodes (publish/delete/
+# react) that means an action can fire before its prerequisite. #1077 changes
+# the contract: a cyclic graph has unsatisfiable dependencies, so it must be
+# rejected up front with a typed error, never executed.
 # ---------------------------------------------------------------------------
 
 class TestTopologicalSortCycle:
-    def test_cycle_returns_original_order(self):
+    def test_cycle_raises_pipeline_cycle_error(self):
+        """A cyclic graph cannot be ordered → PipelineCycleError, not a silent
+        fallback to authoring order (#1077, fail-closed)."""
         graph = PipelineGraph(
             nodes=[_node("x"), _node("y"), _node("z")],
             edges=[_edge("x", "y"), _edge("y", "z"), _edge("z", "x")],
         )
-        order = _topological_sort(graph)
-        ids = [n.id for n in order]
-        # Should fall back to the original node list
-        assert ids == ["x", "y", "z"]
+        with pytest.raises(PipelineCycleError):
+            _topological_sort(graph)
+
+    def test_self_loop_raises_pipeline_cycle_error(self):
+        """A single node pointing at itself is the minimal cycle — also rejected."""
+        graph = PipelineGraph(nodes=[_node("solo")], edges=[_edge("solo", "solo")])
+        with pytest.raises(PipelineCycleError):
+            _topological_sort(graph)
+
+    def test_cycle_error_names_offending_nodes(self):
+        """The error must identify the nodes still trapped in the cycle so an
+        operator can see WHICH part of the graph is unschedulable. Uses
+        distinctive node ids (not bare single letters that collide with the
+        surrounding prose) so the assertion is about the reported cycle list."""
+        graph = PipelineGraph(
+            nodes=[_node("root_clean"), _node("loop_lhs"), _node("loop_rhs")],
+            # root_clean is an acyclic root; loop_lhs<->loop_rhs form the cycle.
+            edges=[
+                _edge("root_clean", "loop_lhs"),
+                _edge("loop_lhs", "loop_rhs"),
+                _edge("loop_rhs", "loop_lhs"),
+            ],
+        )
+        with pytest.raises(PipelineCycleError) as excinfo:
+            _topological_sort(graph)
+        message = str(excinfo.value)
+        assert "loop_lhs" in message and "loop_rhs" in message
+        # The acyclic root must NOT be reported as part of the cycle.
+        assert "root_clean" not in message
 
 
 # ---------------------------------------------------------------------------
@@ -596,21 +633,16 @@ class TestExecuteDiamondRunsMergeOnce:
         assert call_log[-1] == "d"
 
 
-class TestExecuteCycleRunsAllNodes:
+class TestExecuteCycleRejectedFailClosed:
     @pytest.mark.anyio
-    async def test_cycle_fallback_still_runs_every_node_once(self):
-        """A cyclic graph (x->y->z->x) can't be topo-sorted; the executor falls
-        back to original node order and must still run each node exactly once
-        (no infinite loop, no dropped node) — issue #1037 names the cycle
-        fallback's *end-to-end* behaviour as uncovered.
+    async def test_cycle_raises_before_any_node_runs(self):
+        """A cyclic graph (x->y->z->x) has unsatisfiable dependencies. #1077
+        changes the old fallback-and-run contract: execute() must reject it with
+        PipelineCycleError BEFORE invoking a single handler.
 
-        This pins the *current* fallback contract (run-in-authoring-order), NOT
-        an endorsement that running a cyclic graph is safe: for side-effecting
-        nodes (publish/delete/react) a cycle means unsatisfiable dependencies,
-        so authoring order can run an action before its prerequisite. Whether to
-        reject cycles up front (at add_edge / before execute) instead of falling
-        back is a behaviour change beyond this test-only PR's scope — raised as
-        a design fork on #1037 for the owner (cycle-review, Codex)."""
+        This is the security-relevant assertion — for side-effecting nodes
+        (publish/delete/react) the old fallback could fire an action before its
+        prerequisite. Fail-closed means ZERO handlers run on a cyclic graph."""
         graph = PipelineGraph(
             nodes=[_node("x"), _node("y"), _node("z")],
             edges=[_edge("x", "y"), _edge("y", "z"), _edge("z", "x")],
@@ -622,10 +654,54 @@ class TestExecuteCycleRunsAllNodes:
             "src.services.pipeline_executor.get_handler",
             side_effect=_counting_handler_factory(call_log),
         ):
+            with pytest.raises(PipelineCycleError):
+                await PipelineExecutor().execute(pipeline, graph, {})
+
+        # No node executed — the cycle is rejected before the run loop.
+        assert call_log == []
+
+    @pytest.mark.anyio
+    async def test_cycle_with_side_effecting_publish_node_runs_nothing(self):
+        """Concrete trust-boundary scenario from #1077: a cycle that includes a
+        side-effecting PUBLISH node must not fire that publish. The whole graph
+        is blocked, so the publish handler is never invoked."""
+        graph = PipelineGraph(
+            nodes=[
+                _node("gen", PipelineNodeType.LLM_GENERATE),
+                _node("pub", PipelineNodeType.PUBLISH),
+            ],
+            edges=[_edge("gen", "pub"), _edge("pub", "gen")],
+        )
+        pipeline = _pipeline()
+        call_log: list[str] = []
+
+        with patch(
+            "src.services.pipeline_executor.get_handler",
+            side_effect=_counting_handler_factory(call_log),
+        ):
+            with pytest.raises(PipelineCycleError):
+                await PipelineExecutor().execute(pipeline, graph, {})
+
+        assert "pub" not in call_log
+        assert call_log == []
+
+    @pytest.mark.anyio
+    async def test_acyclic_graph_still_executes_normally(self):
+        """Guard: the fail-closed change must NOT break valid acyclic graphs —
+        a clean chain still runs every node in dependency order."""
+        graph = PipelineGraph(
+            nodes=[_node("x"), _node("y"), _node("z")],
+            edges=[_edge("x", "y"), _edge("y", "z")],
+        )
+        pipeline = _pipeline()
+        call_log: list[str] = []
+
+        with patch(
+            "src.services.pipeline_executor.get_handler",
+            side_effect=_counting_handler_factory(call_log),
+        ):
             result = await PipelineExecutor().execute(pipeline, graph, {})
 
-        # Original order, each once. NOTE: in the cycle fallback every node has a
-        # live predecessor that already ran, so none are suppressed.
         assert call_log == ["x", "y", "z"]
         assert isinstance(result["context"], NodeContext)
 

--- a/tests/test_pipeline_service_edge_cases.py
+++ b/tests/test_pipeline_service_edge_cases.py
@@ -1162,6 +1162,43 @@ async def test_add_edge_no_graph(svc, pipeline_id):
 
 
 @pytest.mark.anyio
+async def test_add_edge_rejecting_back_edge_that_closes_cycle(svc, graph_pipeline_id):
+    """#1077 (fail-closed, defence in depth): the fixture graph is src->fetch->gen.
+    Adding gen->src would close a cycle (src reachable from gen), so add_edge must
+    reject it with PipelineValidationError and NOT persist the edge."""
+    from src.services.pipeline_service import PipelineValidationError
+
+    with pytest.raises(PipelineValidationError):
+        await svc.add_edge(graph_pipeline_id, "gen", "src")
+    # The graph must be unchanged: no gen->src edge was written.
+    graph = await svc.get_graph(graph_pipeline_id)
+    assert not any(e.from_node == "gen" and e.to_node == "src" for e in graph.edges)
+    assert len(graph.edges) == 2  # only the original src->fetch, fetch->gen
+
+
+@pytest.mark.anyio
+async def test_add_edge_rejects_self_loop(svc, graph_pipeline_id):
+    """A self-loop (node -> itself) is the minimal cycle and is rejected too."""
+    from src.services.pipeline_service import PipelineValidationError
+
+    with pytest.raises(PipelineValidationError):
+        await svc.add_edge(graph_pipeline_id, "gen", "gen")
+    graph = await svc.get_graph(graph_pipeline_id)
+    assert not any(e.from_node == "gen" and e.to_node == "gen" for e in graph.edges)
+
+
+@pytest.mark.anyio
+async def test_add_edge_allows_forward_edge_no_cycle(svc, graph_pipeline_id):
+    """Guard: a forward edge that does NOT close a cycle (src->gen, a shortcut
+    across the existing chain) must still be accepted — the cycle check must not
+    reject legitimate DAG edges."""
+    ok = await svc.add_edge(graph_pipeline_id, "src", "gen")
+    assert ok is True
+    graph = await svc.get_graph(graph_pipeline_id)
+    assert any(e.from_node == "src" and e.to_node == "gen" for e in graph.edges)
+
+
+@pytest.mark.anyio
 async def test_remove_edge(svc, graph_pipeline_id):
     ok = await svc.remove_edge(graph_pipeline_id, "src", "fetch")
     assert ok is True
@@ -1176,11 +1213,15 @@ async def test_remove_edge_not_found(svc, graph_pipeline_id):
 
 
 # ---------------------------------------------------------------------------
-# resolve_retrieval_scope — channel scoping graceful fallback (#1037, epic #1024).
+# resolve_retrieval_scope — channel scoping fail-closed (#1077, epic #1025).
 #
 # get_retrieval_scope's happy paths (single / multi source) are covered above;
-# the issue calls out the *error* path — a failing source lookup must degrade to
-# an unscoped retrieval, never crash the pipeline run.
+# the *error* path is the security-relevant one. A channel_id of None means
+# UNSCOPED retrieval across ALL channels, so a failed source lookup must NOT
+# silently fall back to None (which would widen a single-source pipeline into a
+# cross-channel search — a trust-boundary breach). #1077 changes the old
+# swallow-and-widen behaviour to a typed PipelineScopeError. The legitimate
+# unscoped paths (no lister / zero / multiple sources) still return None.
 # ---------------------------------------------------------------------------
 
 
@@ -1196,27 +1237,48 @@ async def test_resolve_scope_no_lister_returns_unscoped():
 
 
 @pytest.mark.anyio
-async def test_resolve_scope_source_lookup_error_falls_back_gracefully():
-    """A scoping error (source lister raises) is swallowed: retrieval continues
-    unscoped instead of propagating the exception into the run — this pins the
-    *current* graceful-fallback contract that issue #1037 asks to cover.
+async def test_resolve_scope_source_lookup_error_fails_closed():
+    """A scoping error (source lister raises) must FAIL CLOSED: #1077 changes the
+    old swallow-and-widen contract to a typed PipelineScopeError.
 
-    NOTE (design fork, raised on #1037 from cycle-review/Codex): `channel_id is
-    None` means UNSCOPED retrieval, so this fallback widens a single-source
-    pipeline to a cross-channel search on a transient lookup failure. Whether
-    that should instead fail closed (block/empty scope) is a content-isolation
-    decision for the owner and a behaviour change beyond this test-only PR. This
-    test documents today's behaviour; it does not endorse it as safe."""
-    from src.services.pipeline_service import resolve_retrieval_scope
+    SECURITY (content isolation, #1077): `channel_id is None` means UNSCOPED
+    retrieval across ALL channels. The old code swallowed a transient source
+    lookup failure and returned channel_id=None, silently widening a
+    single-source pipeline into a cross-channel search — content could be
+    generated/published from channels outside the configured sources (a
+    trust-boundary breach). Fail-closed means the pipeline run aborts instead
+    of leaking: no scope is ever widened by a failed lookup."""
+    from src.services.pipeline_service import PipelineScopeError, resolve_retrieval_scope
 
     pipeline = ContentPipeline(id=7, name="Boom", prompt_template="t")
 
     async def exploding_lister(_pid):
         raise RuntimeError("DB unavailable")
 
-    scope = await resolve_retrieval_scope(pipeline, list_sources=exploding_lister)
-    assert scope.query == "Boom"
-    assert scope.channel_id is None  # graceful fallback, no raise
+    with pytest.raises(PipelineScopeError):
+        await resolve_retrieval_scope(pipeline, list_sources=exploding_lister)
+
+
+@pytest.mark.anyio
+async def test_resolve_scope_error_does_not_widen_to_unscoped():
+    """Mutation-guard for the fail-closed fix: prove the failed-lookup path never
+    yields an unscoped (channel_id=None) result. If the fix regresses to
+    swallowing the error, this test sees a returned scope instead of the raise."""
+    from src.services.pipeline_service import PipelineScopeError, resolve_retrieval_scope
+
+    pipeline = ContentPipeline(id=8, name="Leak", prompt_template="t")
+
+    async def exploding_lister(_pid):
+        raise RuntimeError("transient DB blip")
+
+    returned_scope = None
+    try:
+        returned_scope = await resolve_retrieval_scope(pipeline, list_sources=exploding_lister)
+    except PipelineScopeError:
+        pass
+    # The ONLY acceptable outcome is the raise above; a returned scope (of any
+    # channel_id, especially None) means the leak path is back.
+    assert returned_scope is None
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Closes #1077. Follow-up to #1037 (cycle-review, Codex). Part of epic #1025 (content-cycle safety).

## Что и зачем

#1075 зафиксировал ТЕКУЩЕЕ небезопасное поведение с явными пометками о развилке для владельца. Эта задача МЕНЯЕТ его — оба риска переводятся в **fail-closed** (решение владельца: типизированные ошибки).

### Риск 1 — цикл в DAG → side-effects в authoring order
`_topological_sort` при цикле молча падал в fallback на исходный порядок, и `execute()` всё равно прогонял все узлы, включая side-effecting (publish/delete/react) → действие могло выполниться до своей предпосылки.

**Фикс:** `_topological_sort` поднимает `PipelineCycleError` (с именами узлов цикла) **до выполнения хоть одного хендлера** → цикличный граф выполняет **0 узлов**. Дополнительно `add_edge` отклоняет ребро, замыкающее цикл (`PipelineValidationError`) — defence in depth.

### Риск 2 (изоляция контента) — scoping-сбой → постинг из ВСЕХ каналов
`resolve_retrieval_scope` при исключении в source-листинге проглатывал ошибку и возвращал `channel_id=None`, что означает **UNSCOPED** (cross-channel) retrieval. Транзиентный сбой БД молча расширял single-source пайплайн до всех каналов → контент мог генериться/публиковаться из источников вне настроенных (нарушение trust-boundary).

**Фикс:** поднимается `PipelineScopeError`. Легитимные unscoped-пути (нет листера / 0 / >1 источников) по-прежнему дают `channel_id=None` — отклоняется ТОЛЬКО ошибочный lookup.

## Как это вписано
DAG-путь (`ContentGenerationService.generate`) уже оборачивает выполнение в `try/except`, помечающий run как `failed` — обе ошибки фейлят run с явной причиной и без side-effects. Web `generate-stream` и CLI `generate-stream` / `edge add` получили чистую обработку (redirect / error-event) вместо неперехваченного 500/трейсбека.

## TDD
- 🔴→🟢 Адаптированы #1075-тесты, документировавшие старое поведение (cycle-fallback unit + e2e; scope-swallow unit + integration).
- Добавлено: доказательство отсутствия side-effects (publish-узел в цикле не вызывается ни разу); отклонение цикла в `add_edge` (service + CLI); web-route fail-closed.
- **Каждый ассерт мутационно верифицирован** — откатом каждого фикса по отдельности.

## Проверки
- `ruff check src/ tests/ conftest.py` — чисто
- `mypy` — без новых ошибок в изменённом коде (baseline неизменен)
- `pytest` — 243 теста на затронутых файлах + широкий прогон (1705 parallel + 128 serial) зелёные

## Файлы
- `src/services/pipeline_executor.py` — `PipelineCycleError`, raise в `_topological_sort`
- `src/services/pipeline_service.py` — `PipelineScopeError`, raise в `resolve_retrieval_scope`, `_edge_creates_cycle` + валидация в `add_edge`
- `src/web/pipelines/handlers.py`, `src/cli/commands/pipeline.py` — обработка ошибок у вызывающих
- тесты: `test_pipeline_executor`, `test_pipeline_service_edge_cases`, `test_generation_service_rag_context`, `test_cli_pipeline_commands`, `routes/test_pipelines_routes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)