### PR TITLE
test(cleanup): tighten tautological >= assertions to ==N (#1093)

### DIFF
--- a/tests/test_agent_manager_runtime_paths.py
+++ b/tests/test_agent_manager_runtime_paths.py
@@ -680,7 +680,7 @@ class TestClaudeSdkBackendChatStreamErrors:
             async for chunk in mgr.chat_stream(thread_id, "test"):
                 chunks.append(chunk)
 
-        assert call_count >= 2, f"Expected retry, got {call_count} calls"
+        assert call_count == 2, f"Expected exactly 1 retry (2 total calls), got {call_count}"
 
     @pytest.mark.anyio
     async def test_generic_exception_no_retry(self, db):

--- a/tests/test_bundles.py
+++ b/tests/test_bundles.py
@@ -119,7 +119,7 @@ class TestChannelBundle:
         pk = await b.add_channel(_channel(channel_id=601))
         await b.set_filtered_bulk([(pk, "spam")])
         count = await b.reset_all_filters()
-        assert count >= 1
+        assert count == 1
         ch = await b.get_by_pk(pk)
         assert ch is not None and ch.is_filtered is False
 
@@ -393,13 +393,13 @@ class TestChannelBundle:
         b = ChannelBundle.from_database(db)
         await b.create_collection_task(903, "ch903")
         tasks = await b.get_collection_tasks()
-        assert len(tasks) >= 1
+        assert len(tasks) == 1
 
     async def test_get_active_collection_tasks_for_channel(self, db):
         b = ChannelBundle.from_database(db)
         await b.create_collection_task(904, "ch904")
         tasks = await b.get_active_collection_tasks_for_channel(904)
-        assert len(tasks) >= 1
+        assert len(tasks) == 1
 
     async def test_get_channel_ids_with_active_tasks(self, db):
         b = ChannelBundle.from_database(db)
@@ -426,7 +426,7 @@ class TestChannelBundle:
         tid = await b.create_collection_task(908, "ch908")
         await b.update_collection_task(tid, CollectionTaskStatus.RUNNING)
         count = await b.fail_running_collection_tasks_on_startup()
-        assert count >= 1
+        assert count == 1
         task = await b.get_collection_task(tid)
         assert task is not None and task.status == CollectionTaskStatus.FAILED
 
@@ -460,7 +460,7 @@ class TestChannelBundle:
         count = await b.tasks.requeue_running_generic_tasks_on_startup(
             NOW, [CollectionTaskType.STATS_ALL.value]
         )
-        assert count >= 0
+        assert count == 0  # no STATS_ALL tasks in RUNNING state
 
 
 # ---------------------------------------------------------------------------
@@ -581,7 +581,7 @@ class TestSearchBundle:
         b = SearchBundle.from_database(db)
         await b.log_search("+70001112233", "test query", 5)
         recent = await b.get_recent_searches()
-        assert len(recent) >= 1
+        assert len(recent) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bundles.py
+++ b/tests/test_bundles.py
@@ -487,7 +487,7 @@ class TestCollectionBundle:
         await b.channels.add_channel(_channel(channel_id=1012))
         await b.insert_message(_message(channel_id=1012, message_id=1, text="findme"))
         results, total = await b.search_messages(SearchParams(query="findme"))
-        assert total >= 1
+        assert total >= 1  # MessageSearchPage.total is a lower bound by design (#766)
 
     async def test_search_total_is_exact_when_offset_past_end(self, db):
         # Regression #971: an empty overflow page (offset beyond the result set)
@@ -575,7 +575,7 @@ class TestSearchBundle:
         await b.add_channel(_channel(channel_id=2002))
         await b.insert_messages_batch([_message(channel_id=2002, message_id=1, text="searchterm")])
         results, total = await b.search_messages(SearchParams(query="searchterm"))
-        assert total >= 1
+        assert total >= 1  # MessageSearchPage.total is a lower bound by design (#766)
 
     async def test_log_and_get_searches(self, db):
         b = SearchBundle.from_database(db)

--- a/tests/test_cli_process_database_repository_paths.py
+++ b/tests/test_cli_process_database_repository_paths.py
@@ -855,7 +855,7 @@ async def test_messages_get_by_id_existing(db):
     await db.repos.messages.insert_message(msg)
 
     msgs, _ = await db.repos.messages.search_messages(SearchParams(channel_id=90, limit=1))
-    assert len(msgs) >= 1
+    assert len(msgs) == 1
     fetched = await db.repos.messages.get_by_id(msgs[0].id)
     assert fetched is not None
     assert fetched.channel_id == 90
@@ -966,7 +966,7 @@ async def test_messages_insert_batch_with_reactions(db):
     msgs[0].reactions_json = reactions
 
     count = await db.repos.messages.insert_messages_batch(msgs)
-    assert count >= 1
+    assert count == 3
 
 
 @pytest.mark.anyio
@@ -1245,7 +1245,7 @@ async def test_photo_loader_list_batches(db):
         await db.repos.photo_loader.create_batch(batch)
 
     batches = await db.repos.photo_loader.list_batches()
-    assert len(batches) >= 3
+    assert len(batches) == 3
 
 
 @pytest.mark.anyio
@@ -1331,7 +1331,7 @@ async def test_photo_loader_list_items(db):
         await db.repos.photo_loader.create_item(item)
 
     items = await db.repos.photo_loader.list_items()
-    assert len(items) >= 3
+    assert len(items) == 3
 
 
 @pytest.mark.anyio
@@ -1475,7 +1475,7 @@ async def test_photo_loader_requeue_running_items(db):
     await db.repos.photo_loader.claim_next_due_item(now)
 
     count = await db.repos.photo_loader.requeue_running_items_on_startup(now)
-    assert count >= 1
+    assert count == 1
 
     fetched = await db.repos.photo_loader.get_item(item_id)
     assert fetched.status == PhotoBatchStatus.PENDING
@@ -1507,7 +1507,7 @@ async def test_photo_loader_list_auto_jobs(db):
         await db.repos.photo_loader.create_auto_job(job)
 
     jobs = await db.repos.photo_loader.list_auto_jobs()
-    assert len(jobs) >= 3
+    assert len(jobs) == 3
 
 
 @pytest.mark.anyio

--- a/tests/test_cli_telegram_agent_dispatcher_paths.py
+++ b/tests/test_cli_telegram_agent_dispatcher_paths.py
@@ -166,7 +166,7 @@ class TestRunBenchmarkStep:
 
         step = BenchmarkStep("test", (sys.executable, "-c", "pass"))
         elapsed = _run_benchmark_step(step)
-        assert elapsed >= 0
+        assert isinstance(elapsed, float)
 
     def test_failure_exits(self):
         import sys

--- a/tests/test_cli_telegram_agent_dispatcher_paths.py
+++ b/tests/test_cli_telegram_agent_dispatcher_paths.py
@@ -166,7 +166,7 @@ class TestRunBenchmarkStep:
 
         step = BenchmarkStep("test", (sys.executable, "-c", "pass"))
         elapsed = _run_benchmark_step(step)
-        assert isinstance(elapsed, float)
+        assert elapsed > 0
 
     def test_failure_exits(self):
         import sys

--- a/tests/test_cli_test_commands.py
+++ b/tests/test_cli_test_commands.py
@@ -246,7 +246,7 @@ class TestRunBenchmarkStep:
         mock_run.return_value = MagicMock(returncode=0)
         step = BenchmarkStep("test_step", (sys.executable, "-c", "pass"))
         elapsed = _run_benchmark_step(step)
-        assert elapsed >= 0
+        assert isinstance(elapsed, float)
         out = capsys.readouterr().out
         assert "test_step" in out
 

--- a/tests/test_cli_test_commands.py
+++ b/tests/test_cli_test_commands.py
@@ -246,7 +246,7 @@ class TestRunBenchmarkStep:
         mock_run.return_value = MagicMock(returncode=0)
         step = BenchmarkStep("test_step", (sys.executable, "-c", "pass"))
         elapsed = _run_benchmark_step(step)
-        assert isinstance(elapsed, float)
+        assert elapsed > 0
         out = capsys.readouterr().out
         assert "test_step" in out
 

--- a/tests/test_collector_runtime.py
+++ b/tests/test_collector_runtime.py
@@ -302,8 +302,9 @@ async def test_collect_channel_stats_warms_cache_for_uncached_numeric_id(
     collector = Collector(harness.pool, db, SchedulerConfig())
     stats = await collector.collect_channel_stats(channel)
 
-    # Warm-then-retry must have happened (resolve called twice) and stats saved.
-    assert calls["n"] >= 2
+    # Warm-then-retry: resolve called exactly twice (1st raises on cache miss,
+    # 2nd succeeds after warm_dialog_cache()).
+    assert calls["n"] == 2
     assert stats is not None
     assert stats.subscriber_count == 4200
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -368,7 +368,7 @@ async def test_set_channels_filtered_bulk_and_reset(db):
     assert by_channel_id[-1007002].filter_flags == "non_cyrillic,chat_noise"
 
     reset_count = await db.reset_all_channel_filters()
-    assert reset_count >= 2
+    assert reset_count == 2
 
     channels = await db.get_channels()
     by_channel_id = {channel.channel_id: channel for channel in channels}

--- a/tests/test_migrations_worker_bootstrap_paths.py
+++ b/tests/test_migrations_worker_bootstrap_paths.py
@@ -568,8 +568,10 @@ async def test_publish_snapshots_basic():
 
     await _publish_snapshots(container)
 
-    # Should have called upsert_snapshot multiple times
-    assert mock_runtime_snapshots.upsert_snapshot.call_count >= 5
+    # _publish_snapshots makes exactly 8 upsert_snapshot calls (heartbeat,
+    # accounts_status, pool_counters, collector_status, scheduler_status,
+    # scheduler_jobs, collection_queue_status, notification_target_status).
+    assert mock_runtime_snapshots.upsert_snapshot.call_count == 8
 
 
 @pytest.mark.anyio
@@ -611,7 +613,7 @@ async def test_publish_snapshots_with_available_notification():
         mock_notif_svc.return_value.get_status = AsyncMock(return_value=None)
         await _publish_snapshots(container)
 
-    assert mock_runtime_snapshots.upsert_snapshot.call_count >= 5
+    assert mock_runtime_snapshots.upsert_snapshot.call_count == 8
 
 
 @pytest.mark.anyio
@@ -653,7 +655,7 @@ async def test_publish_snapshots_notification_exception():
         mock_notif_svc.return_value.get_status = AsyncMock(side_effect=Exception("bot error"))
         await _publish_snapshots(container)
 
-    assert mock_runtime_snapshots.upsert_snapshot.call_count >= 5
+    assert mock_runtime_snapshots.upsert_snapshot.call_count == 8
 
 
 # ============================================================================

--- a/tests/test_telegram_command_dispatcher.py
+++ b/tests/test_telegram_command_dispatcher.py
@@ -2410,8 +2410,9 @@ async def test_run_loop_sleeps_on_no_command():
 
     with patch("src.services.telegram_command_dispatcher.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
         await d._run_loop()
-    # asyncio.sleep should have been called (once for each None command)
-    assert mock_sleep.await_count >= 1
+    # The loop runs twice (claim_count hits 2 and sets _stop_event); each None
+    # claim triggers a sleep, so exactly 2 sleeps occur.
+    assert mock_sleep.await_count == 2
 
 
 # --- _handle_dialogs_leave: empty dialogs list ---


### PR DESCRIPTION
## Summary

Часть эпика #1084 (оптимизация тестов). Тавтологичные `>=N` ассерты → точные `==N`.

- `elapsed >= 0` → `elapsed > 0` (время всегда > 0 при реальном вызове; `>= 0` не ловит ничего)
- `upsert_snapshot.call_count >= 5` → `== 8` (точно 8 вызовов в `_publish_snapshots`)
- `reset_count >= 2` → `== 2` (ровно 2 канала в `:memory:` DB)
- `calls["n"] >= 2` → `== 2` (warm-then-retry: ровно 2 вызова резолвера)
- `call_count >= 2` → `== 2` (ровно 1 retry на "Control request timeout")
- `mock_sleep.await_count >= 1` → `== 2` (цикл дважды, 2 None → 2 sleep)
- `count >= 0` → `== 0` (нет STATS_ALL задач в RUNNING в этом тесте)
- Аналогично для `photo_loader` и bundle-тестов

Каждое изменение мутационно верифицировано: `==N` ловит регрессию, которую `>=N` пропускал.

**sleep(0):** `test_generation_service_streaming.py` оставлен — `sleep(0)` там в async-генераторе для симуляции стриминга, не синхронизационный паттерн. Не пересекается с #1091.

**skip/xfail:** все `@pytest.mark.skip` и `skipif` уже имеют `reason=`, документация полная.

## Test plan

- [x] Все изменённые тесты проходят с новыми ассертами
- [x] `pytest -m "not aiosqlite_serial" -n auto`: 8760 passed, 0 failed
- [x] `pytest -m aiosqlite_serial`: 937 passed, 0 failed
- [x] `ruff check`: All checks passed
- [x] `/code-review --fix`: найдено и исправлено `isinstance(elapsed, float)` → `elapsed > 0`

Closes #1093

🤖 Generated with [Claude Code](https://claude.com/claude-code)