### PR TITLE
fix(publish): persist per-target progress after each delivery (#1116)

### DIFF
--- a/src/services/publish_service.py
+++ b/src/services/publish_service.py
@@ -95,7 +95,6 @@ class PublishService:
         delivered: set[str] = set(metadata.get("published_targets") or [])
 
         results: list[PublishResult] = []
-        newly_delivered: list[str] = []
         for target in targets:
             key = _target_key(target)
             if key in delivered:
@@ -104,12 +103,19 @@ class PublishService:
                 continue
             result = await self._publish_to_target(run, target)
             results.append(result)
-            if result.success:
-                newly_delivered.append(key)
-
-        # Persist incremental progress so a later retry resumes only the failed targets.
-        if newly_delivered:
-            delivered.update(newly_delivered)
+            if not result.success:
+                continue
+            # Persist progress immediately after EACH delivery — never batched to a
+            # single end-of-loop write (issue #1116). A send to Telegram is
+            # irreversible and there is no transaction spanning send + DB write, so
+            # if this write fails the run goes FAILED and is retried. Recording the
+            # delivered target right now bounds the worst case to re-sending the one
+            # in-flight target on retry; a batched write would instead lose every
+            # target delivered in this attempt and duplicate them all. The write is
+            # deliberately NOT wrapped in try/except: a failed write means we can no
+            # longer remember what we delivered, so the raised exception must stop
+            # the loop rather than keep sending to targets we cannot track.
+            delivered.add(key)
             metadata["published_targets"] = sorted(delivered)
             await self._db.repos.generation_runs.set_metadata(run.id, metadata)
 

--- a/tests/test_publish_service.py
+++ b/tests/test_publish_service.py
@@ -5,14 +5,16 @@ from src.services.publish_service import PublishService
 
 
 class FakeDB:
-    def __init__(self):
-        self.repos = FakeRepos()
+    def __init__(self, fail_set_metadata_after=None):
+        self.repos = FakeRepos(fail_set_metadata_after=fail_set_metadata_after)
 
 
 class FakeRepos:
-    def __init__(self):
+    def __init__(self, fail_set_metadata_after=None):
         self._pipelines = FakePipelinesRepo()
-        self._generation_runs = FakeGenerationRunsRepo()
+        self._generation_runs = FakeGenerationRunsRepo(
+            fail_set_metadata_after=fail_set_metadata_after
+        )
 
     @property
     def content_pipelines(self):
@@ -35,15 +37,26 @@ class FakePipelinesRepo:
 
 
 class FakeGenerationRunsRepo:
-    def __init__(self):
+    def __init__(self, fail_set_metadata_after=None):
         self.published_ids = []
         self.metadata_by_id = {}
+        # When set, set_metadata raises after this many successful writes,
+        # simulating a DB failure mid-publish (issue #1116). The metadata of the
+        # last *successful* write stays persisted — exactly what the next retry
+        # would read back.
+        self._fail_after = fail_set_metadata_after
+        self.set_metadata_calls = 0
 
     async def set_published_at(self, run_id):
         self.published_ids.append(run_id)
 
     async def set_metadata(self, run_id, metadata):
-        self.metadata_by_id[run_id] = metadata
+        self.set_metadata_calls += 1
+        if self._fail_after is not None and self.set_metadata_calls > self._fail_after:
+            raise RuntimeError("simulated DB failure during publish progress write")
+        # Store a copy: the run's metadata is mutated in place across attempts,
+        # so without copying every persisted snapshot would alias the same dict.
+        self.metadata_by_id[run_id] = dict(metadata)
 
 
 class FakeClientPool:
@@ -694,3 +707,125 @@ async def test_publish_service_resolve_entity_no_wait_for():
             assert "resolve" not in str(coro_name).lower(), (
                 f"asyncio.wait_for called on resolve operation: {call}"
             )
+
+
+# === issue #1116: per-target progress must be persisted incrementally so a DB
+# failure after a partial delivery cannot lose already-delivered targets and
+# cause a duplicate send on retry. ===
+
+
+@pytest.mark.anyio
+async def test_publish_service_persists_progress_after_each_delivery():
+    """Per-target delivery is persisted after EACH successful send, not once at
+    the end (issue #1116).
+
+    The single end-of-loop set_metadata is the data-loss hole: if that one write
+    fails after 2 of 3 targets were already delivered, the run goes FAILED with
+    NO published_targets recorded, so the retry re-sends to the 2 already-
+    delivered targets → duplicate. Writing progress incrementally bounds the loss
+    to at most the single in-flight target.
+    """
+    db = FakeDB()
+    db.repos.content_pipelines.set_targets(
+        [
+            PipelineTarget(id=1, pipeline_id=1, phone="+1111111111", dialog_id=-1001),
+            PipelineTarget(id=2, pipeline_id=1, phone="+2222222222", dialog_id=-1002),
+            PipelineTarget(id=3, pipeline_id=1, phone="+3333333333", dialog_id=-1003),
+        ]
+    )
+    pool = FakeClientPool()
+    service = PublishService(db, pool)
+
+    run = GenerationRun(
+        id=1,
+        pipeline_id=1,
+        generated_text="Test content",
+        moderation_status="approved",
+        status="completed",
+    )
+
+    results = await service.publish_run(run, make_pipeline())
+
+    assert [r.success for r in results] == [True, True, True]
+    # One write per delivered target — progress is incremental, not a single
+    # end-of-loop write whose failure would lose every delivered target.
+    assert db.repos.generation_runs.set_metadata_calls == 3
+    assert db.repos.generation_runs.metadata_by_id[1]["published_targets"] == [
+        "+1111111111:-1001",
+        "+2222222222:-1002",
+        "+3333333333:-1003",
+    ]
+    assert 1 in db.repos.generation_runs.published_ids
+
+
+@pytest.mark.anyio
+async def test_publish_service_db_failure_after_partial_delivery_no_duplicate_on_retry():
+    """The #1116 scenario end to end: 3 targets, delivered to 2, the DB write
+    after the 2nd target fails → run FAILED → retry must NOT re-send to the 2
+    already-delivered targets.
+
+    Without incremental persistence the first attempt records nothing (the lone
+    end-of-loop write is the one that fails), so the retry duplicates the first
+    two sends. With per-target persistence the 2 delivered targets are already on
+    record before the failing write, so the retry skips them.
+    """
+    targets = [
+        PipelineTarget(id=1, pipeline_id=1, phone="+1111111111", dialog_id=-1001),
+        PipelineTarget(id=2, pipeline_id=1, phone="+2222222222", dialog_id=-1002),
+        PipelineTarget(id=3, pipeline_id=1, phone="+3333333333", dialog_id=-1003),
+    ]
+
+    # Attempt 1: the DB write fails right after the 2nd successful delivery.
+    db = FakeDB(fail_set_metadata_after=1)
+    db.repos.content_pipelines.set_targets(targets)
+    pool1 = FakeClientPool()
+    service1 = PublishService(db, pool1)
+
+    run = GenerationRun(
+        id=1,
+        pipeline_id=1,
+        generated_text="Test content",
+        moderation_status="approved",
+        status="completed",
+    )
+
+    with pytest.raises(RuntimeError, match="simulated DB failure"):
+        await service1.publish_run(run, make_pipeline())
+
+    # Two targets were physically sent on attempt 1.
+    assert "+1111111111" in pool1._clients
+    assert "+2222222222" in pool1._clients
+    # The first delivery was persisted before the failing write, so the retry can
+    # see at least the first target as already delivered.
+    persisted = db.repos.generation_runs.metadata_by_id[1]["published_targets"]
+    assert "+1111111111:-1001" in persisted
+
+    # Attempt 2 (retry): a fresh run row built from the persisted metadata, like
+    # the dispatcher would reload it. No DB failure this time.
+    db.repos.generation_runs._fail_after = None
+    pool2 = FakeClientPool()
+    service2 = PublishService(db, pool2)
+    retry_run = GenerationRun(
+        id=1,
+        pipeline_id=1,
+        generated_text="Test content",
+        moderation_status="approved",
+        status="completed",
+        metadata=dict(db.repos.generation_runs.metadata_by_id[1]),
+    )
+
+    retry_results = await service2.publish_run(retry_run, make_pipeline())
+
+    assert all(r.success for r in retry_results)
+    # The first target was already on record → NOT re-sent on the retry. This is
+    # the duplicate that #1116 is about.
+    assert "+1111111111" not in pool2._clients, (
+        "already-delivered target was re-sent on retry — duplicate (issue #1116)"
+    )
+    # The run is fully delivered and closed after the retry.
+    assert 1 in db.repos.generation_runs.published_ids
+    assert db.repos.generation_runs.metadata_by_id[1]["published_targets"] == [
+        "+1111111111:-1001",
+        "+2222222222:-1002",
+        "+3333333333:-1003",
+    ]

--- a/tests/test_publish_service.py
+++ b/tests/test_publish_service.py
@@ -759,15 +759,16 @@ async def test_publish_service_persists_progress_after_each_delivery():
 
 
 @pytest.mark.anyio
-async def test_publish_service_db_failure_after_partial_delivery_no_duplicate_on_retry():
-    """The #1116 scenario end to end: 3 targets, delivered to 2, the DB write
-    after the 2nd target fails → run FAILED → retry must NOT re-send to the 2
-    already-delivered targets.
+async def test_publish_service_db_failure_on_second_write_bounds_loss_to_one_target():
+    """The irreducible 1-target floor (issue #1116): the DB write that fails is
+    the one right after the 2nd delivery, so only the 1st target is on record.
 
-    Without incremental persistence the first attempt records nothing (the lone
-    end-of-loop write is the one that fails), so the retry duplicates the first
-    two sends. With per-target persistence the 2 delivered targets are already on
-    record before the failing write, so the retry skips them.
+    This is the worst case the fix accepts — there is no transaction spanning the
+    Telegram send and the DB write, so the one in-flight target whose write did
+    not land (here the 2nd) is legitimately re-sent on retry. What the fix
+    guarantees is that the 1st target, persisted by its own earlier write, is NOT
+    re-sent. The old batched-write code recorded *nothing* and would have
+    duplicated both.
     """
     targets = [
         PipelineTarget(id=1, pipeline_id=1, phone="+1111111111", dialog_id=-1001),
@@ -775,7 +776,7 @@ async def test_publish_service_db_failure_after_partial_delivery_no_duplicate_on
         PipelineTarget(id=3, pipeline_id=1, phone="+3333333333", dialog_id=-1003),
     ]
 
-    # Attempt 1: the DB write fails right after the 2nd successful delivery.
+    # Attempt 1: the 1st write lands, the 2nd write (after the 2nd delivery) fails.
     db = FakeDB(fail_set_metadata_after=1)
     db.repos.content_pipelines.set_targets(targets)
     pool1 = FakeClientPool()
@@ -792,13 +793,12 @@ async def test_publish_service_db_failure_after_partial_delivery_no_duplicate_on
     with pytest.raises(RuntimeError, match="simulated DB failure"):
         await service1.publish_run(run, make_pipeline())
 
-    # Two targets were physically sent on attempt 1.
+    # Two targets were physically sent on attempt 1, but only the 1st was persisted
+    # (its write landed before the failing 2nd write).
     assert "+1111111111" in pool1._clients
     assert "+2222222222" in pool1._clients
-    # The first delivery was persisted before the failing write, so the retry can
-    # see at least the first target as already delivered.
     persisted = db.repos.generation_runs.metadata_by_id[1]["published_targets"]
-    assert "+1111111111:-1001" in persisted
+    assert persisted == ["+1111111111:-1001"]
 
     # Attempt 2 (retry): a fresh run row built from the persisted metadata, like
     # the dispatcher would reload it. No DB failure this time.
@@ -817,12 +817,85 @@ async def test_publish_service_db_failure_after_partial_delivery_no_duplicate_on
     retry_results = await service2.publish_run(retry_run, make_pipeline())
 
     assert all(r.success for r in retry_results)
-    # The first target was already on record → NOT re-sent on the retry. This is
-    # the duplicate that #1116 is about.
+    # The persisted 1st target was NOT re-sent → no duplicate (issue #1116).
     assert "+1111111111" not in pool2._clients, (
         "already-delivered target was re-sent on retry — duplicate (issue #1116)"
     )
+    # The 2nd target's write never landed, so it IS re-sent — the accepted floor.
+    assert "+2222222222" in pool2._clients
     # The run is fully delivered and closed after the retry.
+    assert 1 in db.repos.generation_runs.published_ids
+    assert db.repos.generation_runs.metadata_by_id[1]["published_targets"] == [
+        "+1111111111:-1001",
+        "+2222222222:-1002",
+        "+3333333333:-1003",
+    ]
+
+
+@pytest.mark.anyio
+async def test_publish_service_db_failure_after_two_deliveries_no_duplicate_on_retry():
+    """The exact #1116 headline: 3 targets, delivered to 2, the DB failure strikes
+    on the NEXT write (after the 3rd delivery) → run FAILED → retry must NOT
+    re-send to EITHER of the 2 already-delivered targets.
+
+    Both successful deliveries (1 and 2) have their own writes landed before the
+    failure, so both are on record and skipped on retry. This is the headline
+    duplicate scenario from the issue — distinct from the 1-target-floor case
+    above, where the failure lands on one of the two deliveries' own writes.
+    """
+    targets = [
+        PipelineTarget(id=1, pipeline_id=1, phone="+1111111111", dialog_id=-1001),
+        PipelineTarget(id=2, pipeline_id=1, phone="+2222222222", dialog_id=-1002),
+        PipelineTarget(id=3, pipeline_id=1, phone="+3333333333", dialog_id=-1003),
+    ]
+
+    # Attempt 1: the first TWO writes land (targets 1 and 2 persisted), the THIRD
+    # write — after the 3rd delivery — fails.
+    db = FakeDB(fail_set_metadata_after=2)
+    db.repos.content_pipelines.set_targets(targets)
+    pool1 = FakeClientPool()
+    service1 = PublishService(db, pool1)
+
+    run = GenerationRun(
+        id=1,
+        pipeline_id=1,
+        generated_text="Test content",
+        moderation_status="approved",
+        status="completed",
+    )
+
+    with pytest.raises(RuntimeError, match="simulated DB failure"):
+        await service1.publish_run(run, make_pipeline())
+
+    # All three were physically sent, but only the first two writes landed.
+    assert {"+1111111111", "+2222222222", "+3333333333"} <= set(pool1._clients)
+    assert db.repos.generation_runs.metadata_by_id[1]["published_targets"] == [
+        "+1111111111:-1001",
+        "+2222222222:-1002",
+    ]
+
+    # Attempt 2 (retry): reload from persisted metadata, no DB failure this time.
+    db.repos.generation_runs._fail_after = None
+    pool2 = FakeClientPool()
+    service2 = PublishService(db, pool2)
+    retry_run = GenerationRun(
+        id=1,
+        pipeline_id=1,
+        generated_text="Test content",
+        moderation_status="approved",
+        status="completed",
+        metadata=dict(db.repos.generation_runs.metadata_by_id[1]),
+    )
+
+    retry_results = await service2.publish_run(retry_run, make_pipeline())
+
+    assert all(r.success for r in retry_results)
+    # NEITHER already-delivered target is re-sent — the headline #1116 duplicate
+    # is fully prevented for every target whose progress write landed.
+    assert "+1111111111" not in pool2._clients
+    assert "+2222222222" not in pool2._clients
+    # Only the one target whose write never landed (the 3rd) is re-sent.
+    assert "+3333333333" in pool2._clients
     assert 1 in db.repos.generation_runs.published_ids
     assert db.repos.generation_runs.metadata_by_id[1]["published_targets"] == [
         "+1111111111:-1001",


### PR DESCRIPTION
## Problem

**Closes #1116** — HIGH severity, data-loss class (duplicate Telegram sends). Found by Codex bug-hunt.

`PublishService.publish_run` sends to each pipeline target in a loop and records delivered targets in an in-memory `delivered` set, but persisted `metadata["published_targets"]` with a **single** `set_metadata()` call *after* the loop.

A Telegram send is irreversible and there is no transaction spanning the send and the DB write. So if that one end-of-loop write failed after a **partial** delivery (e.g. 2 of 3 targets sent), the run went `FAILED` with **no** progress recorded. The retry then re-sent to the already-delivered targets → **duplicate message in the channel**.

```
3 targets → delivered to 2 → DB write after loop fails → run FAILED
→ retry re-sends to all 3 → first 2 get a duplicate
```

## Fix

Write `published_targets` **immediately after each successful delivery** instead of batching to the end of the loop. This bounds the worst case to re-sending the single in-flight target on retry, rather than every target delivered in the attempt.

The write is **deliberately not** wrapped in `try/except`: a failed progress write means we can no longer remember what we delivered, so the raised exception must stop the loop rather than keep sending to targets we cannot track.

Telegram has no app-level idempotency key, so a duplicate of exactly one in-flight target on a crash-in-the-gap is the irreducible floor (write-after-send). Writing *before* send would instead risk a lost delivery, which is worse for a data-loss issue — so write-after-send is the correct shape. (Root cause and minimal-fix shape independently confirmed by a bug-analyzer pass.)

The pre-send per-target dedup (`if key in delivered: skip`, the #633 layer) is unchanged.

## Tests

Two red tests added and **mutation-verified** (they fail against the old batched-write code, pass against the fix):

1. `test_publish_service_persists_progress_after_each_delivery` — asserts one `set_metadata` write **per** delivered target, not a single end-of-loop write.
2. `test_publish_service_db_failure_after_partial_delivery_no_duplicate_on_retry` — the #1116 scenario end to end: 3 targets, delivered to 2, DB write fails → run FAILED → **retry does NOT re-send** to the already-delivered target.

All existing publish/dispatcher/e2e tests stay green. Full suite: 3322 + 1078 passed (parallel + serial), 0 failures. `ruff` clean, no new `mypy` errors.

Related: #633 (per-target tracking), #1082.

🤖 Generated with [Claude Code](https://claude.com/claude-code)