### PR TITLE
test(photo-auto): recurring-cycle TDD — fake-clock + stateful dedup guard

### DIFF
--- a/tests/test_photo_auto_upload_service.py
+++ b/tests/test_photo_auto_upload_service.py
@@ -386,3 +386,163 @@ def test_validate_folder_file_not_dir(tmp_path):
 
 def test_validate_folder_valid(tmp_path):
     PhotoAutoUploadService._validate_folder(str(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# Recurring-cycle integration test (fake-clock, stateful in-memory bundle)
+# ---------------------------------------------------------------------------
+# Доказывает инвариант: сработало → через интервал снова → без дублей.
+# Fake bundle держит state: sent_files (дедуп) + job (обновляемый last_run_at).
+# Fake publish: накапливает sent_paths для проверки.
+# Fake clock: now передаётся явно в run_due через монки-патч _is_due-часов.
+# ---------------------------------------------------------------------------
+
+
+class _StatefulBundle:
+    """In-memory stateful fake bundle: реальный дедуп + mutable job state."""
+
+    def __init__(self, job: PhotoAutoUploadJob) -> None:
+        self._job = job
+        self._sent: set[str] = set()
+
+    async def list_auto_jobs(self, active_only: bool = True) -> list[PhotoAutoUploadJob]:
+        if active_only and not self._job.is_active:
+            return []
+        return [self._job]
+
+    async def get_auto_job(self, job_id: int) -> PhotoAutoUploadJob | None:
+        if self._job.id == job_id:
+            return self._job
+        return None
+
+    async def has_sent_auto_file(self, job_id: int, file_path: str) -> bool:
+        return file_path in self._sent
+
+    async def mark_auto_file_sent(self, job_id: int, file_path: str) -> None:
+        self._sent.add(file_path)
+
+    async def update_auto_job(self, job_id: int, **kwargs: object) -> None:
+        # PhotoAutoUploadJob — Pydantic model; model_copy обновляет только переданные поля.
+        self._job = self._job.model_copy(update={k: v for k, v in kwargs.items()})
+
+    # Unused by service but expected by interface
+    async def create_auto_job(self, job: PhotoAutoUploadJob) -> int:
+        return self._job.id or 1
+
+    async def delete_auto_job(self, job_id: int) -> None:
+        pass
+
+
+class _TrackingPublish:
+    """Fake publish that records which paths were sent and simulates on_file_sent callback."""
+
+    def __init__(self) -> None:
+        self.sent_paths: list[str] = []
+
+    async def send_now(self, *, file_paths: list[str], on_file_sent=None, **_kwargs: object) -> list[int]:
+        for path in file_paths:
+            self.sent_paths.append(path)
+            if on_file_sent is not None:
+                await on_file_sent(path, [len(self.sent_paths)])
+        return list(range(len(file_paths)))
+
+
+async def test_recurring_cycle_dedup_and_timing(tmp_path):
+    """
+    Интеграционный сценарий recurring-цикла (fake-clock, in-memory state):
+
+    T0        : run_due → job due (last_run_at=None) → file1 отправлен, last_run_at=T0
+    t0_plus_half : run_due → job НЕ due (не прошёл интервал) → 0 отправок
+    t0_plus_n    : run_due → job due → file1 НЕ переотправлен (дедуп), file2 отправлен
+    t0_plus_2n   : run_due → job due → новых файлов нет → 0 отправок, last_run_at сдвигается
+    """
+    interval = 60  # interval_minutes
+    t0 = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    # Создаём начальный job (last_run_at=None → due немедленно)
+    job = PhotoAutoUploadJob(
+        id=1,
+        phone="+1234",
+        target_dialog_id=-100,
+        target_title=None,
+        target_type=None,
+        folder_path=str(tmp_path),
+        send_mode=PhotoSendMode.SEPARATE,
+        interval_minutes=interval,
+        is_active=True,
+        last_run_at=None,
+        last_seen_marker=None,
+    )
+
+    bundle = _StatefulBundle(job)
+    publish = _TrackingPublish()
+    service = PhotoAutoUploadService(bundle, publish)  # type: ignore[arg-type]
+
+    # Файл 1 существует с самого начала
+    file1 = tmp_path / "img1.jpg"
+    file1.write_bytes(b"\xff\xd8\xff")
+
+    # _run_due_at: fake-clock замена run_due() — передаёт явный момент времени в _is_due.
+    # run_due() строит now = datetime.now(utc) сам; мы воспроизводим его логику с нужным clock.
+    async def _run_due_at(clock_now: datetime) -> int:
+        """Запускает due-цикл с явным fake-clock вместо datetime.now(utc)."""
+        jobs = await service._bundle.list_auto_jobs(active_only=True)
+        due = [j for j in jobs if PhotoAutoUploadService._is_due(j, clock_now)]
+        if not due:
+            return 0
+        processed = 0
+        for j in due:
+            await service.run_job(j.id or 0)
+            processed += 1
+        return processed
+
+    # run_job пишет last_run_at = datetime.now(utc) через bundle.update_auto_job.
+    # Подменяем update_auto_job чтобы он фиксировал clock_now, а не реальное время —
+    # иначе _is_due в следующем шаге оценивал бы не fake-clock, а wall-clock.
+    original_update = bundle.update_auto_job
+
+    def _make_patched_update(clock_now: datetime):
+        async def _patched_update(job_id: int, **kwargs: object) -> None:
+            if "last_run_at" in kwargs and kwargs["last_run_at"] is not None:
+                kwargs["last_run_at"] = clock_now
+            await original_update(job_id, **kwargs)
+
+        return _patched_update
+
+    # Шаг 1: t0
+    bundle.update_auto_job = _make_patched_update(t0)
+    count1 = await _run_due_at(t0)
+    assert count1 == 1, f"t0: ожидали 1 задание, получили {count1}"
+    assert len(publish.sent_paths) == 1, f"t0: ожидали 1 файл отправленным, получили {publish.sent_paths}"
+    assert str(file1) in publish.sent_paths
+    assert bundle._job.last_run_at == t0, f"t0: last_run_at должен быть t0, не {bundle._job.last_run_at}"
+
+    # Шаг 2: t0+interval/2 — НЕ due
+    bundle.update_auto_job = _make_patched_update(t0 + timedelta(minutes=interval // 2))
+    count2 = await _run_due_at(t0 + timedelta(minutes=interval // 2))
+    assert count2 == 0, f"t0+interval/2: ожидали 0 (не due), получили {count2}"
+    sent_after_step2 = len(publish.sent_paths)
+    assert sent_after_step2 == 1, "t0+interval/2: новых отправок быть не должно"
+
+    # Шаг 3: t0+interval — due снова, file2 — новый файл, file1 — НЕ переотправляется
+    file2 = tmp_path / "img2.jpg"
+    file2.write_bytes(b"\xff\xd8\xff\xe0")
+    t1 = t0 + timedelta(minutes=interval)
+    bundle.update_auto_job = _make_patched_update(t1)
+    count3 = await _run_due_at(t1)
+    assert count3 == 1, f"t0+interval: ожидали 1 задание, получили {count3}"
+    sent_at_step3 = publish.sent_paths[sent_after_step2:]
+    assert len(sent_at_step3) == 1, f"t0+interval: ожидали только 1 новый файл, получили {sent_at_step3}"
+    assert str(file2) in sent_at_step3, f"t0+interval: file2 должен быть отправлен, не {sent_at_step3}"
+    assert str(file1) not in sent_at_step3, "t0+interval: file1 не должен переотправляться (дедуп)"
+    assert bundle._job.last_run_at == t1
+
+    # Шаг 4: t0+2*interval — due, но новых файлов нет → 0 отправок, last_run_at обновляется
+    t2 = t0 + timedelta(minutes=2 * interval)
+    bundle.update_auto_job = _make_patched_update(t2)
+    count4 = await _run_due_at(t2)
+    assert count4 == 1, f"t0+2*interval: ожидали 1 задание (due), получили {count4}"
+    sent_at_step4 = publish.sent_paths[sent_after_step2 + 1:]
+    assert len(sent_at_step4) == 0, f"t0+2*interval: файлов для отправки нет, получили {sent_at_step4}"
+    assert bundle._job.last_run_at == t2, "t0+2*interval: last_run_at должен сдвинуться до t2"
+    assert len(publish.sent_paths) == 2, "Итого отправлено ровно 2 файла за все 4 шага"


### PR DESCRIPTION
## Summary

- Adds `test_recurring_cycle_dedup_and_timing` — integration test proving the full recurring-cycle invariant for `PhotoAutoUploadService` on a fake clock without any real Telegram I/O
- Uses `_StatefulBundle` (in-memory dedup + mutable job state) and `_TrackingPublish` (fake send with `on_file_sent` callback support) for true stateful integration coverage
- Verifies 4 steps: first run fires → half-interval skips → full interval fires (old files deduped, new sent) → empty folder advances `last_run_at` without sending
- Two mutations were applied to confirm each key assertion is load-bearing (timing mutation caught step-2, dedup mutation caught step-3)

## What was proven

| Step | Clock | Expected | Guard |
|------|-------|----------|-------|
| 1 | t0 | fires, file1 sent, `last_run_at=t0` | `count1==1`, `len(sent)==1` |
| 2 | t0+interval/2 | NOT due, 0 sends | `count2==0` |
| 3 | t0+interval | fires, file2 sent, file1 NOT re-sent | `len(sent_step3)==1`, file1 absent |
| 4 | t0+2*interval | fires, no new files, `last_run_at` advances | `count4==1`, `len(sent_step4)==0` |

No production code changed — tests showed the existing implementation is correct.

## Test plan

- [x] `pytest tests/test_photo_auto_upload_service.py -v` → 31 passed (all existing + new)
- [x] `pytest tests/ -n auto -m "not aiosqlite_serial"` → 8739 passed, 140 skipped
- [x] `ruff check tests/test_photo_auto_upload_service.py` → clean
- [x] mypy — no new errors introduced (pre-existing line-23 error in `_make_job` helper)
- [x] Mutation test 1: `_is_due` always-True → step-2 assert catches it
- [x] Mutation test 2: dedup disabled → step-3 assert catches it

Closes #1031

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JgwLQxgR4661mmY2i8VHN5