### PR TITLE
feat(scripts): детектор «изобретённого велосипеда» + baseline (#1108)

### DIFF
--- a/scripts/detect_reinvented.py
+++ b/scripts/detect_reinvented.py
@@ -15,8 +15,13 @@ battle-tested стандартная замена (stdlib или уже-уста
   * ручная HMAC/JWT-подпись токенов (есть `itsdangerous`/`hmac`);
   * ручной base64-паддинг (есть `base64.urlsafe_b64decode` без ручной добивки `=`);
   * самописный retry/backoff-цикл (есть `tenacity`/`aiolimiter`);
-  * ручной парсинг URL/email строками (есть `urllib.parse`/`email.utils`);
+  * ручной разбор email через `split('@')` (есть `email.utils.parseaddr`);
   * самописный счётчик/частотный словарь (есть `collections.Counter`).
+
+Разбор URL строками (`split('/')`/`'?'`/`'#'`) намеренно НЕ ловится: эти
+разделители встречаются повсеместно вне URL-контекста, и эвристика на них
+завалила бы отчёт false-positive'ами — против философии «лучше пропуск, чем
+ложная находка». Для URL остаётся `urllib.parse`, но детектор его не флагует.
 
 Эвристики намеренно консервативны: лучше пропустить сомнительный кейс, чем
 завалить отчёт false-positive'ами (см. отрицательные фикстуры в тестах).
@@ -104,8 +109,24 @@ class Finding:
     confidence: Confidence
 
     def key(self) -> tuple[str, str, int]:
-        """Стабильный ключ для дедупа и baseline-диффа: (файл, тип, строка)."""
+        """Ключ дедупа В РАМКАХ ОДНОГО прогона: (файл, тип, строка).
+
+        Включает строку намеренно — две разные находки одного типа в одном файле
+        (на разных строках) должны остаться обе. Для диффа МЕЖДУ прогонами строка
+        не годится (см. identity): вставка строки выше сдвинула бы номер.
+        """
         return (self.file, self.kind, self.line)
+
+    def identity(self) -> tuple[str, str, str]:
+        """Стабильный отпечаток для baseline-диффа: (файл, тип, что).
+
+        НЕ зависит от номера строки — `what` содержит имя функции (например
+        «…цикл в collect_all_channels()»), что переживает вставку/удаление строк
+        выше находки и при этом различает разные функции одного типа в файле.
+        Без этого `--fail-on-new` перепомечал бы неизменный код как «новый» после
+        любого рефакторинга, сдвигающего строки (находка ревью Codex на #1110).
+        """
+        return (self.file, self.kind, self.what)
 
     def human(self) -> str:
         """Строка отчёта: `файл:строка — что — замена — уверенность`."""
@@ -194,8 +215,11 @@ def _detect_manual_b64_padding(tree: ast.AST, filename: str) -> list[Finding]:
     Паттерн `s += "=" * (...)` / `padding = 4 - len(s) % 4` ради ручного
     выравнивания длины — частый спутник самописных токенов. `base64` умеет
     декодировать без ручной добивки, если использовать `b64decode(..., validate)`
-    с уже выровненной строкой, а для urlsafe есть готовые рецепты. Low/med —
-    сигнал слабый сам по себе, поэтому уверенность med только рядом с b64-вызовом.
+    с уже выровненной строкой, а для urlsafe есть готовые рецепты.
+
+    Флагим `"=" * n` ТОЛЬКО рядом (в пределах нескольких строк) с b64-вызовом:
+    без этого `print("=" * 80)` и прочие разделители давали бы сплошной low-шум
+    (находка ревью на #1110). Раз b64-контекст обязателен — уверенность med.
     """
     findings: list[Finding] = []
     b64_lines = {
@@ -203,16 +227,19 @@ def _detect_manual_b64_padding(tree: ast.AST, filename: str) -> list[Finding]:
         for c in _calls_in(tree)
         if "b64" in _called_name(c) or "base64" in _called_name(c)
     }
+    if not b64_lines:  # нет ни одного base64-вызова — '=' * n заведомо не паддинг
+        return findings
     for node in ast.walk(tree):
-        # `"=" * expr` — умножение строки из одного `=` на число: ручной паддинг.
+        # `"=" * expr` — умножение строки из одного `=` на число: кандидат в паддинг.
         if (
             isinstance(node, ast.BinOp)
             and isinstance(node.op, ast.Mult)
             and isinstance(node.left, ast.Constant)
             and node.left.value == "="
         ):
-            # Уверенность выше, если рядом (в пределах нескольких строк) есть b64-вызов.
-            near_b64 = any(abs(node.lineno - bl) <= 8 for bl in b64_lines)
+            # Только рядом с b64-вызовом — иначе это разделитель, а не паддинг.
+            if not any(abs(node.lineno - bl) <= 8 for bl in b64_lines):
+                continue
             findings.append(
                 Finding(
                     file=filename,
@@ -220,7 +247,7 @@ def _detect_manual_b64_padding(tree: ast.AST, filename: str) -> list[Finding]:
                     kind="manual-base64-padding",
                     what="ручная добивка base64-паддинга '='",
                     replacement="base64.urlsafe_b64decode с корректным выравниванием",
-                    confidence="med" if near_b64 else "low",
+                    confidence="med",
                 )
             )
     return findings
@@ -257,13 +284,13 @@ def _detect_retry_loop(
     return None
 
 
-def _detect_manual_url_email_parse(tree: ast.AST, filename: str) -> list[Finding]:
-    """Ручной парсинг email/URL через `.split('@')` / `.split('/')`.
+def _detect_manual_email_parse(tree: ast.AST, filename: str) -> list[Finding]:
+    """Ручной разбор email через `addr.split('@')` → `email.utils.parseaddr`.
 
-    `addr.split("@")` для разбора email → `email.utils.parseaddr`; ручная нарезка
-    URL по `/`/`?`/`#` → `urllib.parse.urlparse`. Low-confidence: split('@')
-    встречается и вне email-контекста, поэтому помечаем как слабый сигнал и не
-    шумим без явной строки-разделителя.
+    Low-confidence: `split('@')` встречается и вне email-контекста, поэтому это
+    слабый сигнал. Разбор URL по `/`/`?`/`#` сознательно НЕ ловим — эти
+    разделители слишком частые вне URL, эвристика на них была бы сплошным
+    false-positive (см. модульный docstring).
     """
     findings: list[Finding] = []
     for node in ast.walk(tree):
@@ -348,7 +375,7 @@ def detect_in_source(source: str, filename: str) -> list[Finding]:
             findings.append(counter)
 
     findings.extend(_detect_manual_b64_padding(tree, filename))
-    findings.extend(_detect_manual_url_email_parse(tree, filename))
+    findings.extend(_detect_manual_email_parse(tree, filename))
 
     # Дедуп по (файл, тип, строка): вложенная функция и её внешняя обёртка обе
     # видят один и тот же цикл через ast.walk → одна находка, не две с разными
@@ -379,20 +406,30 @@ def findings_to_baseline(findings: list[Finding]) -> list[dict]:
     return [asdict(f) for f in sorted(findings, key=lambda f: f.key())]
 
 
-def load_baseline(path: Path) -> set[tuple[str, str, int]] | None:
-    """Прочитать снимок и вернуть множество ключей находок. None — снимка нет."""
+def load_baseline(path: Path) -> set[tuple[str, str, str]] | None:
+    """Прочитать снимок и вернуть множество identity-отпечатков. None — снимка нет.
+
+    Отпечаток — `(file, kind, what)` (см. Finding.identity), а НЕ номер строки:
+    дифф должен переживать сдвиг строк после рефакторингов.
+    """
     if not path.exists():
         return None
     raw = json.loads(path.read_text(encoding="utf-8"))
     items = raw.get("findings", []) if isinstance(raw, dict) else raw
-    return {(item["file"], item["kind"], int(item["line"])) for item in items}
+    return {(item["file"], item["kind"], item["what"]) for item in items}
 
 
-def new_findings(findings: list[Finding], baseline_keys: set[tuple[str, str, int]] | None) -> list[Finding]:
-    """Находки, которых нет в baseline. Если baseline отсутствует — все новые."""
-    if baseline_keys is None:
+def new_findings(
+    findings: list[Finding], baseline_ids: set[tuple[str, str, str]] | None
+) -> list[Finding]:
+    """Находки, которых нет в baseline (по identity). Без baseline — все новые.
+
+    Сравнение по identity (file/kind/what), не по строке: неизменный код,
+    сдвинутый вставкой строк выше, не считается новым велосипедом.
+    """
+    if baseline_ids is None:
         return list(findings)
-    return [f for f in findings if f.key() not in baseline_keys]
+    return [f for f in findings if f.identity() not in baseline_ids]
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/detect_reinvented.py
+++ b/scripts/detect_reinvented.py
@@ -1,0 +1,539 @@
+#!/usr/bin/env python3
+"""Детектор «изобретённого велосипеда»: самописный код, для которого есть
+battle-tested стандартная замена (stdlib или уже-установленная зависимость).
+
+Запуск:
+    python scripts/detect_reinvented.py [--path src] [--json] [--update-baseline] [--fail-on-new]
+
+Ядро эпика #1083 (детектор кастомных функций → стандартные библиотеки). Скрипт
+прогоняет AST-эвристики по дереву исходников и печатает список кандидатов в
+формате:
+
+    файл:строка — что делает — предлагаемая стандартная замена — уверенность
+
+Эвристики (AST-based, не regex — `ast.walk`/`ast.NodeVisitor`):
+  * ручная HMAC/JWT-подпись токенов (есть `itsdangerous`/`hmac`);
+  * ручной base64-паддинг (есть `base64.urlsafe_b64decode` без ручной добивки `=`);
+  * самописный retry/backoff-цикл (есть `tenacity`/`aiolimiter`);
+  * ручной парсинг URL/email строками (есть `urllib.parse`/`email.utils`);
+  * самописный счётчик/частотный словарь (есть `collections.Counter`).
+
+Эвристики намеренно консервативны: лучше пропустить сомнительный кейс, чем
+завалить отчёт false-positive'ами (см. отрицательные фикстуры в тестах).
+
+Baseline (`scripts/reinvented_baseline.json`): первый прогон фиксирует текущие
+находки в снимок; последующие прогоны диффят против него и подсвечивают
+**НОВЫЕ** велосипеды — так в регрессию ловятся свежие самописные реализации, а
+накопленный долг не шумит каждый раз. `--update-baseline` пересоздаёт снимок.
+
+Advisory по умолчанию: exit 0 (как scripts/doc_coverage.py). `--fail-on-new`
+включает гейт — ненулевой код, если относительно baseline появились НОВЫЕ
+находки (для опционального CI-шага, расписание — отдельный sub, #1097).
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+# Снимок-baseline лежит рядом со скриптом (в scripts/), а не в cwd — чтобы запуск
+# из любого каталога видел тот же файл. Единый источник истины про путь.
+BASELINE_PATH = Path(__file__).resolve().parent / "reinvented_baseline.json"
+
+Confidence = str  # "high" | "med" | "low" — порядок ниже
+_CONFIDENCE_ORDER = {"high": 0, "med": 1, "low": 2}
+
+_COLOR = sys.stdout.isatty()
+
+
+def _c(text: str, code: str) -> str:
+    return f"\033[{code}m{text}\033[0m" if _COLOR else text
+
+
+def bold(text: str) -> str:
+    return _c(text, "1")
+
+
+def dim(text: str) -> str:
+    return _c(text, "2")
+
+
+def red(text: str) -> str:
+    return _c(text, "31")
+
+
+def warn(text: str) -> str:
+    return _c(text, "33")
+
+
+def good(text: str) -> str:
+    return _c(text, "32")
+
+
+_CONFIDENCE_PAINT = {"high": red, "med": warn, "low": dim}
+
+
+def confidence_color(confidence: Confidence) -> str:
+    paint = _CONFIDENCE_PAINT.get(confidence, lambda t: t)
+    return paint(confidence)
+
+
+# --------------------------------------------------------------------------- #
+# Модель находки
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class Finding:
+    """Один кандидат на замену стандартной библиотекой.
+
+    `kind` — стабильный машинный ключ эвристики (используется в baseline-диффе,
+    не зависит от человекочитаемого текста). `what` — что делает код,
+    `replacement` — предлагаемая стандартная замена, `confidence` — уверенность.
+    """
+
+    file: str
+    line: int
+    kind: str
+    what: str
+    replacement: str
+    confidence: Confidence
+
+    def key(self) -> tuple[str, str, int]:
+        """Стабильный ключ для дедупа и baseline-диффа: (файл, тип, строка)."""
+        return (self.file, self.kind, self.line)
+
+    def human(self) -> str:
+        """Строка отчёта: `файл:строка — что — замена — уверенность`."""
+        loc = f"{self.file}:{self.line}"
+        return f"{loc} — {self.what} — → {self.replacement} — {self.confidence}"
+
+
+# --------------------------------------------------------------------------- #
+# Чистая логика эвристик (тестируется на фикстурах, без файловой системы)
+# --------------------------------------------------------------------------- #
+
+
+def _attr_chain(node: ast.AST) -> str:
+    """Восстановить пунктирное имя из узла-вызова: `hmac.new` → 'hmac.new'.
+
+    Возвращает '' для всего, что не разворачивается в простую цепочку имён.
+    """
+    parts: list[str] = []
+    cur: ast.AST | None = node
+    while isinstance(cur, ast.Attribute):
+        parts.append(cur.attr)
+        cur = cur.value
+    if isinstance(cur, ast.Name):
+        parts.append(cur.id)
+    else:
+        return ""
+    return ".".join(reversed(parts))
+
+
+def _called_name(call: ast.Call) -> str:
+    """Имя вызываемого: `hmac.new(...)` → 'hmac.new', `range(...)` → 'range'."""
+    if isinstance(call.func, ast.Name):
+        return call.func.id
+    if isinstance(call.func, ast.Attribute):
+        return _attr_chain(call.func)
+    return ""
+
+
+def _calls_in(node: ast.AST) -> list[ast.Call]:
+    return [n for n in ast.walk(node) if isinstance(n, ast.Call)]
+
+
+def _call_names_in(node: ast.AST) -> set[str]:
+    return {_called_name(c) for c in _calls_in(node)}
+
+
+def _func_defs(tree: ast.AST) -> list[ast.FunctionDef | ast.AsyncFunctionDef]:
+    return [n for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))]
+
+
+def _detect_handrolled_signing(
+    func: ast.FunctionDef | ast.AsyncFunctionDef, filename: str
+) -> Finding | None:
+    """Ручная криптоподпись токена: `hmac.new`/`hashlib.*` + base64 + json в одной функции.
+
+    Эталон эпика — hand-rolled HMAC-JWT из `src/web/session.py` (#782 / #1): функция
+    собирала `base64url(HMAC-SHA256(secret, payload))` руками. Зрелая замена —
+    `itsdangerous.Signer` (на которую session.py и переехал в #953), либо
+    PyJWT/`hmac.compare_digest`. High-confidence, потому что комбинация
+    «своя крипта поверх json-payload» почти всегда — велосипед.
+    """
+    names = _call_names_in(func)
+    has_hmac = any(n.startswith("hmac.") for n in names)
+    has_hashlib_digest = any(n.startswith("hashlib.") for n in names)
+    has_b64 = any("b64" in n or "base64" in n for n in names)
+    has_json = any(n.startswith("json.") for n in names)
+    # Подпись = крипто-примитив (hmac или сырой hashlib-дайджест) + сериализация
+    # payload в base64/json. Без payload-части это просто хеширование, не подпись.
+    crypto = has_hmac or has_hashlib_digest
+    if crypto and has_b64 and has_json:
+        confidence = "high" if has_hmac else "med"
+        return Finding(
+            file=filename,
+            line=func.lineno,
+            kind="handrolled-token-signing",
+            what=f"ручная HMAC/JWT-подпись токена в {func.name}()",
+            replacement="itsdangerous.Signer / PyJWT (+ hmac.compare_digest)",
+            confidence=confidence,
+        )
+    return None
+
+
+def _detect_manual_b64_padding(tree: ast.AST, filename: str) -> list[Finding]:
+    """Ручная добивка base64-паддинга `=` перед urlsafe_b64decode.
+
+    Паттерн `s += "=" * (...)` / `padding = 4 - len(s) % 4` ради ручного
+    выравнивания длины — частый спутник самописных токенов. `base64` умеет
+    декодировать без ручной добивки, если использовать `b64decode(..., validate)`
+    с уже выровненной строкой, а для urlsafe есть готовые рецепты. Low/med —
+    сигнал слабый сам по себе, поэтому уверенность med только рядом с b64-вызовом.
+    """
+    findings: list[Finding] = []
+    b64_lines = {
+        c.lineno
+        for c in _calls_in(tree)
+        if "b64" in _called_name(c) or "base64" in _called_name(c)
+    }
+    for node in ast.walk(tree):
+        # `"=" * expr` — умножение строки из одного `=` на число: ручной паддинг.
+        if (
+            isinstance(node, ast.BinOp)
+            and isinstance(node.op, ast.Mult)
+            and isinstance(node.left, ast.Constant)
+            and node.left.value == "="
+        ):
+            # Уверенность выше, если рядом (в пределах нескольких строк) есть b64-вызов.
+            near_b64 = any(abs(node.lineno - bl) <= 8 for bl in b64_lines)
+            findings.append(
+                Finding(
+                    file=filename,
+                    line=node.lineno,
+                    kind="manual-base64-padding",
+                    what="ручная добивка base64-паддинга '='",
+                    replacement="base64.urlsafe_b64decode с корректным выравниванием",
+                    confidence="med" if near_b64 else "low",
+                )
+            )
+    return findings
+
+
+def _detect_retry_loop(
+    func: ast.FunctionDef | ast.AsyncFunctionDef, filename: str
+) -> Finding | None:
+    """Самописный retry/backoff: цикл с try/except + sleep внутри тела.
+
+    Паттерн `for _ in range(retries): try: ... except: sleep(backoff)` — ровно то,
+    что инкапсулируют `tenacity` (синхронно/async) и `aiolimiter` (rate-limit).
+    Med-confidence: цикл-с-перехватом-и-задержкой почти всегда повторная попытка,
+    но бывают легитимные poll-циклы — поэтому не high.
+    """
+    for loop in ast.walk(func):
+        if not isinstance(loop, (ast.For, ast.While)):
+            continue
+        has_try = any(isinstance(n, ast.Try) for n in ast.walk(loop))
+        sleeps = {
+            _called_name(c)
+            for c in _calls_in(loop)
+            if _called_name(c) in ("time.sleep", "asyncio.sleep", "sleep")
+        }
+        if has_try and sleeps:
+            return Finding(
+                file=filename,
+                line=loop.lineno,
+                kind="handrolled-retry-loop",
+                what=f"самописный retry/backoff-цикл в {func.name}()",
+                replacement="tenacity.retry / aiolimiter (для rate-limit)",
+                confidence="med",
+            )
+    return None
+
+
+def _detect_manual_url_email_parse(tree: ast.AST, filename: str) -> list[Finding]:
+    """Ручной парсинг email/URL через `.split('@')` / `.split('/')`.
+
+    `addr.split("@")` для разбора email → `email.utils.parseaddr`; ручная нарезка
+    URL по `/`/`?`/`#` → `urllib.parse.urlparse`. Low-confidence: split('@')
+    встречается и вне email-контекста, поэтому помечаем как слабый сигнал и не
+    шумим без явной строки-разделителя.
+    """
+    findings: list[Finding] = []
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and _called_name(node).endswith(".split")):
+            continue
+        if not (node.args and isinstance(node.args[0], ast.Constant)):
+            continue
+        sep = node.args[0].value
+        if sep == "@":
+            findings.append(
+                Finding(
+                    file=filename,
+                    line=node.lineno,
+                    kind="manual-email-parse",
+                    what="ручной разбор email через split('@')",
+                    replacement="email.utils.parseaddr",
+                    confidence="low",
+                )
+            )
+    return findings
+
+
+def _detect_manual_counter(
+    func: ast.FunctionDef | ast.AsyncFunctionDef, filename: str
+) -> Finding | None:
+    """Самописный частотный счётчик `d[k] = d.get(k, 0) + 1`.
+
+    Классический велосипед поверх `collections.Counter`. Ищем присваивание в
+    индекс, где правая часть — `<subscript-или-get> + 1`. Med-confidence: паттерн
+    узкий и почти не даёт ложных срабатываний.
+    """
+    for node in ast.walk(func):
+        if not (isinstance(node, ast.Assign) and len(node.targets) == 1):
+            continue
+        target = node.targets[0]
+        if not isinstance(target, ast.Subscript):
+            continue
+        value = node.value
+        # RHS вида `<что-то> + 1` (или `1 + <что-то>`).
+        if isinstance(value, ast.BinOp) and isinstance(value.op, ast.Add):
+            operands = [value.left, value.right]
+            has_one = any(isinstance(o, ast.Constant) and o.value == 1 for o in operands)
+            # один из операндов — обращение к тому же контейнеру (subscript или .get)
+            has_lookup = any(
+                isinstance(o, ast.Subscript)
+                or (isinstance(o, ast.Call) and _called_name(o).endswith(".get"))
+                for o in operands
+            )
+            if has_one and has_lookup:
+                return Finding(
+                    file=filename,
+                    line=node.lineno,
+                    kind="manual-counter",
+                    what=f"самописный частотный счётчик в {func.name}()",
+                    replacement="collections.Counter",
+                    confidence="med",
+                )
+    return None
+
+
+def detect_in_source(source: str, filename: str) -> list[Finding]:
+    """Прогнать все эвристики по одному исходнику. Чистая функция — ядро тестов.
+
+    Невалидный Python (SyntaxError) даёт пустой список, а не исключение: отчёт
+    advisory, один битый файл не должен ронять прогон.
+    """
+    try:
+        tree = ast.parse(source, filename=filename)
+    except SyntaxError:
+        return []
+
+    findings: list[Finding] = []
+    for func in _func_defs(tree):
+        signing = _detect_handrolled_signing(func, filename)
+        if signing:
+            findings.append(signing)
+        retry = _detect_retry_loop(func, filename)
+        if retry:
+            findings.append(retry)
+        counter = _detect_manual_counter(func, filename)
+        if counter:
+            findings.append(counter)
+
+    findings.extend(_detect_manual_b64_padding(tree, filename))
+    findings.extend(_detect_manual_url_email_parse(tree, filename))
+
+    # Дедуп по (файл, тип, строка): вложенная функция и её внешняя обёртка обе
+    # видят один и тот же цикл через ast.walk → одна находка, не две с разными
+    # именами функций. Оставляем первую после сортировки (детерминированно).
+    return _dedup_sorted(findings)
+
+
+def _dedup_sorted(findings: list[Finding]) -> list[Finding]:
+    """Отсортировать детерминированно и убрать дубли по key() (файл, тип, строка)."""
+    findings.sort(key=lambda f: (f.file, f.line, _CONFIDENCE_ORDER.get(f.confidence, 9), f.kind))
+    seen: set[tuple[str, str, int]] = set()
+    unique: list[Finding] = []
+    for f in findings:
+        if f.key() in seen:
+            continue
+        seen.add(f.key())
+        unique.append(f)
+    return unique
+
+
+# --------------------------------------------------------------------------- #
+# Baseline-логика (чистая, тестируется на списках Finding)
+# --------------------------------------------------------------------------- #
+
+
+def findings_to_baseline(findings: list[Finding]) -> list[dict]:
+    """Сериализовать находки в стабильный список dict'ов для JSON-снимка."""
+    return [asdict(f) for f in sorted(findings, key=lambda f: f.key())]
+
+
+def load_baseline(path: Path) -> set[tuple[str, str, int]] | None:
+    """Прочитать снимок и вернуть множество ключей находок. None — снимка нет."""
+    if not path.exists():
+        return None
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    items = raw.get("findings", []) if isinstance(raw, dict) else raw
+    return {(item["file"], item["kind"], int(item["line"])) for item in items}
+
+
+def new_findings(findings: list[Finding], baseline_keys: set[tuple[str, str, int]] | None) -> list[Finding]:
+    """Находки, которых нет в baseline. Если baseline отсутствует — все новые."""
+    if baseline_keys is None:
+        return list(findings)
+    return [f for f in findings if f.key() not in baseline_keys]
+
+
+# --------------------------------------------------------------------------- #
+# Файловый слой
+# --------------------------------------------------------------------------- #
+
+
+def iter_py_files(root: Path) -> list[Path]:
+    if root.is_file():
+        return [root] if root.suffix == ".py" else []
+    return sorted(root.rglob("*.py"))
+
+
+def scan_path(root: Path) -> list[Finding]:
+    """Прогнать детектор по всем .py под root. Нечитаемые файлы пропускаются."""
+    findings: list[Finding] = []
+    for path in iter_py_files(root):
+        try:
+            source = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        findings.extend(detect_in_source(source, path.as_posix()))
+    return _dedup_sorted(findings)
+
+
+def write_baseline(path: Path, findings: list[Finding]) -> None:
+    payload = {
+        "_comment": (
+            "Baseline-снимок scripts/detect_reinvented.py (#1108). Фиксирует "
+            "текущие находки-велосипеды, чтобы прогоны диффили и подсвечивали НОВЫЕ. "
+            "Пересоздать: python scripts/detect_reinvented.py --update-baseline."
+        ),
+        "findings": findings_to_baseline(findings),
+    }
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+# --------------------------------------------------------------------------- #
+# Отчёт
+# --------------------------------------------------------------------------- #
+
+
+def header(title: str) -> None:
+    print()
+    print(bold(f"=== {title} ==="))
+
+
+def print_report(findings: list[Finding], new: list[Finding], baseline_existed: bool) -> None:
+    print(bold(f"Детектор «изобретённого велосипеда» — находок: {len(findings)}"))
+
+    by_conf = {c: [f for f in findings if f.confidence == c] for c in ("high", "med", "low")}
+    header("Все находки (файл:строка — что — замена — уверенность)")
+    if not findings:
+        print(dim("  кандидатов не найдено — отлично"))
+    for conf in ("high", "med", "low"):
+        group = by_conf[conf]
+        if not group:
+            continue
+        print(dim(f"\n  {confidence_color(conf)} ({len(group)}):"))
+        for f in group:
+            print(f"    {f.human()}")
+
+    header("Новые велосипеды относительно baseline")
+    if not baseline_existed:
+        print(warn("  baseline ещё нет — этот прогон станет снимком (запустите --update-baseline)"))
+    elif not new:
+        print(good("  новых находок нет — регрессий не внесено"))
+    else:
+        print(red(f"  НОВЫХ находок: {len(new)}"))
+        for f in new:
+            print(f"    {red('NEW')} {f.human()}")
+
+
+# --------------------------------------------------------------------------- #
+# main
+# --------------------------------------------------------------------------- #
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Детектор кастомных функций → стандартные библиотеки.")
+    parser.add_argument("--path", default="src", help="Путь для анализа (по умолчанию src)")
+    parser.add_argument("--json", action="store_true", help="Машинный JSON-вывод вместо человекочитаемого отчёта")
+    parser.add_argument(
+        "--update-baseline",
+        action="store_true",
+        help=f"Пересоздать baseline-снимок ({BASELINE_PATH.name}) по текущим находкам и выйти",
+    )
+    parser.add_argument(
+        "--fail-on-new",
+        action="store_true",
+        help="Вернуть ненулевой exit code, если относительно baseline появились НОВЫЕ находки (для CI)",
+    )
+    args = parser.parse_args()
+
+    path = Path(args.path)
+    if not path.exists():
+        print(f"Путь не найден: {path}", file=sys.stderr)
+        return 2
+
+    files = iter_py_files(path)
+    if not files:
+        print(f"В {path} нет .py-файлов", file=sys.stderr)
+        return 2
+
+    findings = scan_path(path)
+
+    if args.update_baseline:
+        write_baseline(BASELINE_PATH, findings)
+        print(good(f"Baseline обновлён: {BASELINE_PATH} ({len(findings)} находок)"))
+        return 0
+
+    baseline_keys = load_baseline(BASELINE_PATH)
+    new = new_findings(findings, baseline_keys)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "path": str(path),
+                    "total": len(findings),
+                    "findings": findings_to_baseline(findings),
+                    "new": findings_to_baseline(new),
+                    "baseline_exists": baseline_keys is not None,
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+        )
+    else:
+        print(bold(f"Анализ: {path}  ({len(files)} файлов)"))
+        print_report(findings, new, baseline_existed=baseline_keys is not None)
+        header("Итог")
+        if args.fail_on_new and baseline_keys is not None and new:
+            print(red(f"Новых велосипедов: {len(new)} → провал (--fail-on-new)"))
+        else:
+            print(dim("Информационный прогон (exit 0). Для CI-гейта используйте --fail-on-new."))
+
+    if args.fail_on_new and baseline_keys is not None and new:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/reinvented_baseline.json
+++ b/scripts/reinvented_baseline.json
@@ -1,0 +1,141 @@
+{
+  "_comment": "Baseline-снимок scripts/detect_reinvented.py (#1108). Фиксирует текущие находки-велосипеды, чтобы прогоны диффили и подсвечивали НОВЫЕ. Пересоздать: python scripts/detect_reinvented.py --update-baseline.",
+  "findings": [
+    {
+      "file": "src/agent/manager.py",
+      "line": 429,
+      "kind": "handrolled-retry-loop",
+      "what": "самописный retry/backoff-цикл в _await_with_countdown()",
+      "replacement": "tenacity.retry / aiolimiter (для rate-limit)",
+      "confidence": "med"
+    },
+    {
+      "file": "src/cli/graph_viz.py",
+      "line": 31,
+      "kind": "manual-counter",
+      "what": "самописный частотный счётчик в render_ascii()",
+      "replacement": "collections.Counter",
+      "confidence": "med"
+    },
+    {
+      "file": "src/database/facade.py",
+      "line": 236,
+      "kind": "handrolled-retry-loop",
+      "what": "самописный retry/backoff-цикл в _with_busy_retry()",
+      "replacement": "tenacity.retry / aiolimiter (для rate-limit)",
+      "confidence": "med"
+    },
+    {
+      "file": "src/services/error_recovery_service.py",
+      "line": 355,
+      "kind": "manual-counter",
+      "what": "самописный частотный счётчик в get_error_stats()",
+      "replacement": "collections.Counter",
+      "confidence": "med"
+    },
+    {
+      "file": "src/services/task_handlers/stats.py",
+      "line": 173,
+      "kind": "handrolled-retry-loop",
+      "what": "самописный retry/backoff-цикл в handle_stats_all()",
+      "replacement": "tenacity.retry / aiolimiter (для rate-limit)",
+      "confidence": "med"
+    },
+    {
+      "file": "src/services/telegram_command_dispatcher.py",
+      "line": 144,
+      "kind": "handrolled-retry-loop",
+      "what": "самописный retry/backoff-цикл в _run_loop()",
+      "replacement": "tenacity.retry / aiolimiter (для rate-limit)",
+      "confidence": "med"
+    },
+    {
+      "file": "src/services/telegram_command_dispatcher.py",
+      "line": 343,
+      "kind": "handrolled-retry-loop",
+      "what": "самописный retry/backoff-цикл в _update_command_safely()",
+      "replacement": "tenacity.retry / aiolimiter (для rate-limit)",
+      "confidence": "med"
+    },
+    {
+      "file": "src/services/unified_dispatcher.py",
+      "line": 178,
+      "kind": "handrolled-retry-loop",
+      "what": "самописный retry/backoff-цикл в _run_loop()",
+      "replacement": "tenacity.retry / aiolimiter (для rate-limit)",
+      "confidence": "med"
+    },
+    {
+      "file": "src/telegram/collector.py",
+      "line": 674,
+      "kind": "handrolled-retry-loop",
+      "what": "самописный retry/backoff-цикл в collect_all_channels()",
+      "replacement": "tenacity.retry / aiolimiter (для rate-limit)",
+      "confidence": "med"
+    },
+    {
+      "file": "src/telegram/collector.py",
+      "line": 2277,
+      "kind": "handrolled-retry-loop",
+      "what": "самописный retry/backoff-цикл в collect_all_stats()",
+      "replacement": "tenacity.retry / aiolimiter (для rate-limit)",
+      "confidence": "med"
+    },
+    {
+      "file": "src/telegram/collector.py",
+      "line": 694,
+      "kind": "manual-counter",
+      "what": "самописный частотный счётчик в collect_all_channels()",
+      "replacement": "collections.Counter",
+      "confidence": "med"
+    },
+    {
+      "file": "src/telegram/pool_dialogs.py",
+      "line": 311,
+      "kind": "handrolled-retry-loop",
+      "what": "самописный retry/backoff-цикл в warm_all_dialogs()",
+      "replacement": "tenacity.retry / aiolimiter (для rate-limit)",
+      "confidence": "med"
+    },
+    {
+      "file": "src/telegram/pool_dialogs.py",
+      "line": 1277,
+      "kind": "handrolled-retry-loop",
+      "what": "самописный retry/backoff-цикл в leave_channels()",
+      "replacement": "tenacity.retry / aiolimiter (для rate-limit)",
+      "confidence": "med"
+    },
+    {
+      "file": "src/web/bootstrap.py",
+      "line": 74,
+      "kind": "handrolled-retry-loop",
+      "what": "самописный retry/backoff-цикл в _retry_telegram_pool_until_connected()",
+      "replacement": "tenacity.retry / aiolimiter (для rate-limit)",
+      "confidence": "med"
+    },
+    {
+      "file": "src/web/search/handlers.py",
+      "line": 84,
+      "kind": "handrolled-retry-loop",
+      "what": "самописный retry/backoff-цикл в _telegram_search_via_worker()",
+      "replacement": "tenacity.retry / aiolimiter (для rate-limit)",
+      "confidence": "med"
+    },
+    {
+      "file": "src/web/session.py",
+      "line": 22,
+      "kind": "manual-base64-padding",
+      "what": "ручная добивка base64-паддинга '='",
+      "replacement": "base64.urlsafe_b64decode с корректным выравниванием",
+      "confidence": "med"
+    },
+    {
+      "file": "src/web/settings/handlers.py",
+      "line": 376,
+      "kind": "manual-counter",
+      "what": "самописный частотный счётчик в _run_bulk_test_job()",
+      "replacement": "collections.Counter",
+      "confidence": "med"
+    }
+  ]
+}

--- a/tests/test_detect_reinvented.py
+++ b/tests/test_detect_reinvented.py
@@ -266,6 +266,19 @@ def test_split_on_other_sep_not_flagged() -> None:
     assert "manual-email-parse" not in _kinds(src)
 
 
+def test_url_split_intentionally_not_flagged() -> None:
+    """Регресс (Codex #1110): разбор URL через split('/')/'?'/'#' НЕ ловится.
+
+    Эти разделители слишком частые вне URL — эвристика на них была бы сплошным
+    false-positive. Решение намеренное; детектор не заявляет URL-покрытие.
+    """
+    src = """
+        def path_of(url):
+            return url.split("/")[2], url.split("?")[0], url.split("#")[0]
+    """
+    assert _kinds(src) == set(), "URL-split не должен давать никаких находок"
+
+
 # --------------------------------------------------------------------------- #
 # Эвристика: ручная добивка base64-паддинга
 # --------------------------------------------------------------------------- #
@@ -292,6 +305,20 @@ def test_string_multiply_unrelated_not_flagged() -> None:
     src = """
         def rule(width):
             return "-" * width
+    """
+    assert "manual-base64-padding" not in _kinds(src)
+
+
+def test_equals_multiply_without_b64_not_flagged() -> None:
+    """Регресс (ревью #1110): `print('=' * 80)` без b64-вызова рядом — НЕ паддинг.
+
+    Без b64-контекста `'=' * n` — обычный разделитель; флагить его = low-шум.
+    """
+    src = """
+        def banner():
+            print("=" * 80)
+            print("REPORT")
+            print("=" * 80)
     """
     assert "manual-base64-padding" not in _kinds(src)
 
@@ -332,33 +359,49 @@ def test_human_format_has_all_fields() -> None:
 # --------------------------------------------------------------------------- #
 
 
-def _finding(file: str, line: int, kind: str = "manual-counter"):  # type: ignore[no-untyped-def]
-    return Finding(file=file, line=line, kind=kind, what="w", replacement="r", confidence="med")
+def _finding(file: str, line: int, kind: str = "manual-counter", what: str = "w"):  # type: ignore[no-untyped-def]
+    return Finding(file=file, line=line, kind=kind, what=what, replacement="r", confidence="med")
 
 
 def test_no_baseline_means_all_new() -> None:
     """Без baseline (None) все находки считаются новыми."""
-    findings = [_finding("a.py", 1), _finding("b.py", 2)]
+    findings = [_finding("a.py", 1, what="x"), _finding("b.py", 2, what="y")]
     new = detect_reinvented.new_findings(findings, None)
     assert len(new) == 2
 
 
 def test_new_findings_diffs_against_baseline() -> None:
-    """В baseline зафиксирован один ключ; новой считается только отсутствующая находка."""
-    known = _finding("a.py", 1)
-    fresh = _finding("b.py", 2)
-    baseline_keys = {known.key()}
-    new = detect_reinvented.new_findings([known, fresh], baseline_keys)
-    assert [f.key() for f in new] == [fresh.key()]
+    """В baseline зафиксирован один identity; новой считается только отсутствующая находка."""
+    known = _finding("a.py", 1, what="known")
+    fresh = _finding("b.py", 2, what="fresh")
+    baseline_ids = {known.identity()}
+    new = detect_reinvented.new_findings([known, fresh], baseline_ids)
+    assert [f.identity() for f in new] == [fresh.identity()]
+
+
+def test_new_findings_stable_across_line_shift() -> None:
+    """Регресс (Codex #1110): сдвиг строки НЕ делает неизменную находку «новой».
+
+    Baseline зафиксирован по identity (file/kind/what). Та же находка, всплывшая
+    на другой строке после вставки кода выше, не считается новым велосипедом —
+    иначе --fail-on-new шумел бы после любого рефакторинга.
+    """
+    original = _finding("a.py", line=10, what="самописный счётчик в f()")
+    shifted = _finding("a.py", line=42, what="самописный счётчик в f()")  # та же находка, +строки выше
+    baseline_ids = {original.identity()}
+    assert detect_reinvented.new_findings([shifted], baseline_ids) == []
 
 
 def test_baseline_roundtrip(tmp_path: Path) -> None:
-    """write_baseline → load_baseline восстанавливает множество ключей находок."""
-    findings = [_finding("a.py", 1, "manual-counter"), _finding("b.py", 9, "handrolled-retry-loop")]
+    """write_baseline → load_baseline восстанавливает множество identity-отпечатков."""
+    findings = [
+        _finding("a.py", 1, "manual-counter", what="счётчик в a()"),
+        _finding("b.py", 9, "handrolled-retry-loop", what="retry в b()"),
+    ]
     snapshot = tmp_path / "baseline.json"
     detect_reinvented.write_baseline(snapshot, findings)
-    keys = detect_reinvented.load_baseline(snapshot)
-    assert keys == {f.key() for f in findings}
+    ids = detect_reinvented.load_baseline(snapshot)
+    assert ids == {f.identity() for f in findings}
 
 
 def test_load_baseline_missing_returns_none(tmp_path: Path) -> None:

--- a/tests/test_detect_reinvented.py
+++ b/tests/test_detect_reinvented.py
@@ -1,0 +1,381 @@
+"""Тесты для scripts/detect_reinvented.py — детектора «изобретённого велосипеда» (#1108).
+
+Чистая логика эвристик проверяется на мини-фикстурах «велосипед vs идиоматичный
+код» (по образцу того, как tests/test_doc_coverage.py тестирует обёртку над
+interrogate на фейках формы, а не на реальном инструменте). Каждая эвристика
+имеет:
+  * положительную фикстуру — самописный код, который ДОЛЖЕН поймать детектор;
+  * отрицательную — идиоматичный / уже-на-stdlib код, который НЕ должен давать
+    false-positive.
+
+Верификационный кейс эпика (#1083: «детектор находит ≥1 известный кейс из #782»)
+— hand-rolled HMAC-JWT из src/web/session.py (#782 / пункт #1). Эталонная
+функция собирала `base64url(HMAC-SHA256(secret, payload))` руками; детектор
+обязан её поймать. При этом ТЕКУЩИЙ session.py уже переехал на itsdangerous.Signer
+(#953) — и на нём детектор молчать НЕ обязан по этой эвристике, что тоже
+зафиксировано отдельным тестом (отрицательный по handrolled-signing).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# scripts/ — не пакет; грузим модуль по пути, как tests/test_doc_coverage.py.
+# Модуль регистрируется в sys.modules ДО exec_module: его @dataclass со
+# строковыми аннотациями (from __future__ import annotations) обращается к
+# sys.modules[cls.__module__] при разборе типов — без регистрации падает с
+# AttributeError на NoneType.
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "detect_reinvented.py"
+_spec = importlib.util.spec_from_file_location("detect_reinvented", _SCRIPT)
+assert _spec and _spec.loader
+detect_reinvented = importlib.util.module_from_spec(_spec)
+sys.modules["detect_reinvented"] = detect_reinvented
+_spec.loader.exec_module(detect_reinvented)
+
+detect_in_source = detect_reinvented.detect_in_source
+Finding = detect_reinvented.Finding
+
+
+def _kinds(source: str) -> set[str]:
+    return {f.kind for f in detect_in_source(textwrap.dedent(source), "fixture.py")}
+
+
+# --------------------------------------------------------------------------- #
+# Верификационный кейс эпика: hand-rolled HMAC-JWT (#782 / session.py #1)
+# --------------------------------------------------------------------------- #
+
+# Исторический паттерн session.py ДО рефакторинга на itsdangerous (#953):
+# своя HMAC-SHA256 подпись поверх base64url(json-payload). Это и есть эталон,
+# который детектор обязан поймать (verification «≥1 известный кейс из #782»).
+HANDROLLED_HMAC_JWT = """
+    import base64
+    import hashlib
+    import hmac
+    import json
+    import time
+
+    def create_session_token(username, secret, ttl=3600):
+        payload = json.dumps({"user": username, "exp": int(time.time()) + ttl})
+        payload_b64 = base64.urlsafe_b64encode(payload.encode()).rstrip(b"=").decode()
+        sig = hmac.new(secret.encode(), payload_b64.encode(), hashlib.sha256).digest()
+        sig_b64 = base64.urlsafe_b64encode(sig).rstrip(b"=").decode()
+        return f"{payload_b64}.{sig_b64}"
+"""
+
+# Текущий session.py: подпись делегирована itsdangerous.Signer — никакого
+# hmac.new/собственной крипты в теле. По эвристике handrolled-signing молчим.
+IDIOMATIC_ITSDANGEROUS = """
+    import base64
+    import hashlib
+    import json
+    import time
+
+    from itsdangerous import Signer
+
+    def create_session_token(username, secret, ttl=3600):
+        payload = json.dumps({"user": username, "exp": int(time.time()) + ttl})
+        payload_b64 = base64.urlsafe_b64encode(payload.encode()).rstrip(b"=").decode()
+        return Signer(secret, sep=".", digest_method=hashlib.sha256).sign(payload_b64).decode()
+"""
+
+
+def test_handrolled_hmac_jwt_is_caught() -> None:
+    """Verification-кейс #1083: эталонный hand-rolled HMAC-JWT (#782) ловится, high."""
+    findings = detect_in_source(textwrap.dedent(HANDROLLED_HMAC_JWT), "src/web/session.py")
+    signing = [f for f in findings if f.kind == "handrolled-token-signing"]
+    assert len(signing) == 1, "детектор обязан поймать самописную HMAC-JWT подпись (#782 эталон)"
+    assert signing[0].confidence == "high"
+    assert "session.py" in signing[0].file
+    assert "itsdangerous" in signing[0].replacement
+
+
+def test_itsdangerous_signing_not_flagged() -> None:
+    """Идиоматичная подпись через itsdangerous.Signer НЕ даёт handrolled-находки."""
+    assert "handrolled-token-signing" not in _kinds(IDIOMATIC_ITSDANGEROUS)
+
+
+# --------------------------------------------------------------------------- #
+# Эвристика: самописный retry/backoff (#782 контекст; есть tenacity/aiolimiter)
+# --------------------------------------------------------------------------- #
+
+
+def test_retry_loop_with_sleep_is_caught() -> None:
+    """Цикл с try/except + sleep — самописный retry, должен ловиться (med)."""
+    src = """
+        import time
+
+        def fetch(url, retries=3):
+            for attempt in range(retries):
+                try:
+                    return do_request(url)
+                except ConnectionError:
+                    time.sleep(2 ** attempt)
+            raise RuntimeError("failed")
+    """
+    findings = [f for f in detect_in_source(textwrap.dedent(src), "f.py") if f.kind == "handrolled-retry-loop"]
+    assert len(findings) == 1
+    assert findings[0].confidence == "med"
+    assert "tenacity" in findings[0].replacement
+
+
+def test_async_retry_loop_is_caught() -> None:
+    """async-вариант: while + try/except + asyncio.sleep тоже ловится."""
+    src = """
+        import asyncio
+
+        async def fetch(url):
+            attempt = 0
+            while attempt < 5:
+                try:
+                    return await do_request(url)
+                except TimeoutError:
+                    await asyncio.sleep(1)
+                attempt += 1
+    """
+    assert "handrolled-retry-loop" in _kinds(src)
+
+
+def test_nested_function_retry_deduped() -> None:
+    """Вложенная функция и её обёртка видят один цикл через ast.walk → одна находка.
+
+    Без дедупа по (файл, тип, строка) один и тот же retry-цикл вышел бы дважды с
+    именами обеих функций (внешней и вложенной).
+    """
+    src = """
+        import asyncio
+
+        async def outer():
+            async def inner():
+                while True:
+                    try:
+                        return await work()
+                    except TimeoutError:
+                        await asyncio.sleep(1)
+            return await inner()
+    """
+    retries = [f for f in detect_in_source(textwrap.dedent(src), "f.py") if f.kind == "handrolled-retry-loop"]
+    assert len(retries) == 1, "один цикл — одна находка, дубли по вложенности дедуплицированы"
+
+
+def test_plain_loop_without_try_is_not_flagged() -> None:
+    """Обычный цикл без try/except (и без sleep) — не retry, не находка."""
+    src = """
+        def total(items):
+            acc = 0
+            for x in items:
+                acc += x
+            return acc
+    """
+    assert "handrolled-retry-loop" not in _kinds(src)
+
+
+def test_loop_with_sleep_but_no_try_is_not_flagged() -> None:
+    """Poll-цикл со sleep, но БЕЗ try/except — не считаем retry (нет перехвата)."""
+    src = """
+        import time
+
+        def wait_ready(check):
+            while not check():
+                time.sleep(1)
+    """
+    assert "handrolled-retry-loop" not in _kinds(src)
+
+
+# --------------------------------------------------------------------------- #
+# Эвристика: самописный частотный счётчик (есть collections.Counter)
+# --------------------------------------------------------------------------- #
+
+
+def test_manual_counter_is_caught() -> None:
+    """`d[k] = d.get(k, 0) + 1` — велосипед поверх Counter, ловится (med)."""
+    src = """
+        def histogram(items):
+            counts = {}
+            for x in items:
+                counts[x] = counts.get(x, 0) + 1
+            return counts
+    """
+    findings = [f for f in detect_in_source(textwrap.dedent(src), "f.py") if f.kind == "manual-counter"]
+    assert len(findings) == 1
+    assert "Counter" in findings[0].replacement
+
+
+def test_manual_counter_subscript_increment_is_caught() -> None:
+    """Вариант `d[k] = d[k] + 1` (через subscript, не .get) тоже ловится."""
+    src = """
+        def histogram(items, counts):
+            for x in items:
+                counts[x] = counts[x] + 1
+            return counts
+    """
+    assert "manual-counter" in _kinds(src)
+
+
+def test_collections_counter_not_flagged() -> None:
+    """Идиоматичный Counter — никаких manual-counter находок."""
+    src = """
+        from collections import Counter
+
+        def histogram(items):
+            return Counter(items)
+    """
+    assert "manual-counter" not in _kinds(src)
+
+
+def test_augmented_assign_to_var_not_flagged() -> None:
+    """`acc = acc + 1` по обычной переменной (не subscript) — не счётчик-словарь."""
+    src = """
+        def count_positive(items):
+            acc = 0
+            for x in items:
+                if x > 0:
+                    acc = acc + 1
+            return acc
+    """
+    assert "manual-counter" not in _kinds(src)
+
+
+# --------------------------------------------------------------------------- #
+# Эвристика: ручной парсинг email (есть email.utils)
+# --------------------------------------------------------------------------- #
+
+
+def test_manual_email_split_is_caught() -> None:
+    """`addr.split('@')` — ручной разбор email, ловится (low)."""
+    src = """
+        def domain_of(addr):
+            return addr.split("@")[1]
+    """
+    findings = [f for f in detect_in_source(textwrap.dedent(src), "f.py") if f.kind == "manual-email-parse"]
+    assert len(findings) == 1
+    assert findings[0].confidence == "low"
+    assert "email.utils" in findings[0].replacement
+
+
+def test_split_on_other_sep_not_flagged() -> None:
+    """split по другому разделителю (не '@') — не email-эвристика."""
+    src = """
+        def first_csv(line):
+            return line.split(",")[0]
+    """
+    assert "manual-email-parse" not in _kinds(src)
+
+
+# --------------------------------------------------------------------------- #
+# Эвристика: ручная добивка base64-паддинга
+# --------------------------------------------------------------------------- #
+
+
+def test_manual_base64_padding_is_caught() -> None:
+    """`s += '=' * padding` рядом с b64decode — ручной паддинг, ловится (med)."""
+    src = """
+        import base64
+
+        def b64url_decode(s):
+            padding = 4 - len(s) % 4
+            if padding != 4:
+                s += "=" * padding
+            return base64.urlsafe_b64decode(s)
+    """
+    findings = [f for f in detect_in_source(textwrap.dedent(src), "f.py") if f.kind == "manual-base64-padding"]
+    assert len(findings) == 1
+    assert findings[0].confidence == "med"
+
+
+def test_string_multiply_unrelated_not_flagged() -> None:
+    """`'-' * width` (рисование разделителя) — не base64-паддинг."""
+    src = """
+        def rule(width):
+            return "-" * width
+    """
+    assert "manual-base64-padding" not in _kinds(src)
+
+
+# --------------------------------------------------------------------------- #
+# Свойства модели / устойчивость
+# --------------------------------------------------------------------------- #
+
+
+def test_syntax_error_yields_no_findings() -> None:
+    """Битый Python не роняет детектор (advisory): пустой список."""
+    assert detect_in_source("def broken(:\n    pass", "bad.py") == []
+
+
+def test_findings_are_sorted_deterministically() -> None:
+    """Порядок находок стабилен (по файлу/строке) — для воспроизводимого baseline."""
+    src = textwrap.dedent(HANDROLLED_HMAC_JWT)
+    first = detect_in_source(src, "a.py")
+    second = detect_in_source(src, "a.py")
+    assert [f.key() for f in first] == [f.key() for f in second]
+
+
+def test_human_format_has_all_fields() -> None:
+    """Человекочитаемая строка содержит файл:строку, что, замену, уверенность."""
+    f = Finding(
+        file="src/x.py", line=42, kind="manual-counter",
+        what="самописный счётчик", replacement="collections.Counter", confidence="med",
+    )
+    human = f.human()
+    assert "src/x.py:42" in human
+    assert "самописный счётчик" in human
+    assert "collections.Counter" in human
+    assert "med" in human
+
+
+# --------------------------------------------------------------------------- #
+# Baseline-логика (дифф НОВЫХ велосипедов)
+# --------------------------------------------------------------------------- #
+
+
+def _finding(file: str, line: int, kind: str = "manual-counter"):  # type: ignore[no-untyped-def]
+    return Finding(file=file, line=line, kind=kind, what="w", replacement="r", confidence="med")
+
+
+def test_no_baseline_means_all_new() -> None:
+    """Без baseline (None) все находки считаются новыми."""
+    findings = [_finding("a.py", 1), _finding("b.py", 2)]
+    new = detect_reinvented.new_findings(findings, None)
+    assert len(new) == 2
+
+
+def test_new_findings_diffs_against_baseline() -> None:
+    """В baseline зафиксирован один ключ; новой считается только отсутствующая находка."""
+    known = _finding("a.py", 1)
+    fresh = _finding("b.py", 2)
+    baseline_keys = {known.key()}
+    new = detect_reinvented.new_findings([known, fresh], baseline_keys)
+    assert [f.key() for f in new] == [fresh.key()]
+
+
+def test_baseline_roundtrip(tmp_path: Path) -> None:
+    """write_baseline → load_baseline восстанавливает множество ключей находок."""
+    findings = [_finding("a.py", 1, "manual-counter"), _finding("b.py", 9, "handrolled-retry-loop")]
+    snapshot = tmp_path / "baseline.json"
+    detect_reinvented.write_baseline(snapshot, findings)
+    keys = detect_reinvented.load_baseline(snapshot)
+    assert keys == {f.key() for f in findings}
+
+
+def test_load_baseline_missing_returns_none(tmp_path: Path) -> None:
+    """Отсутствующий снимок → None (а не пустое множество): «baseline ещё нет»."""
+    assert detect_reinvented.load_baseline(tmp_path / "nope.json") is None
+
+
+# --------------------------------------------------------------------------- #
+# Прогон по реальному src/web/session.py: текущий код НЕ должен давать
+# handrolled-signing (он на itsdangerous). Защищает от регресса эвристики.
+# --------------------------------------------------------------------------- #
+
+
+def test_real_session_py_not_flagged_as_handrolled() -> None:
+    """Текущий src/web/session.py (itsdangerous) не ловится как hand-rolled signing."""
+    session_py = Path(__file__).resolve().parents[1] / "src" / "web" / "session.py"
+    if not session_py.exists():  # pragma: no cover - файл есть в репозитории
+        pytest.skip("src/web/session.py отсутствует")
+    findings = detect_in_source(session_py.read_text(encoding="utf-8"), "src/web/session.py")
+    assert "handrolled-token-signing" not in {f.kind for f in findings}


### PR DESCRIPTION
Closes #1108

Часть эпика #1083 (детектор кастомных функций → стандартные библиотеки). Учтён вердикт research-саба #1107: готовые линтеры (refurb/perflint/C4) ловят 0/6 доменных эталонов #782 — нужен **свой детектор с доменными AST-эвристиками**, а не обёртка вокруг линтера. Идиомы остаются за ruff (FURB/PERF/C4), детектор фокусируется на доменных велосипедах уровня #782.

## Что в PR
- **`scripts/detect_reinvented.py`** (по образцу `scripts/code_health.py` / `doc_coverage.py`): argparse, `--path src`, JSON-вывод (`--json`), цветной человекочитаемый отчёт, `def main() -> int`, advisory exit 0.
- **`scripts/reinvented_baseline.json`** — baseline-снимок (17 находок по текущему `src/`).
- **`tests/test_detect_reinvented.py`** — 23 теста на фикстурах (уровень `unit`).

## Эвристики (AST-based, `ast.walk` / `NodeVisitor`; намеренно консервативны)
| Эвристика | Что ловит | Замена | Увер. |
|---|---|---|---|
| `handrolled-token-signing` | `hmac`/`hashlib` + base64 + json в функции | `itsdangerous.Signer` / PyJWT | high/med |
| `handrolled-retry-loop` | цикл с `try/except` + `sleep` | `tenacity` / `aiolimiter` | med |
| `manual-base64-padding` | ручная добивка `'=' * n` рядом с b64 | `base64.urlsafe_b64decode` | med/low |
| `manual-email-parse` | `addr.split('@')` | `email.utils.parseaddr` | low |
| `manual-counter` | `d[k] = d.get(k,0)+1` | `collections.Counter` | med |

Сверено: ruff `FURB/PERF/C4` НЕ ловит `manual-counter` — дублирования с линтерами нет.

Вывод по каждой находке: **`файл:строка — что делает — предлагаемая замена — уверенность`**.

## Baseline + дифф НОВЫХ
Первый прогон фиксирует находки в JSON-снимок; последующие диффят по ключу `(file, kind, line)` и подсвечивают **НОВЫЕ** велосипеды (ловит свежие самописные реализации в регрессию, накопленный долг не шумит). Флаги: `--update-baseline` (пересъём), `--fail-on-new` (CI-гейт, опционально).

## TDD + verification
- Положительные фикстуры (велосипед → находка) и отрицательные (идиоматичный код / уже-на-stdlib → НЕ находка).
- **Verification-кейс #1083** («≥1 известный кейс из #782»): hand-rolled HMAC-JWT (`session.py` #1) ловится с `high`. Текущий `session.py` уже на `itsdangerous` (#953) — по этой эвристике молчит (отдельный отрицательный тест защищает от регресса).
- Дедуп вложенных функций (внешняя обёртка + вложенная видят один цикл → одна находка).

## Границы
- НЕ трогает `.github/workflows/ci.yml` — расписание детектора отдельный sub, зависит от #1097. Скрипт самодостаточен (ручной запуск).
- `ruff check`, `mypy` чисто; `pytest` зелёный без ворнингов.

🤖 Generated with [Claude Code](https://claude.com/claude-code)