### PR TITLE
fix(notifications): idempotent teardown_bot recovers orphan DB row (#1085)

### DIFF
--- a/src/services/notification_service.py
+++ b/src/services/notification_service.py
@@ -97,7 +97,18 @@ class NotificationService:
         return True
 
     async def teardown_bot(self) -> None:
-        """Delete the notification bot via BotFather and remove it from DB."""
+        """Delete the notification bot via BotFather and remove it from DB.
+
+        Idempotent after a remote delete (issue #1085): if the bot is already
+        gone from Telegram, ``botfather.delete_bot`` raises
+        :class:`~src.telegram.botfather.BotNotFoundError`. That is treated as
+        "the Telegram delete already happened" — we skip the TG step and proceed
+        straight to the DB-row cleanup, so a repeat teardown can finally remove
+        an orphan row left behind when a prior DB-delete failed (#1041). Any
+        *other* BotFather error means the live bot may still exist, so it is
+        re-raised *before* the DB-delete: we never wipe the row while the bot
+        might still be reachable in Telegram.
+        """
         async with self._target_service.use_client() as (client, _phone):
             me = await asyncio.wait_for(client.get_me(), timeout=15.0)
             tg_user_id: int = me.id
@@ -105,7 +116,20 @@ class NotificationService:
             if bot is None:
                 raise RuntimeError("No notification bot found for this user")
 
-            await botfather.delete_bot(client, bot.bot_username)
+            try:
+                await botfather.delete_bot(client, bot.bot_username)
+            except botfather.BotNotFoundError:
+                # The bot is no longer in /mybots — it was already deleted in
+                # Telegram (e.g. a previous teardown that then failed at the
+                # DB-delete step). Fall through to the local cleanup so the
+                # orphan row can be removed; this is what makes teardown
+                # idempotent and recoverable, not just observable.
+                logger.info(
+                    "Notification bot @%s already absent from Telegram; "
+                    "proceeding with local DB cleanup for user %s",
+                    bot.bot_username,
+                    tg_user_id,
+                )
 
         # BotFather already destroyed the live bot. If the DB row delete now
         # fails the row becomes an orphan: get_status() keeps reporting the bot

--- a/src/telegram/botfather.py
+++ b/src/telegram/botfather.py
@@ -11,6 +11,18 @@ logger = logging.getLogger(__name__)
 BOTFATHER = "BotFather"
 _TOKEN_RE = re.compile(r"(\d{8,}:[A-Za-z0-9_\-]{35,})")
 
+
+class BotNotFoundError(RuntimeError):
+    """The requested bot is absent from BotFather's ``/mybots`` list.
+
+    Raised by :func:`delete_bot` when the bot button is missing from the
+    ``/mybots`` keyboard — i.e. the bot does not exist in Telegram for this
+    account (typically because it was already deleted). This is a *distinct,
+    recoverable* signal, NOT a generic BotFather failure: a repeat teardown can
+    treat it as "the Telegram delete already happened" and safely proceed to the
+    local DB cleanup, making teardown idempotent (issue #1085, follow-up #1041).
+    """
+
 # Redaction is intentionally BROADER than _TOKEN_RE: the orphan branch fires
 # precisely when BotFather's reply drifted from the expected token format, so a
 # valid token may still be present in the text yet not match the strict regex.
@@ -69,14 +81,42 @@ async def create_bot(client: TelegramClient, name: str, username: str) -> str:
         return token_match.group(1)
 
 
+def _has_inline(message: Message, text: str) -> bool:
+    """Return True if any inline button's text contains *text* (case-insensitive).
+
+    Mirrors the matching used by :func:`_click_inline` so callers can probe for a
+    button (e.g. the bot entry in ``/mybots``) without clicking it.
+    """
+    if not message.reply_markup:
+        return False
+    low = text.lower()
+    for row in message.reply_markup.rows:
+        for button in row.buttons:
+            btn_text = getattr(button, "text", "") or ""
+            if low in btn_text.lower():
+                return True
+    return False
+
+
 async def delete_bot(client: TelegramClient, bot_username: str) -> None:
-    """Delete a bot via BotFather by username."""
+    """Delete a bot via BotFather by username.
+
+    Raises :class:`BotNotFoundError` if the bot is absent from ``/mybots`` (it
+    no longer exists in Telegram for this account); the caller can treat that as
+    an already-completed delete and continue with local cleanup (#1085).
+    """
+    target = bot_username.lstrip("@")
     async with client.conversation(BOTFATHER, timeout=60) as conv:
         await conv.send_message("/mybots")
         resp = await conv.get_response()
 
-        # Click on the bot button
-        await _click_inline(resp, bot_username.lstrip("@"))
+        # Click on the bot button. A missing button here means the bot is not in
+        # /mybots — it was already deleted in Telegram — so raise the distinct
+        # BotNotFoundError (recoverable) rather than a generic "button not found".
+        if not _has_inline(resp, target):
+            logger.info("Bot @%s not found in /mybots — already deleted in Telegram", target)
+            raise BotNotFoundError(f"Bot @{target} not found in /mybots")
+        await _click_inline(resp, target)
         resp = await conv.get_edit()
 
         # Click "Delete Bot"

--- a/src/telegram/botfather.py
+++ b/src/telegram/botfather.py
@@ -110,9 +110,23 @@ async def delete_bot(client: TelegramClient, bot_username: str) -> None:
         await conv.send_message("/mybots")
         resp = await conv.get_response()
 
-        # Click on the bot button. A missing button here means the bot is not in
-        # /mybots — it was already deleted in Telegram — so raise the distinct
-        # BotNotFoundError (recoverable) rather than a generic "button not found".
+        # BotNotFoundError is the *recoverable* signal (caller may then delete the
+        # DB row), so it must mean "the bot is genuinely absent from a valid
+        # /mybots listing" — NOT "BotFather gave an unexpected reply". A reply
+        # WITHOUT an inline keyboard is not a bot list at all (an error/rate-limit
+        # message, or format drift); the live bot may still exist, so raise a
+        # GENERIC error that teardown will NOT forgive, leaving the DB row intact.
+        # Mapping this to BotNotFoundError would risk wiping a live bot's row
+        # (#1085 review, Codex finding).
+        if not resp.reply_markup:
+            safe = _redact_tokens(resp.text or "")
+            raise RuntimeError(
+                f"Unexpected BotFather reply to /mybots (no bot list): {safe[:200]!r}"
+            )
+
+        # The reply IS a /mybots listing. If our bot's button is absent from it,
+        # the bot was already deleted in Telegram — that is the recoverable
+        # BotNotFoundError the caller can treat as "TG step already done".
         if not _has_inline(resp, target):
             logger.info("Bot @%s not found in /mybots — already deleted in Telegram", target)
             raise BotNotFoundError(f"Bot @{target} not found in /mybots")

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -331,6 +331,34 @@ async def test_delete_bot_missing_from_mybots_raises_bot_not_found():
         await botfather.delete_bot(mock_client, "@leadhunter_gone_bot")
 
 
+async def test_delete_bot_keyboardless_reply_is_generic_error_not_bot_not_found():
+    """RED→GREEN (#1085, Codex finding): an error/keyboard-less reply is NOT "bot gone".
+
+    ``BotNotFoundError`` is the *recoverable* signal that lets ``teardown_bot``
+    skip the Telegram step and delete the DB row. It must therefore mean "the bot
+    is genuinely absent from a valid /mybots listing" — NOT "BotFather replied
+    with something we didn't expect". If ``/mybots`` returns an error, a
+    rate-limit, or any reply WITHOUT an inline keyboard (so we never saw a bot
+    list at all), the live bot may still exist. Mapping that to
+    ``BotNotFoundError`` would let teardown wipe the DB row while the bot is
+    alive — a data-loss orphan flip. Such a reply must raise a *generic*
+    RuntimeError (which ``teardown_bot`` does NOT forgive), leaving the row
+    intact.
+    """
+    # A plain text BotFather reply (rate-limit / transient error) — no keyboard.
+    err_msg = MagicMock()
+    err_msg.text = "Sorry, too many requests. Please try again later."
+    err_msg.reply_markup = None
+    mock_conv = _make_conv(err_msg)
+    mock_client = MagicMock()
+    mock_client.conversation.return_value = mock_conv
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await botfather.delete_bot(mock_client, "@leadhunter_alive_bot")
+    # Must NOT be the recoverable subclass — the bot might still be live.
+    assert not isinstance(exc_info.value, botfather.BotNotFoundError)
+
+
 @pytest.mark.anyio
 async def test_setup_bot_success(db, real_pool_harness_factory):
     harness = real_pool_harness_factory()

--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -307,6 +307,30 @@ async def test_delete_bot_success():
     confirm_msg.click.assert_awaited_once()
 
 
+async def test_delete_bot_missing_from_mybots_raises_bot_not_found():
+    """RED→GREEN (#1085): a bot absent from /mybots is a distinct, recoverable signal.
+
+    When ``teardown_bot``'s first BotFather call already destroyed the bot but the
+    DB-delete then failed, the row becomes an orphan (issue #1041). A *repeat*
+    teardown calls ``delete_bot`` again, but the bot is gone from Telegram, so it
+    is no longer listed in ``/mybots`` and the first ``_click_inline`` (which looks
+    up the bot button) finds nothing.
+
+    That "bot is not in /mybots" condition must be a *typed* signal
+    (``BotNotFoundError``) — separable from a real BotFather failure — so the
+    caller can treat it as "TG step already done, proceed to DB cleanup" instead
+    of a hard error that strands the orphan row forever.
+    """
+    # /mybots reply that does NOT contain our bot — only some other bot.
+    mybots_msg = _make_message([["@someone_else_bot"]])
+    mock_conv = _make_conv(mybots_msg)
+    mock_client = MagicMock()
+    mock_client.conversation.return_value = mock_conv
+
+    with pytest.raises(botfather.BotNotFoundError):
+        await botfather.delete_bot(mock_client, "@leadhunter_gone_bot")
+
+
 @pytest.mark.anyio
 async def test_setup_bot_success(db, real_pool_harness_factory):
     harness = real_pool_harness_factory()
@@ -572,6 +596,96 @@ async def test_teardown_bot_db_delete_failure_warns_about_orphan(
     combined = " ".join(r.getMessage() for r in caplog.records).lower()
     assert "orphan" in combined
     assert "leadhunter_frank_bot" in combined or "999" in combined
+
+
+@pytest.mark.anyio
+async def test_teardown_bot_idempotent_after_orphan_cleans_db(db, real_pool_harness_factory):
+    """RED→GREEN (#1085): a repeat teardown must clean the orphan DB row.
+
+    Scenario from the issue: the first teardown deleted the live bot via
+    BotFather, then the DB-delete failed (#1041) — leaving an orphan row. The
+    bot is now gone from Telegram. A repeat ``teardown_bot`` calls
+    ``botfather.delete_bot`` again, which can no longer find the bot in
+    ``/mybots`` and raises ``BotNotFoundError``.
+
+    Before the fix that error propagated *before* the DB-delete ran, so the
+    orphan row could never be removed via the normal flow. After the fix the
+    "bot missing in Telegram" signal is treated as "TG step already done" and
+    teardown proceeds to delete the DB row — making the operation idempotent.
+    """
+    saved = NotificationBot(
+        tg_user_id=1010,
+        tg_username="grace",
+        bot_id=444,
+        bot_username="leadhunter_grace_bot",
+        bot_token="101010101:AABBCCDDEEFFaabbccddeeffAABBCCDDEEFF",
+    )
+    await db.save_notification_bot(saved)
+
+    harness = real_pool_harness_factory()
+    await _connect_notification_account(
+        harness,
+        phone="+70001111111",
+        session_string="session-1",
+        me_id=1010,
+        me_username="grace",
+        is_primary=True,
+    )
+    svc = NotificationService(db, NotificationTargetService(db, harness.pool))
+
+    # The bot was already deleted in Telegram on the first (failed) teardown, so
+    # BotFather can't find it in /mybots — signalled by BotNotFoundError.
+    with patch(
+        "src.services.notification_service.botfather.delete_bot",
+        new_callable=AsyncMock,
+        side_effect=botfather.BotNotFoundError("@leadhunter_grace_bot not in /mybots"),
+    ):
+        await svc.teardown_bot()
+
+    # The orphan row must be gone — teardown is idempotent.
+    assert await db.get_notification_bot(1010) is None
+
+
+@pytest.mark.anyio
+async def test_teardown_bot_real_botfather_error_does_not_delete_db(db, real_pool_harness_factory):
+    """GUARD (#1085): a genuine BotFather failure must NOT delete the DB row.
+
+    The idempotent path only forgives the specific "bot missing in Telegram"
+    signal (``BotNotFoundError``). Any *other* BotFather failure means the live
+    bot may still exist (the irreversible TG delete did NOT happen), so we must
+    keep the DB row and propagate the error — never run the DB-delete after a
+    failed TG-delete. This guards against over-broadening the forgiving branch.
+    """
+    saved = NotificationBot(
+        tg_user_id=1111,
+        tg_username="heidi",
+        bot_id=555,
+        bot_username="leadhunter_heidi_bot",
+        bot_token="111111222:AABBCCDDEEFFaabbccddeeffAABBCCDDEEFF",
+    )
+    await db.save_notification_bot(saved)
+
+    harness = real_pool_harness_factory()
+    await _connect_notification_account(
+        harness,
+        phone="+70001111111",
+        session_string="session-1",
+        me_id=1111,
+        me_username="heidi",
+        is_primary=True,
+    )
+    svc = NotificationService(db, NotificationTargetService(db, harness.pool))
+
+    with patch(
+        "src.services.notification_service.botfather.delete_bot",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("BotFather: Sorry, something went wrong"),
+    ):
+        with pytest.raises(RuntimeError, match="something went wrong"):
+            await svc.teardown_bot()
+
+    # DB row must survive — the bot might still be live in Telegram.
+    assert await db.get_notification_bot(1111) is not None
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Что и почему

Follow-up из cycle-review PR #1082 (#1041), находка Codex.

`NotificationService.teardown_bot` сначала удаляет живого бота через BotFather (Telegram), затем удаляет строку из БД. Когда DB-delete падал после успеха BotFather (#1041), строка становилась **сиротой**. PR #1082 сделал сироту **наблюдаемой** (loud orphan-error), но не **восстановимой**: повторный `teardown_bot` снова шёл в `botfather.delete_bot` первым шагом, но бот уже удалён в TG → его нет в `/mybots` → `_click_inline` падал с generic `RuntimeError("button not found")` ещё ДО DB-delete. Сироту нельзя было убрать штатным flow — нужна была ручная правка БД.

Этот PR делает teardown **идемпотентным**.

## Как

Отделяю «бот отсутствует в Telegram» от реальной ошибки BotFather:

- `botfather.delete_bot` теперь пробит `/mybots` (`_has_inline`) и при отсутствии кнопки бота бросает **типизированный** `BotNotFoundError` (бот уже удалён в TG), вместо generic `RuntimeError`.
- `teardown_bot` ловит `BotNotFoundError` как сигнал «TG-удаление уже состоялось» и продолжает к DB-cleanup → повторный teardown стирает orphan-строку.
- **Любая другая** ошибка BotFather по-прежнему пробрасывается **ДО** DB-delete: мы никогда не стираем строку, пока живой бот может ещё существовать в Telegram (не вводим fallible-шаг после необратимого).

Фикс живёт в единственной точке входа `teardown_bot`, поэтому CLI / web / agent поверхности становятся идемпотентными автоматически (parity бесплатно).

## Тесты (fake/harness-first; BotFather НЕ конвертирован в live pytest)

- `test_delete_bot_missing_from_mybots_raises_bot_not_found` — `delete_bot` бросает `BotNotFoundError`, когда бота нет в `/mybots`
- `test_teardown_bot_idempotent_after_orphan_cleans_db` — RED→GREEN: повторный teardown по orphan-строке успешно удаляет её из БД
- `test_teardown_bot_real_botfather_error_does_not_delete_db` — GUARD: настоящая ошибка BotFather сохраняет DB-строку нетронутой

ruff чисто, mypy без новых ошибок, pytest `-n auto` стабилен (8755 passed parallel + 937 serial).

Closes #1085

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012rL5MkYDfFdCya1NUCtTBZ
