### PR TITLE
fix(agent-tools): coerce JSON-string bool args so the LLM tool path works (#1115)

### DIFF
--- a/src/agent/tools/collection.py
+++ b/src/agent/tools/collection.py
@@ -7,7 +7,7 @@ from typing import Annotated
 from claude_agent_sdk import tool
 
 from src.agent.tools._categories import ToolCategory, ToolMeta
-from src.agent.tools._registry import _text_response, require_pool
+from src.agent.tools._registry import _text_response, arg_bool, require_pool
 
 # Permission metadata for this module's tools (#245). Single source of
 # truth: permissions.py derives TOOL_CATEGORIES / MODULE_GROUPS /
@@ -47,7 +47,9 @@ def register(db, client_pool, embedding_service, **kwargs):
             ch = await db.get_channel_by_pk(int(pk))
             if ch is None:
                 return _text_response(f"Канал pk={pk} не найден.")
-            force = bool(args.get("force", False))
+            # bool("false") is True — coerce so a JSON-string force="false" does not
+            # silently force-collect a filtered channel (#1115).
+            force = arg_bool(args, "force", False)
             if ch.is_filtered and not force:
                 return _text_response(
                     f"Канал '{ch.title}' отфильтрован. Используйте force=true для принудительного сбора."

--- a/src/agent/tools/messaging_admin.py
+++ b/src/agent/tools/messaging_admin.py
@@ -5,7 +5,7 @@ from typing import Any
 from claude_agent_sdk import tool
 from mcp.types import ToolAnnotations
 
-from src.agent.tools._registry import _text_response, arg_str, require_confirmation
+from src.agent.tools._registry import _text_response, arg_bool, arg_str, is_affirmative, require_confirmation
 from src.agent.tools._telegram_runtime import prepare_telegram_tool
 from src.agent.tools.messaging_schemas import (
     EDIT_ADMIN_SCHEMA,
@@ -90,7 +90,9 @@ def register_admin_moderation_tools(ctx: Any, client_pool: Any) -> list[Any]:
             return err
         chat_id = arg_str(args, "chat_id")
         user_id = arg_str(args, "user_id")
-        is_admin = args.get("is_admin", True)
+        # Coerce explicitly: a model emitting the JSON string "false" must demote,
+        # not promote — bool("false") is True would silently invert the action (#1115).
+        is_admin = arg_bool(args, "is_admin", True)
         title = args.get("title") or None
         if not chat_id or not user_id:
             return _text_response("Ошибка: chat_id и user_id обязательны.")
@@ -133,8 +135,13 @@ def register_admin_moderation_tools(ctx: Any, client_pool: Any) -> list[Any]:
         chat_id = arg_str(args, "chat_id")
         user_id = arg_str(args, "user_id")
         until_date_str = args.get("until_date") or None
-        send_messages = args.get("send_messages")
-        send_media = args.get("send_media")
+        # Preserve the three-state (None=unchanged / True / False): only coerce when
+        # the flag is present, so a JSON string "false" restricts instead of being
+        # treated as truthy and silently allowing the action (#1115).
+        raw_send_messages = args.get("send_messages")
+        raw_send_media = args.get("send_media")
+        send_messages = is_affirmative(raw_send_messages) if raw_send_messages is not None else None
+        send_media = is_affirmative(raw_send_media) if raw_send_media is not None else None
         if not chat_id or not user_id:
             return _text_response("Ошибка: chat_id и user_id обязательны.")
         if send_messages is None and send_media is None:

--- a/src/agent/tools/messaging_media.py
+++ b/src/agent/tools/messaging_media.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from claude_agent_sdk import tool
 
-from src.agent.tools._registry import _text_response, require_confirmation
+from src.agent.tools._registry import _text_response, arg_bool, require_confirmation
 from src.agent.tools.messaging_schemas import DOWNLOAD_MEDIA_SCHEMA, PIN_MESSAGE_SCHEMA, UNPIN_MESSAGE_SCHEMA
 from src.services.telegram_actions import (
     TelegramActionClientUnavailableError,
@@ -37,7 +37,9 @@ def register_pin_media_tools(ctx: Any, client_pool: Any) -> list[Any]:
             return perm_gate
         chat_id = args.get("chat_id", "")
         message_id = args.get("message_id")
-        notify = args.get("notify", False)
+        # bool("false") is True, so a JSON-string notify="false" would ping every
+        # member; coerce explicitly so only an affirmative value notifies (#1115).
+        notify = arg_bool(args, "notify", False)
         if not chat_id or not message_id:
             return _text_response("Ошибка: chat_id и message_id обязательны.")
         gate = require_confirmation(f"закрепит сообщение #{message_id} в чате {chat_id}", args)

--- a/src/agent/tools/photo_loader_write.py
+++ b/src/agent/tools/photo_loader_write.py
@@ -13,6 +13,8 @@ from src.agent.tools._photo_loader_runtime import (
 )
 from src.agent.tools._registry import (
     _text_response,
+    arg_bool,
+    is_affirmative,
     require_confirmation,
 )
 from src.agent.tools.photo_loader_schemas import (
@@ -207,7 +209,9 @@ def register_batch_write_tools(db: Any, ctx: Any, client_pool: Any) -> list[Any]
         pool_gate = ctx.require_pool("Обработка фото")
         if pool_gate:
             return pool_gate
-        dry_run = bool(args.get("dry_run"))
+        # bool("false") is True — a JSON-string dry_run="false" would silently force
+        # preview-only and never actually send; coerce via is_affirmative (#1115).
+        dry_run = arg_bool(args, "dry_run", False)
         if dry_run:
             # Preview only — no send, no mark, no state change. Skip the confirmation
             # gate (nothing happens) and the photo-item path (it has no dry-run).
@@ -350,15 +354,23 @@ def register_auto_write_tools(db: Any, ctx: Any, client_pool: Any) -> list[Any]:
         job_id = args.get("job_id")
         if job_id is None:
             return _text_response("Ошибка: job_id обязателен.")
+        # Three-state: None leaves is_active unchanged; only coerce when present, so a
+        # JSON-string is_active="false" deactivates instead of staying truthy (#1115).
+        raw_is_active = args.get("is_active")
+        is_active = is_affirmative(raw_is_active) if raw_is_active is not None else None
+        # int-coerce the interval the same way create_auto_upload does, so a string
+        # "60" cannot reach the int|None DB column as raw text.
+        raw_interval = args.get("interval_minutes")
+        interval_minutes = int(raw_interval) if raw_interval is not None else None
         changes = []
         if args.get("folder_path"):
             changes.append(f"folder={args['folder_path']}")
         if args.get("mode"):
             changes.append(f"mode={args['mode']}")
-        if args.get("interval_minutes") is not None:
-            changes.append(f"interval={args['interval_minutes']}m")
-        if args.get("is_active") is not None:
-            changes.append(f"active={args['is_active']}")
+        if interval_minutes is not None:
+            changes.append(f"interval={interval_minutes}m")
+        if is_active is not None:
+            changes.append(f"active={is_active}")
         desc = f"обновит автозагрузку id={job_id}"
         if changes:
             desc += f" ({', '.join(changes)})"
@@ -376,8 +388,8 @@ def register_auto_write_tools(db: Any, ctx: Any, client_pool: Any) -> list[Any]:
                 folder_path=args.get("folder_path"),
                 send_mode=PhotoSendMode(mode_str) if mode_str else None,
                 caption=args.get("caption"),
-                interval_minutes=args.get("interval_minutes"),
-                is_active=args.get("is_active"),
+                interval_minutes=interval_minutes,
+                is_active=is_active,
             )
             return _text_response(f"Автозагрузка id={job_id} обновлена.")
         except Exception as exc:

--- a/src/agent/tools/photo_loader_write.py
+++ b/src/agent/tools/photo_loader_write.py
@@ -12,8 +12,10 @@ from src.agent.tools._photo_loader_runtime import (
     split_file_paths,
 )
 from src.agent.tools._registry import (
+    ToolInputError,
     _text_response,
     arg_bool,
+    arg_int,
     is_affirmative,
     require_confirmation,
 )
@@ -358,10 +360,22 @@ def register_auto_write_tools(db: Any, ctx: Any, client_pool: Any) -> list[Any]:
         # JSON-string is_active="false" deactivates instead of staying truthy (#1115).
         raw_is_active = args.get("is_active")
         is_active = is_affirmative(raw_is_active) if raw_is_active is not None else None
-        # int-coerce the interval the same way create_auto_upload does, so a string
-        # "60" cannot reach the int|None DB column as raw text.
-        raw_interval = args.get("interval_minutes")
-        interval_minutes = int(raw_interval) if raw_interval is not None else None
+        # Validate the interval BEFORE writing: arg_int turns a non-numeric value into a
+        # friendly ToolInputError (instead of an unhandled ValueError escaping the
+        # handler), and a sub-1 value would violate PhotoAutoUploadJob.interval_minutes
+        # (Field ge=1) and poison every later get/list_auto_jobs read — reject it up
+        # front rather than corrupt the job (#1115 cycle-review, Codex finding).
+        # Validate the interval BEFORE writing: arg_int turns a non-numeric value into a
+        # friendly ToolInputError (instead of an unhandled ValueError escaping the
+        # handler), and a sub-1 value would violate PhotoAutoUploadJob.interval_minutes
+        # (Field ge=1) and poison every later get/list_auto_jobs read — reject it up
+        # front rather than corrupt the job (#1115 cycle-review, Codex finding).
+        try:
+            interval_minutes = arg_int(args, "interval_minutes")
+        except ToolInputError as exc:
+            return exc.to_response()
+        if interval_minutes is not None and interval_minutes < 1:
+            return _text_response("Ошибка: interval_minutes должен быть >= 1.")
         changes = []
         if args.get("folder_path"):
             changes.append(f"folder={args['folder_path']}")

--- a/src/agent/tools/pipeline_write.py
+++ b/src/agent/tools/pipeline_write.py
@@ -10,9 +10,11 @@ from src.agent.tools._pipeline_runtime import parse_agent_target_refs
 from src.agent.tools._registry import (
     ToolInputError,
     _text_response,
+    arg_bool,
     arg_csv_ints,
     arg_int,
     arg_str,
+    is_affirmative,
     require_confirmation,
 )
 from src.agent.tools.pipeline_schemas import (
@@ -59,7 +61,9 @@ def register_pipeline_write_tools(db: Any, ctx: Any) -> list[Any]:
                 llm_model=args.get("llm_model"),
                 publish_mode=args.get("publish_mode", "moderated"),
                 ab_num_variants=int(args.get("ab_num_variants") or 1),
-                ab_auto_select=bool(args.get("ab_auto_select", False)),
+                # bool("false") is True — coerce so a JSON-string disables A/B
+                # auto-select instead of silently enabling it (#1115).
+                ab_auto_select=arg_bool(args, "ab_auto_select", False),
             )
             return _text_response(f"Пайплайн '{name}' создан (id={pipeline_id}).")
         except ToolInputError as exc:
@@ -119,7 +123,7 @@ def register_pipeline_write_tools(db: Any, ctx: Any) -> list[Any]:
                 else pipeline.ab_num_variants
             )
             ab_auto_select = (
-                bool(args["ab_auto_select"])
+                is_affirmative(args["ab_auto_select"])
                 if args.get("ab_auto_select") is not None
                 else pipeline.ab_auto_select
             )

--- a/src/agent/tools/pipeline_write.py
+++ b/src/agent/tools/pipeline_write.py
@@ -52,6 +52,13 @@ def register_pipeline_write_tools(db: Any, ctx: Any) -> list[Any]:
             source_ids = arg_csv_ints(args, "source_channel_ids", required=True)
             target_refs = parse_agent_target_refs(target_str)
 
+            # Parse strictly: a bare `... or 1` silently turned a real 0 / "0" into 1
+            # instead of surfacing the invalid count; mirror edit_pipeline and reject
+            # sub-1 values (Pipeline.ab_num_variants is Field ge=1) (#1115 cycle-review).
+            ab_num_variants = arg_int(args, "ab_num_variants", 1)
+            if ab_num_variants is None or ab_num_variants < 1:
+                return _text_response("Ошибка: ab_num_variants должен быть >= 1.")
+
             svc = ctx.pipeline_service()
             pipeline_id = await svc.add(
                 name=name,
@@ -60,7 +67,7 @@ def register_pipeline_write_tools(db: Any, ctx: Any) -> list[Any]:
                 target_refs=target_refs,
                 llm_model=args.get("llm_model"),
                 publish_mode=args.get("publish_mode", "moderated"),
-                ab_num_variants=int(args.get("ab_num_variants") or 1),
+                ab_num_variants=ab_num_variants,
                 # bool("false") is True — coerce so a JSON-string disables A/B
                 # auto-select instead of silently enabling it (#1115).
                 ab_auto_select=arg_bool(args, "ab_auto_select", False),

--- a/src/agent/tools/search_queries.py
+++ b/src/agent/tools/search_queries.py
@@ -8,7 +8,7 @@ from claude_agent_sdk import tool
 from mcp.types import ToolAnnotations
 
 from src.agent.tools._categories import ToolCategory, ToolMeta
-from src.agent.tools._registry import _text_response, require_confirmation
+from src.agent.tools._registry import _text_response, arg_bool, is_affirmative, require_confirmation
 
 # Permission metadata for this module's tools (#245). Single source of
 # truth: permissions.py derives TOOL_CATEGORIES / MODULE_GROUPS /
@@ -45,7 +45,7 @@ def register(db, client_pool, embedding_service, **kwargs):
             from src.services.search_query_service import SearchQueryService
 
             svc = SearchQueryService(db)
-            active_only = bool(args.get("active_only", False))
+            active_only = arg_bool(args, "active_only", False)
             queries = await svc.list(active_only=active_only)
             if not queries:
                 return _text_response("Поисковые запросы не найдены.")
@@ -140,10 +140,12 @@ def register(db, client_pool, embedding_service, **kwargs):
 
             svc = SearchQueryService(db)
             interval = int(args.get("interval_minutes", 60))
-            is_regex = bool(args.get("is_regex", False))
-            is_fts = bool(args.get("is_fts", False))
-            notify = bool(args.get("notify_on_collect", False))
-            track_stats = bool(args.get("track_stats", True))
+            # bool("false") is True — coerce bool flags via is_affirmative so a model
+            # emitting JSON-string "false" disables instead of enabling them (#1115).
+            is_regex = arg_bool(args, "is_regex", False)
+            is_fts = arg_bool(args, "is_fts", False)
+            notify = arg_bool(args, "notify_on_collect", False)
+            track_stats = arg_bool(args, "track_stats", True)
             exclude_patterns = args.get("exclude_patterns", "")
             max_length = args.get("max_length")
             chat_filter = args.get("chat_filter", args.get("chats", ""))
@@ -201,10 +203,20 @@ def register(db, client_pool, embedding_service, **kwargs):
                 return _text_response(f"Поисковый запрос id={sq_id} не найден.")
             query = args.get("query", existing.query)
             interval = int(args.get("interval_minutes", existing.interval_minutes))
-            is_regex = bool(args.get("is_regex", existing.is_regex))
-            is_fts = bool(args.get("is_fts", existing.is_fts))
-            notify = bool(args.get("notify_on_collect", existing.notify_on_collect))
-            track_stats = bool(args.get("track_stats", getattr(existing, "track_stats", True)))
+            # Only coerce when the flag is supplied; an absent flag keeps the existing
+            # value. is_affirmative maps the JSON-string "false" to False (#1115).
+            is_regex = is_affirmative(args["is_regex"]) if args.get("is_regex") is not None else existing.is_regex
+            is_fts = is_affirmative(args["is_fts"]) if args.get("is_fts") is not None else existing.is_fts
+            notify = (
+                is_affirmative(args["notify_on_collect"])
+                if args.get("notify_on_collect") is not None
+                else existing.notify_on_collect
+            )
+            track_stats = (
+                is_affirmative(args["track_stats"])
+                if args.get("track_stats") is not None
+                else getattr(existing, "track_stats", True)
+            )
             exclude_patterns = args.get("exclude_patterns", getattr(existing, "exclude_patterns", ""))
             max_length_raw = args.get("max_length", getattr(existing, "max_length", None))
             chat_filter = args.get("chat_filter", args.get("chats", getattr(existing, "chat_filter", "")))

--- a/tests/test_regression_bool_args_1115.py
+++ b/tests/test_regression_bool_args_1115.py
@@ -201,6 +201,73 @@ async def test_update_auto_upload_string_false_deactivates(db):
     assert job.is_active is False
 
 
+async def _seed_auto_job(db) -> int:
+    return await db.repos.photo_loader.create_auto_job(
+        PhotoAutoUploadJob(
+            phone="+79001234567",
+            target_dialog_id=1,
+            folder_path="/tmp",
+            send_mode=PhotoSendMode("album"),
+            caption=None,
+            interval_minutes=60,
+            is_active=True,
+        )
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("bad_interval", ["abc", 0, -5, "0", "-3"])
+async def test_update_auto_upload_invalid_interval_rejected(db, bad_interval):
+    """A non-numeric or sub-1 interval must be rejected with a safe tool error.
+
+    Writing 0/-5 would violate PhotoAutoUploadJob.interval_minutes (Field ge=1) and
+    poison every later get/list_auto_jobs read; a non-numeric value must surface a
+    friendly error, not an unhandled ValueError escaping the handler (#1115 review).
+    """
+    job_id = await _seed_auto_job(db)
+    handlers = _get_tool_handlers(db, client_pool=MagicMock())
+
+    result = await handlers["update_auto_upload"](
+        {"job_id": job_id, "interval_minutes": bad_interval, "confirm": "true"}
+    )
+
+    text = _text(result)
+    assert "Ошибка" in text
+    # The job must remain readable with its original, valid interval — not poisoned.
+    job = await db.repos.photo_loader.get_auto_job(job_id)
+    assert job.interval_minutes == 60
+
+
+@pytest.mark.anyio
+async def test_update_auto_upload_empty_interval_leaves_unchanged(db):
+    """An empty-string interval means "not supplied" → the interval stays unchanged."""
+    job_id = await _seed_auto_job(db)
+    handlers = _get_tool_handlers(db, client_pool=MagicMock())
+
+    result = await handlers["update_auto_upload"](
+        {"job_id": job_id, "interval_minutes": "", "confirm": "true"}
+    )
+
+    assert "обновлена" in _text(result)
+    job = await db.repos.photo_loader.get_auto_job(job_id)
+    assert job.interval_minutes == 60
+
+
+@pytest.mark.anyio
+async def test_update_auto_upload_valid_string_interval_persists(db):
+    """A valid numeric string interval must still be coerced and persisted."""
+    job_id = await _seed_auto_job(db)
+    handlers = _get_tool_handlers(db, client_pool=MagicMock())
+
+    result = await handlers["update_auto_upload"](
+        {"job_id": job_id, "interval_minutes": "30", "confirm": "true"}
+    )
+
+    assert "обновлена" in _text(result)
+    job = await db.repos.photo_loader.get_auto_job(job_id)
+    assert job.interval_minutes == 30
+
+
 # ---------------------------------------------------------------------------
 # add_search_query: is_regex="false" must NOT enable regex mode.
 # ---------------------------------------------------------------------------
@@ -252,3 +319,35 @@ async def test_collect_channel_string_false_force_respects_filter(db):
     result = await handlers["collect_channel"]({"pk": ch.id, "force": "false"})
     # force="false" must be respected → the filtered guard fires.
     assert "отфильтрован" in _text(result)
+
+
+# ---------------------------------------------------------------------------
+# add_pipeline: ab_num_variants=0 must be rejected, not silently coerced to 1.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("bad_variants", [0, "0", -2])
+async def test_add_pipeline_invalid_ab_num_variants_rejected(mock_db, bad_variants):
+    """A sub-1 ab_num_variants must surface an error instead of `... or 1` → 1.
+
+    Pipeline.ab_num_variants is Field ge=1; silently turning a real 0 into 1 hides
+    an invalid request (#1115 review).
+    """
+    from unittest.mock import patch
+
+    handlers = _get_tool_handlers(mock_db)
+    with patch("src.services.pipeline_service.PipelineService") as mock_svc:
+        mock_svc.return_value.add = AsyncMock(return_value=10)
+        result = await handlers["add_pipeline"](
+            {
+                "confirm": "true",
+                "name": "P",
+                "prompt_template": "t",
+                "source_channel_ids": "1",
+                "target_refs": "+7123456|789",
+                "ab_num_variants": bad_variants,
+            }
+        )
+
+    assert "ab_num_variants" in _text(result)

--- a/tests/test_regression_bool_args_1115.py
+++ b/tests/test_regression_bool_args_1115.py
@@ -1,0 +1,254 @@
+"""Regression: agent-tool bool args arrive as JSON strings (#1115).
+
+LLM backends routinely serialize a boolean tool argument as the JSON *string*
+``"false"`` / ``"true"`` instead of a real bool. A handler that reads such a flag
+with a bare ``args.get("flag")`` — or ``bool(args.get("flag"))`` — silently breaks,
+because ``bool("false") is True``: every non-empty string is truthy. The flag then
+reaches the service with the *wrong* (often opposite) meaning, even though the
+service itself is correct. These tests drive the tools exactly as the LLM does
+(handler called with a JSON-arg dict) and assert the real bool that reaches the
+backend.
+
+The shared fix is :func:`src.agent.tools._registry.arg_bool` /
+:func:`is_affirmative`, which already exists for precisely this case (audit
+#837): it maps the strings ``"false"``/``"0"``/``"no"`` to ``False``.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.models import Account, PhotoAutoUploadJob, PhotoSendMode
+from tests.agent_tools_helpers import _get_tool_handlers, _text
+
+
+def _make_account(phone: str = "+79001234567") -> MagicMock:
+    acc = MagicMock(spec=Account)
+    acc.id = 1
+    acc.phone = phone
+    acc.is_active = True
+    acc.is_primary = True
+    acc.session_string = "fake"
+    return acc
+
+
+def _make_mock_pool() -> tuple[MagicMock, AsyncMock]:
+    mock_client = AsyncMock()
+    mock_client.get_entity = AsyncMock(return_value=MagicMock(id=123456))
+    mock_client.edit_admin = AsyncMock()
+    mock_client.edit_permissions = AsyncMock()
+    mock_client.pin_message = AsyncMock()
+
+    mock_session = MagicMock()
+    mock_pool = MagicMock()
+    mock_pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, None))
+    mock_pool.get_client_by_phone = AsyncMock(return_value=(mock_session, None))
+    mock_pool.resolve_dialog_entity = AsyncMock(return_value=MagicMock(id=123456))
+    return mock_pool, mock_client
+
+
+# ---------------------------------------------------------------------------
+# edit_admin: is_admin="false" must DEMOTE, not promote.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_edit_admin_string_false_demotes(mock_db):
+    """is_admin="false" (LLM JSON string) must reach Telethon as is_admin=False."""
+    mock_pool, mock_client = _make_mock_pool()
+    mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+    handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+
+    result = await handlers["edit_admin"](
+        {
+            "phone": "+79001234567",
+            "chat_id": "chat",
+            "user_id": "111",
+            "is_admin": "false",
+            "confirm": "true",
+        }
+    )
+
+    assert "обновлены" in _text(result)
+    mock_client.edit_admin.assert_awaited_once()
+    # The actual privilege flag that hit Telethon.
+    assert mock_client.edit_admin.await_args.kwargs.get("is_admin") is False
+
+
+@pytest.mark.anyio
+async def test_edit_admin_string_false_confirmation_says_demote(mock_db):
+    """The confirmation prompt must describe a demotion, not a promotion."""
+    mock_pool, _ = _make_mock_pool()
+    mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+    handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+
+    # No confirm → gate text is returned; it must reflect the real action.
+    result = await handlers["edit_admin"](
+        {"phone": "+79001234567", "chat_id": "chat", "user_id": "111", "is_admin": "false"}
+    )
+    text = _text(result)
+    assert "понизит" in text
+    assert "повысит" not in text
+
+
+# ---------------------------------------------------------------------------
+# edit_permissions: send_messages="false" must RESTRICT, not allow.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_edit_permissions_string_false_restricts(mock_db):
+    """send_messages="false" must reach Telethon as the bool False (a restriction)."""
+    mock_pool, mock_client = _make_mock_pool()
+    mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+    handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+
+    result = await handlers["edit_permissions"](
+        {
+            "phone": "+79001234567",
+            "chat_id": "chat",
+            "user_id": "111",
+            "send_messages": "false",
+            "confirm": "true",
+        }
+    )
+
+    assert "обновлены" in _text(result)
+    mock_client.edit_permissions.assert_awaited_once()
+    assert mock_client.edit_permissions.await_args.kwargs.get("send_messages") is False
+
+
+@pytest.mark.anyio
+async def test_edit_permissions_omitted_flag_stays_none(mock_db):
+    """An omitted flag must NOT be coerced to False — it stays None (three-state)."""
+    mock_pool, mock_client = _make_mock_pool()
+    mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+    handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+
+    result = await handlers["edit_permissions"](
+        {
+            "phone": "+79001234567",
+            "chat_id": "chat",
+            "user_id": "111",
+            "send_media": "true",
+            "confirm": "true",
+        }
+    )
+
+    assert "обновлены" in _text(result)
+    kwargs = mock_client.edit_permissions.await_args.kwargs
+    # send_messages was not passed → must not appear (service drops None flags).
+    assert "send_messages" not in kwargs
+    assert kwargs.get("send_media") is True
+
+
+# ---------------------------------------------------------------------------
+# pin_message: notify="false" must pin silently.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_pin_message_string_false_notify_is_silent(mock_db):
+    """notify="false" must reach Telethon as notify=False (no member ping)."""
+    mock_pool, mock_client = _make_mock_pool()
+    mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+    handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+
+    result = await handlers["pin_message"](
+        {
+            "phone": "+79001234567",
+            "chat_id": "chat",
+            "message_id": 10,
+            "notify": "false",
+            "confirm": "true",
+        }
+    )
+
+    assert "закреплено" in _text(result)
+    mock_client.pin_message.assert_awaited_once()
+    assert mock_client.pin_message.await_args.kwargs.get("notify") is False
+
+
+# ---------------------------------------------------------------------------
+# update_auto_upload: is_active="false" must DEACTIVATE the job.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_update_auto_upload_string_false_deactivates(db):
+    """is_active="false" must persist is_active=False, not leave the job active."""
+    pool = MagicMock()
+    job_id = await db.repos.photo_loader.create_auto_job(
+        PhotoAutoUploadJob(
+            phone="+79001234567",
+            target_dialog_id=1,
+            folder_path="/tmp",
+            send_mode=PhotoSendMode("album"),
+            caption=None,
+            interval_minutes=60,
+            is_active=True,
+        )
+    )
+    handlers = _get_tool_handlers(db, client_pool=pool)
+
+    result = await handlers["update_auto_upload"](
+        {"job_id": job_id, "is_active": "false", "confirm": "true"}
+    )
+
+    assert "обновлена" in _text(result)
+    job = await db.repos.photo_loader.get_auto_job(job_id)
+    assert job.is_active is False
+
+
+# ---------------------------------------------------------------------------
+# add_search_query: is_regex="false" must NOT enable regex mode.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_add_search_query_string_false_flags_disabled(db):
+    """is_regex/is_fts/notify_on_collect="false" must persist as False, not True."""
+    handlers = _get_tool_handlers(db, client_pool=None)
+
+    result = await handlers["add_search_query"](
+        {
+            "query": "needle",
+            "is_regex": "false",
+            "is_fts": "false",
+            "notify_on_collect": "false",
+            "confirm": "true",
+        }
+    )
+    assert "создан" in _text(result)
+
+    from src.services.search_query_service import SearchQueryService
+
+    queries = await SearchQueryService(db).list()
+    assert len(queries) == 1
+    sq = queries[0]
+    assert sq.is_regex is False
+    assert sq.is_fts is False
+    assert sq.notify_on_collect is False
+
+
+# ---------------------------------------------------------------------------
+# collect_channel: force="false" must NOT force-collect a filtered channel.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_collect_channel_string_false_force_respects_filter(db):
+    """force="false" must keep the filtered-channel guard active."""
+    from src.models import Channel
+
+    await db.add_channel(Channel(channel_id=2002, title="Filtered", username="filtered"))
+    ch = (await db.get_channels(include_filtered=True))[0]
+    await db.set_channel_filtered(ch.id, True)
+
+    pool = MagicMock()
+    handlers = _get_tool_handlers(db, client_pool=pool)
+
+    result = await handlers["collect_channel"]({"pk": ch.id, "force": "false"})
+    # force="false" must be respected → the filtered guard fires.
+    assert "отфильтрован" in _text(result)


### PR DESCRIPTION
Closes #1115

LLM backends serialize a boolean tool argument as the JSON string "false"/"true". Several agent-tool handlers read it with a bare args.get() or bool(args.get()), but bool("false") is True, so the flag reached the service with the opposite meaning even though the service is correct.

Found by driving handlers exactly as the LLM does (JSON-arg dict via the registry): edit_admin(is_admin="false") promoted instead of demoting (admin rights); edit_permissions(send_messages="false") allowed instead of restricting; pin_message(notify="false") pinged all members; update_auto_upload(is_active="false") left job active; run_photo_due(dry_run="false") stayed preview-only; collect_channel(force="false") force-collected a filtered channel; add/edit_search_query and add/edit_pipeline bool flags enabled features. int args are saved by SQLite affinity; bool is not.

Fix: route flags through existing arg_bool/is_affirmative (audit #837). Three-state flags only coerce when supplied. update_auto_upload also int-coerces interval_minutes.

tests/test_regression_bool_args_1115.py: 8 guards calling handlers with JSON-string bools; each red-before (mutation-verified), green-after. pytest -n auto over affected area: 3030 passed. ruff clean; mypy 0 new errors.

Scope per #1115: agent-tool path != service gap; both claude-agent-sdk and deepagents share these handlers.

Generated with Claude Code.