### PR TITLE
docs: document public-API facade, lift doc-coverage 27% → 40.6% (#1134)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,12 +207,17 @@ exclude_lines = [
 exclude_dirs = ["tests"]
 
 # Doc-coverage (interrogate, #1072). scripts/doc_coverage.py and the advisory
-# CI step read this. `fail_under` is a SOFT baseline — the project is at ~24%
-# today; 23 is a ratchet floor that surfaces regressions without forcing a
-# docstring-everything sprint. Raise it as coverage climbs. interrogate ignores
-# things that don't need a docstring (magic/init/nested/private, overloads).
+# CI step read this. `fail_under` is a SOFT baseline — a ratchet floor that
+# surfaces regressions without forcing a docstring-everything sprint. Raise it
+# as coverage climbs. interrogate ignores things that don't need a docstring
+# (magic/init/nested/private, overloads).
+# Ratchet history: 23 (#1072 floor) → 35 (#1134: documented the public-API
+# facade — src/models.py Pydantic models, db.repos bundles, repository CRUD —
+# lifting coverage 27% → 40.6%; floor set to 35 to lock in the win with a
+# margin below the measured 40.6% so a stray docstring loss doesn't trip the
+# gate). Doc-coverage is NOT a CI gate (#1097) — stays a local script.
 [tool.interrogate]
-fail_under = 23
+fail_under = 35
 ignore_init_method = true
 ignore_init_module = true
 ignore_magic = true

--- a/src/config.py
+++ b/src/config.py
@@ -1,3 +1,11 @@
+"""Конфигурация приложения: Pydantic-модели секций + загрузчик из YAML.
+
+[`AppConfig`][src.config.AppConfig] — корень дерева настроек; каждая вложенная
+секция — отдельная `*Config`-модель с дефолтами, так что приложение запускается
+и без `config.yaml`. `load_config` читает YAML, подставляет `${ENV_VAR}` и
+добирает критичные значения (Telegram-креды, agent-модель) прямо из окружения.
+"""
+
 from __future__ import annotations
 
 import logging
@@ -12,17 +20,37 @@ logger = logging.getLogger(__name__)
 
 
 class TelegramConfig(BaseModel):
+    """Учётные данные приложения Telegram (`api_id`/`api_hash`) для MTProto.
+
+    Дефолты-пустышки заполняются из `TG_API_ID`/`TG_API_HASH`, если в YAML их нет.
+    """
+
     api_id: int = 0
     api_hash: str = ""
 
 
 class WebConfig(BaseModel):
+    """Настройки веб-панели: адрес/порт прослушивания и пароль входа.
+
+    Вход — по паролю; имя пользователя задаётся переменной `WEB_USER`
+    (по умолчанию `admin`), а не захардкожено — см. `src/web/panel_auth.py`.
+    """
+
     host: str = "0.0.0.0"
     port: int = 8080
     password: str = ""
 
 
 class SchedulerConfig(BaseModel):
+    """Параметры планировщика сбора: периодичность, задержки и таймауты.
+
+    Управляет интервалом периодического сбора и паузами между каналами/запросами
+    (троттлинг против FLOOD_WAIT), таймаутами потокового сбора и фоновых задач, а
+    также числом параллельных воркеров сбора/статистики (0 = авто — по одному на
+    подключённый аккаунт). Семантика «0/отрицательное» у таймаутов разнится —
+    см. комментарии у полей.
+    """
+
     collect_interval_minutes: int = 60
     delay_between_channels_sec: int = 2
     delay_between_requests_sec: int = 1
@@ -47,12 +75,25 @@ class SchedulerConfig(BaseModel):
 
 
 class NotificationsConfig(BaseModel):
+    """Настройки уведомлений: чат администратора для алертов (`admin_chat_id`) и
+    префиксы имени/username при автосоздании бота уведомлений через BotFather."""
+
     admin_chat_id: int | None = None
     bot_name_prefix: str = "LeadHunter"
     bot_username_prefix: str = "leadhunter_"
 
 
 class DatabaseConfig(BaseModel):
+    """Путь к файлу SQLite и тюнинг производительности соединений (#760).
+
+    `read_pool_size` — число read-соединений (читают параллельно, медленный
+    SELECT не блокирует навигацию). `cache_size_kb` — кэш страниц на соединение
+    (суммарная RAM ≈ `cache_size_kb * (read_pool_size + 1)`). `mmap_size_mb` —
+    окно memory-mapped I/O (адресное пространство, не RAM; 0 отключает). Для
+    `:memory:` read-пул не разворачивается (одно соединение); per-connection
+    PRAGMA-тюнинг (кэш/mmap) применяется как обычно.
+    """
+
     path: str = "data/tg_search.db"
     # Number of read connections in the pool (#760). Reads run concurrently across
     # these, so a slow SELECT never blocks navigation. Ignored for :memory:.
@@ -70,6 +111,12 @@ class DatabaseConfig(BaseModel):
 
 
 class LLMConfig(BaseModel):
+    """Базовые LLM-настройки из конфига: провайдер, модель и ключ.
+
+    `enabled` включает LLM-функции; на практике провайдеры чаще авторегистрируются
+    из переменных окружения (`ProviderService`), а это — fallback из YAML.
+    """
+
     enabled: bool = False
     provider: str = "openai"
     model: str = "gpt-4o-mini"
@@ -77,6 +124,14 @@ class LLMConfig(BaseModel):
 
 
 class AgentConfig(BaseModel):
+    """Настройки агент-бэкенда: модель, deepagents-fallback и таймауты стрима.
+
+    `model` — основная модель агента, `fallback_model`/`fallback_api_key` —
+    запасной провайдер (формат `provider:model`). Группа `*_timeout` ограничивает
+    стадии стримингового вызова (закрытие стрима, первое событие, простой,
+    подтверждение, общий потолок) — защита от зависаний.
+    """
+
     model: str = ""
     fallback_model: str = ""
     fallback_api_key: str = ""
@@ -88,10 +143,20 @@ class AgentConfig(BaseModel):
 
 
 class SecurityConfig(BaseModel):
+    """Параметры безопасности: ключ шифрования StringSession аккаунтов.
+
+    Непустой `session_encryption_key` включает хранение сессий как `enc:v2:*`;
+    см. [`resolve_session_encryption_secret`][src.config.resolve_session_encryption_secret].
+    """
+
     session_encryption_key: str = ""
 
 
 class TelegramRuntimeConfig(BaseModel):
+    """Выбор Telegram-рантайма: режим бэкенда (`backend_mode`), транспорт CLI
+    (`cli_transport`) и каталог кэша сессий (`session_cache_dir`). Все три можно
+    переопределить переменными `TG_*` при загрузке."""
+
     backend_mode: str = "auto"
     cli_transport: str = "hybrid"
     session_cache_dir: str = "data/telegram_sessions"
@@ -114,6 +179,13 @@ class ProductionLimitsConfig(BaseModel):
 
 
 class AppConfig(BaseModel):
+    """Корень конфигурации приложения: агрегирует все секции `*Config`.
+
+    Каждая секция со своими дефолтами, поэтому валидный `AppConfig()` собирается
+    без файла. Загружается и валидируется через
+    [`load_config`][src.config.load_config].
+    """
+
     telegram: TelegramConfig = TelegramConfig()
     telegram_runtime: TelegramRuntimeConfig = TelegramRuntimeConfig()
     web: WebConfig = WebConfig()
@@ -130,6 +202,11 @@ _ENV_PATTERN = re.compile(r"\$\{(\w+)\}")
 
 
 def is_provider_model_ref(value: str) -> bool:
+    """True, если строка имеет вид `provider:model` с непустыми частями.
+
+    Используется для валидации ссылок на модель (например, agent-fallback), где
+    обязателен префикс провайдера.
+    """
     provider, separator, model = value.partition(":")
     return bool(separator and provider.strip() and model.strip())
 

--- a/src/database/bundles.py
+++ b/src/database/bundles.py
@@ -1,3 +1,15 @@
+"""Типизированные бандлы поверх репозиториев — узкие фасады доступа к БД.
+
+`DatabaseRepositories` — плоский агрегатор всех репозиториев, который `Database`
+отдаёт как `db.repos.*` (единая точка доступа к слою хранения). Остальные
+`*Bundle` — это доменно-узкие срезы: каждый собирает только те репозитории,
+что нужны одному потребителю (account-сервис, сбор, нотификации, поиск,
+шедулер, пайплайны, photo-loader), и предоставляет ему методы-обёртки с
+осмысленными именами вместо прямого доступа к `db.repos`. Так зависимости
+сервиса от хранилища видны в одном месте, а сам сервис не тянет весь набор
+репозиториев. Бандлы `frozen`/иммутабельны и создаются через `from_database`.
+"""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -54,6 +66,14 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class DatabaseRepositories:
+    """Плоский агрегатор всех репозиториев, доступный как `db.repos.*`.
+
+    Единая точка доступа к слою хранения: каждый атрибут — отдельный репозиторий
+    своего домена (аккаунты, каналы, сообщения, задачи сбора и т.д.). Сервисы и
+    web/CLI читают данные через `db.repos.<repo>.<method>()`, а `*Bundle` ниже
+    собираются из подмножества этих же репозиториев.
+    """
+
     accounts: AccountsRepository
     channels: ChannelsRepository
     messages: MessagesRepository
@@ -79,49 +99,69 @@ class DatabaseRepositories:
 
 @dataclass(frozen=True)
 class AccountBundle:
+    """Фасад для управления Telegram-аккаунтами пула (CRUD + флаги состояния)."""
+
     accounts: AccountsRepository
 
     @classmethod
     def from_database(cls, db: "Database") -> "AccountBundle":
+        """Собрать бандл из репозитория аккаунтов общего `Database`."""
         return cls(db.repos.accounts)
 
     async def list_accounts(self, active_only: bool = False) -> list[Account]:
+        """Список аккаунтов (с секретом сессии); `active_only` — только активные."""
         return await self.accounts.get_accounts(active_only)
 
     async def list_live_usable_accounts(self, active_only: bool = False) -> list[Account]:
+        """Аккаунты, пригодные для живого подключения (валидная читаемая сессия)."""
         return await self.accounts.get_live_usable_accounts(active_only)
 
     async def list_account_summaries(self, active_only: bool = False) -> list[AccountSummary]:
+        """Безопасные для UI сводки аккаунтов (`AccountSummary`, без `session_string`)."""
         return await self.accounts.get_account_summaries(active_only)
 
     async def add_account(self, account: Account) -> int:
+        """Добавить аккаунт; возвращает его id."""
         return await self.accounts.add_account(account)
 
     async def set_active(self, account_id: int, active: bool) -> None:
+        """Включить/выключить аккаунт по id."""
         await self.accounts.set_account_active(account_id, active)
 
     async def delete_account(self, account_id: int) -> None:
+        """Удалить аккаунт по id."""
         await self.accounts.delete_account(account_id)
 
     async def update_flood(self, phone: str, until) -> None:
+        """Записать `flood_wait_until` для аккаунта (момент окончания FLOOD_WAIT)."""
         await self.accounts.update_account_flood(phone, until)
 
     async def update_premium(self, phone: str, is_premium: bool) -> None:
+        """Обновить флаг Premium-статуса аккаунта."""
         await self.accounts.update_account_premium(phone, is_premium)
 
 
 @dataclass(frozen=True)
 class ChannelBundle:
+    """Фасад управления каналами: сам канал, его статистика и задачи сбора.
+
+    Сводит вместе репозитории `channels`, `channel_stats` и `tasks`, чтобы
+    операции над каналом (CRUD, метаданные, фильтрация) и связанный с ним сбор
+    (создание/обновление collection-задач) жили за одним интерфейсом.
+    """
+
     channels: ChannelsRepository
     channel_stats: ChannelStatsRepository
     tasks: CollectionTasksRepository
 
     @classmethod
     def from_database(cls, db: "Database") -> "ChannelBundle":
+        """Собрать бандл из репозиториев каналов/статистики/задач общего `Database`."""
         repos = db.repos
         return cls(repos.channels, repos.channel_stats, repos.tasks)
 
     async def add_channel(self, channel: Channel) -> int:
+        """Добавить канал; возвращает его pk (первичный ключ БД)."""
         return await self.channels.add_channel(channel)
 
     async def list_channels(
@@ -129,6 +169,7 @@ class ChannelBundle:
         active_only: bool = False,
         include_filtered: bool = True,
     ) -> list[Channel]:
+        """Список каналов; `active_only` — только активные, `include_filtered` — с отфильтрованными."""
         return await self.channels.get_channels(active_only, include_filtered)
 
     async def list_channels_with_counts(
@@ -136,21 +177,27 @@ class ChannelBundle:
         active_only: bool = False,
         include_filtered: bool = True,
     ) -> list[Channel]:
+        """Каналы с проставленным `message_count` (число собранных сообщений)."""
         return await self.channels.get_channels_with_counts(active_only, include_filtered)
 
     async def get_by_pk(self, pk: int) -> Channel | None:
+        """Канал по pk (первичный ключ БД), либо None."""
         return await self.channels.get_channel_by_pk(pk)
 
     async def get_by_channel_id(self, channel_id: int) -> Channel | None:
+        """Канал по Telegram `channel_id`, либо None."""
         return await self.channels.get_channel_by_channel_id(channel_id)
 
     async def set_active(self, pk: int, active: bool) -> None:
+        """Включить/выключить канал по pk."""
         await self.channels.set_channel_active(pk, active)
 
     async def set_type(self, channel_id: int, channel_type: str) -> None:
+        """Задать тип канала (channel/supergroup/...) по Telegram `channel_id`."""
         await self.channels.set_channel_type(channel_id, channel_type)
 
     async def update_last_id(self, channel_id: int, last_id: int) -> None:
+        """Обновить `last_collected_id` канала (граница инкрементального сбора)."""
         await self.channels.update_channel_last_id(channel_id, last_id)
 
     async def update_meta(
@@ -160,6 +207,7 @@ class ChannelBundle:
         username: str | None,
         title: str | None,
     ) -> None:
+        """Обновить базовые метаданные канала — username и title."""
         await self.channels.update_channel_meta(channel_id, username=username, title=title)
 
     async def update_channel_full_meta(
@@ -170,6 +218,7 @@ class ChannelBundle:
         linked_chat_id: int | None,
         has_comments: bool,
     ) -> None:
+        """Обновить расширенные метаданные: описание, привязанный чат, наличие комментариев."""
         await self.channels.update_channel_full_meta(
             channel_id, about=about, linked_chat_id=linked_chat_id, has_comments=has_comments
         )
@@ -180,29 +229,37 @@ class ChannelBundle:
         *,
         commit: bool = True,
     ) -> int:
+        """Пакетно проставить флаги фильтрации каналам `(channel_id, flags_csv)`; вернуть число изменённых."""
         return await self.channels.set_filtered_bulk(updates, commit=commit)
 
     async def reset_all_filters(self, *, commit: bool = True) -> int:
+        """Снять фильтрацию со всех каналов; вернуть число сброшенных."""
         return await self.channels.reset_all_filters(commit=commit)
 
     async def delete_channel(self, pk: int) -> None:
+        """Удалить канал по pk."""
         await self.channels.delete_channel(pk)
 
     async def save_stats(self, stats: ChannelStats) -> int:
+        """Сохранить снимок статистики канала; возвращает id записи."""
         return await self.channel_stats.save_channel_stats(stats)
 
     async def get_stats(self, channel_id: int, limit: int = 1) -> list[ChannelStats]:
+        """Последние `limit` снимков статистики канала (от новых к старым)."""
         return await self.channel_stats.get_channel_stats(channel_id, limit)
 
     async def get_latest_stats_for_all(self) -> dict[int, ChannelStats]:
+        """Свежайший снимок статистики по каждому каналу: `{channel_id: ChannelStats}`."""
         return await self.channel_stats.get_latest_stats_for_all()
 
     async def get_previous_subscriber_counts(self) -> dict[int, int | None]:
+        """Предыдущее (не последнее) число подписчиков по каналам — для расчёта дельты роста."""
         return await self.channel_stats.get_previous_subscriber_counts()
 
     async def get_latest_and_previous_stats(
         self,
     ) -> tuple[dict[int, ChannelStats], dict[int, int | None]]:
+        """Пара (последние снимки статистики, предыдущие счётчики подписчиков) одним проходом."""
         return await self.channel_stats.get_latest_and_previous_stats()
 
     async def create_collection_task(
@@ -215,6 +272,7 @@ class ChannelBundle:
         payload: dict | None = None,
         parent_task_id: int | None = None,
     ) -> int:
+        """Создать задачу сбора для канала; возвращает её id."""
         return await self.tasks.create_collection_task(
             channel_id,
             channel_title,
@@ -234,6 +292,7 @@ class ChannelBundle:
         payload: dict | None = None,
         parent_task_id: int | None = None,
     ) -> int | None:
+        """Создать задачу сбора, только если у канала ещё нет активной; иначе None (анти-дубль)."""
         return await self.tasks.create_collection_task_if_not_active(
             channel_id,
             channel_title,
@@ -252,6 +311,7 @@ class ChannelBundle:
         note: str | None = None,
         run_after: datetime | None = None,
     ) -> None:
+        """Обновить статус задачи сбора и сопутствующие поля (счётчик, ошибка, заметка, run_after)."""
         await self.tasks.update_collection_task(
             task_id,
             status,
@@ -269,6 +329,7 @@ class ChannelBundle:
         note: str | None = None,
         messages_collected: int = 0,
     ) -> None:
+        """Перенести задачу сбора на `run_after` (например после FLOOD_WAIT)."""
         await self.tasks.reschedule_collection_task(
             task_id,
             run_after=run_after,
@@ -282,9 +343,11 @@ class ChannelBundle:
         *,
         note: str | None = None,
     ) -> None:
+        """Вернуть задачу сбора в статус PENDING (повторная постановка в очередь)."""
         await self.tasks.reset_collection_task_to_pending(task_id, note=note)
 
     async def update_collection_task_progress(self, task_id: int, messages_collected: int) -> None:
+        """Записать прогресс задачи сбора (число собранных сообщений на текущий момент)."""
         await self.tasks.update_collection_task_progress(task_id, messages_collected)
 
     async def persist_stats_progress(
@@ -294,32 +357,40 @@ class ChannelBundle:
         payload: StatsAllTaskPayload,
         messages_collected: int,
     ) -> None:
+        """Сохранить промежуточный прогресс STATS_ALL-задачи (payload + счётчик) между шагами."""
         await self.tasks.persist_stats_progress(task_id, payload=payload, messages_collected=messages_collected)
 
     async def get_collection_task(self, task_id: int) -> CollectionTask | None:
+        """Задача сбора по id, либо None."""
         return await self.tasks.get_collection_task(task_id)
 
     async def get_collection_tasks(self, limit: int = 20) -> list[CollectionTask]:
+        """Последние `limit` задач сбора (от новых к старым)."""
         return await self.tasks.get_collection_tasks(limit)
 
     async def count_collection_tasks(self, status_filter: str | None = None) -> int:
+        """Число задач сбора, опционально только в статусе `status_filter`."""
         return await self.tasks.count_collection_tasks(status_filter)
 
     async def get_collection_tasks_paginated(
         self, limit: int = 20, offset: int = 0, status_filter: str | None = None
     ) -> tuple[list[CollectionTask], int]:
+        """Страница задач сбора и общее их число: `(список, total)`."""
         return await self.tasks.get_collection_tasks_paginated(limit, offset, status_filter)
 
     async def get_active_collection_tasks_for_channel(
         self,
         channel_id: int,
     ) -> list[CollectionTask]:
+        """Активные (pending/running) задачи сбора конкретного канала."""
         return await self.tasks.get_active_collection_tasks_for_channel(channel_id)
 
     async def get_channel_ids_with_active_tasks(self) -> set[int]:
+        """Множество `channel_id`, у которых есть активная задача сбора."""
         return await self.tasks.get_channel_ids_with_active_tasks()
 
     async def get_active_stats_task(self) -> CollectionTask | None:
+        """Текущая активная STATS_ALL-задача (сбор статистики по всем каналам), либо None."""
         return await self.tasks.get_active_stats_task()
 
     async def create_stats_task(
@@ -329,6 +400,7 @@ class ChannelBundle:
         run_after: datetime | None = None,
         parent_task_id: int | None = None,
     ) -> int:
+        """Создать STATS_ALL-задачу с заданным payload; возвращает её id."""
         return await self.tasks.create_stats_task(
             payload,
             run_after=run_after,
@@ -343,6 +415,7 @@ class ChannelBundle:
         run_after: datetime,
         messages_collected: int,
     ) -> None:
+        """Перенести STATS_ALL-задачу на `run_after`, сохранив обновлённый payload и прогресс."""
         return await self.tasks.reschedule_stats_task(
             task_id,
             payload=payload,
@@ -351,23 +424,35 @@ class ChannelBundle:
         )
 
     async def get_pending_channel_tasks(self) -> list[CollectionTask]:
+        """Задачи сбора каналов в статусе PENDING (для постановки в очередь воркером)."""
         return await self.tasks.get_pending_channel_tasks()
 
     async def delete_pending_channel_tasks(self) -> int:
+        """Удалить все PENDING-задачи сбора каналов; вернуть число удалённых."""
         return await self.tasks.delete_pending_channel_tasks()
 
     async def fail_running_collection_tasks_on_startup(self) -> int:
+        """Пометить «зависшие» RUNNING-задачи как FAILED при старте; вернуть число затронутых."""
         return await self.tasks.fail_running_collection_tasks_on_startup()
 
     async def reset_orphaned_running_tasks(self) -> int:
+        """Вернуть в PENDING осиротевшие RUNNING-задачи (воркер упал); вернуть число затронутых."""
         return await self.tasks.reset_orphaned_running_tasks()
 
     async def cancel_collection_task(self, task_id: int, note: str | None = None) -> bool:
+        """Отменить задачу сбора; True, если отмена применена."""
         return await self.tasks.cancel_collection_task(task_id, note=note)
 
 
 @dataclass(frozen=True)
 class CollectionBundle:
+    """Фасад для процесса сбора: каналы, запись сообщений, фильтры, настройки и задачи.
+
+    Используется `Collector`/сервисом сбора: даёт доступ к каналам (чтение/мета),
+    пакетной вставке собранных сообщений, фильтрам, настройкам, нотификационным
+    запросам и постановке collection-задач — всё, что нужно одному циклу сбора.
+    """
+
     channels: ChannelsRepository
     messages: MessagesRepository
     filters: FilterRepository
@@ -378,6 +463,7 @@ class CollectionBundle:
 
     @classmethod
     def from_database(cls, db: "Database") -> "CollectionBundle":
+        """Собрать бандл из репозиториев, нужных циклу сбора, общего `Database`."""
         repos = db.repos
         return cls(
             repos.channels,
@@ -394,15 +480,19 @@ class CollectionBundle:
         active_only: bool = False,
         include_filtered: bool = True,
     ) -> list[Channel]:
+        """Список каналов; `active_only` — только активные, `include_filtered` — с отфильтрованными."""
         return await self.channels.get_channels(active_only, include_filtered)
 
     async def get_by_pk(self, pk: int) -> Channel | None:
+        """Канал по pk (первичный ключ БД), либо None."""
         return await self.channels.get_channel_by_pk(pk)
 
     async def get_by_channel_id(self, channel_id: int) -> Channel | None:
+        """Канал по Telegram `channel_id`, либо None."""
         return await self.channels.get_channel_by_channel_id(channel_id)
 
     async def update_last_id(self, channel_id: int, last_id: int) -> None:
+        """Обновить `last_collected_id` канала (граница инкрементального сбора)."""
         await self.channels.update_channel_last_id(channel_id, last_id)
 
     async def update_meta(
@@ -412,12 +502,15 @@ class CollectionBundle:
         username: str | None,
         title: str | None,
     ) -> None:
+        """Обновить базовые метаданные канала — username и title."""
         await self.channels.update_channel_meta(channel_id, username=username, title=title)
 
     async def set_active(self, pk: int, active: bool) -> None:
+        """Включить/выключить канал по pk."""
         await self.channels.set_channel_active(pk, active)
 
     async def set_type(self, channel_id: int, channel_type: str) -> None:
+        """Задать тип канала по Telegram `channel_id`."""
         await self.channels.set_channel_type(channel_id, channel_type)
 
     async def set_filtered_bulk(
@@ -426,26 +519,33 @@ class CollectionBundle:
         *,
         commit: bool = True,
     ) -> int:
+        """Пакетно проставить флаги фильтрации каналам `(channel_id, flags_csv)`; вернуть число изменённых."""
         return await self.channels.set_filtered_bulk(updates, commit=commit)
 
     async def reset_all_filters(self, *, commit: bool = True) -> int:
+        """Снять фильтрацию со всех каналов; вернуть число сброшенных."""
         return await self.channels.reset_all_filters(commit=commit)
 
     async def insert_message(self, msg: Message) -> bool:
+        """Вставить одно сообщение; True, если строка добавлена (False при дубле)."""
         return await self.messages.insert_message(msg)
 
     async def insert_messages_batch(
         self, messages: list[Message], premium_search_query: str | None = None
     ) -> int:
+        """Пакетная вставка сообщений (`INSERT OR IGNORE`); вернуть число реально добавленных."""
         return await self.messages.insert_messages_batch(messages, premium_search_query)
 
     async def search_messages(self, params: SearchParams) -> MessageSearchPage:
+        """Поиск сообщений по фильтру `SearchParams`; возвращает страницу результатов."""
         return await self.messages.search_messages(params)
 
     async def delete_messages_for_channel(self, channel_id: int) -> int:
+        """Удалить все сообщения канала; вернуть число удалённых строк."""
         return await self.messages.delete_messages_for_channel(channel_id)
 
     async def get_message_stats(self) -> dict:
+        """Сводная статистика по таблице сообщений (счётчики и т.п.)."""
         return await self.messages.get_stats()
 
     async def count_matching_prefixes_in_other_channels(
@@ -453,18 +553,23 @@ class CollectionBundle:
         channel_id: int,
         prefixes: list[str],
     ) -> int:
+        """Сколько раз префиксы сообщений канала встречаются в других каналах (детектор кросс-спама)."""
         return await self.filters.count_matching_prefixes_in_other_channels(channel_id, prefixes)
 
     async def get_setting(self, key: str) -> str | None:
+        """Прочитать настройку по ключу, либо None."""
         return await self.settings.get_setting(key)
 
     async def set_setting(self, key: str, value: str) -> None:
+        """Записать настройку по ключу."""
         await self.settings.set_setting(key, value)
 
     async def list_notification_queries(self, active_only: bool = True) -> list[SearchQuery]:
+        """Сохранённые поисковые запросы с нотификацией при сборе (`notify_on_collect`)."""
         return await self.search_queries.get_notification_queries(active_only)
 
     async def get_channel_stats(self, channel_id: int, limit: int = 1) -> list[ChannelStats]:
+        """Последние `limit` снимков статистики канала."""
         return await self.channel_stats.get_channel_stats(channel_id, limit)
 
     async def create_collection_task(
@@ -477,6 +582,7 @@ class CollectionBundle:
         payload: dict | None = None,
         parent_task_id: int | None = None,
     ) -> int:
+        """Создать задачу сбора для канала; возвращает её id."""
         return await self.tasks.create_collection_task(
             channel_id,
             channel_title,
@@ -489,46 +595,65 @@ class CollectionBundle:
 
 @dataclass(frozen=True)
 class NotificationBundle:
+    """Фасад нотификаций: аккаунты-отправители, настройки и персональные боты."""
+
     accounts: AccountsRepository
     settings: SettingsRepository
     notification_bots: NotificationBotsRepository
 
     @classmethod
     def from_database(cls, db: "Database") -> "NotificationBundle":
+        """Собрать бандл из репозиториев аккаунтов/настроек/ботов общего `Database`."""
         repos = db.repos
         return cls(repos.accounts, repos.settings, repos.notification_bots)
 
     async def list_accounts(self, active_only: bool = False) -> list[Account]:
+        """Список аккаунтов (с секретом сессии); `active_only` — только активные."""
         return await self.accounts.get_accounts(active_only)
 
     async def list_account_summaries(self, active_only: bool = False) -> list[AccountSummary]:
+        """Безопасные для UI сводки аккаунтов (`AccountSummary`, без секрета сессии)."""
         return await self.accounts.get_account_summaries(active_only)
 
     async def get_setting(self, key: str) -> str | None:
+        """Прочитать настройку по ключу, либо None."""
         return await self.settings.get_setting(key)
 
     async def set_setting(self, key: str, value: str) -> None:
+        """Записать настройку по ключу."""
         await self.settings.set_setting(key, value)
 
     async def get_bot(self, tg_user_id: int) -> NotificationBot | None:
+        """Персональный бот-нотификатор для пользователя Telegram, либо None."""
         return await self.notification_bots.get_bot(tg_user_id)
 
     async def save_bot(self, bot: NotificationBot) -> int:
+        """Сохранить (upsert) бота-нотификатора; возвращает его id."""
         return await self.notification_bots.save_bot(bot)
 
     async def delete_bot(self, tg_user_id: int) -> None:
+        """Удалить бота-нотификатора пользователя."""
         await self.notification_bots.delete_bot(tg_user_id)
 
 
 @dataclass(frozen=True)
 class PhotoLoaderBundle:
+    """Фасад photo-loader: пакеты/элементы отправки фото и авто-загрузка из папки.
+
+    Покрывает три сущности: батчи (`PhotoBatch`), их элементы (`PhotoBatchItem`,
+    единицы отправки/планирования) и авто-задания (`PhotoAutoUploadJob`,
+    периодическая отправка новых файлов из папки).
+    """
+
     photo_loader: PhotoLoaderRepository
 
     @classmethod
     def from_database(cls, db: "Database") -> "PhotoLoaderBundle":
+        """Собрать бандл из репозитория photo-loader общего `Database`."""
         return cls(db.repos.photo_loader)
 
     async def create_batch(self, batch: PhotoBatch) -> int:
+        """Создать батч отправки фото; возвращает его id."""
         return await self.photo_loader.create_batch(batch)
 
     async def update_batch(
@@ -539,6 +664,7 @@ class PhotoLoaderBundle:
         error: str | None = None,
         last_run_at: datetime | None = None,
     ) -> None:
+        """Обновить переданные поля батча (статус, ошибка, время последнего прогона)."""
         await self.photo_loader.update_batch(
             batch_id,
             status=status,
@@ -547,21 +673,27 @@ class PhotoLoaderBundle:
         )
 
     async def get_batch(self, batch_id: int) -> PhotoBatch | None:
+        """Батч по id, либо None."""
         return await self.photo_loader.get_batch(batch_id)
 
     async def list_batches(self, limit: int = 50) -> list[PhotoBatch]:
+        """Последние `limit` батчей."""
         return await self.photo_loader.list_batches(limit)
 
     async def create_item(self, item: PhotoBatchItem) -> int:
+        """Создать элемент батча (единицу отправки/планирования); возвращает его id."""
         return await self.photo_loader.create_item(item)
 
     async def get_item(self, item_id: int) -> PhotoBatchItem | None:
+        """Элемент батча по id, либо None."""
         return await self.photo_loader.get_item(item_id)
 
     async def list_items(self, limit: int = 100) -> list[PhotoBatchItem]:
+        """Последние `limit` элементов (по всем батчам)."""
         return await self.photo_loader.list_items(limit)
 
     async def list_items_for_batch(self, batch_id: int, limit: int | None = None) -> list[PhotoBatchItem]:
+        """Элементы конкретного батча; `limit=None` — все."""
         return await self.photo_loader.list_items_for_batch(batch_id, limit=limit)
 
     async def update_item(
@@ -574,6 +706,7 @@ class PhotoLoaderBundle:
         started_at: datetime | None = None,
         completed_at: datetime | None = None,
     ) -> None:
+        """Обновить переданные поля элемента (статус, ошибка, id отправленных сообщений, тайминги)."""
         await self.photo_loader.update_item(
             item_id,
             status=status,
@@ -584,17 +717,25 @@ class PhotoLoaderBundle:
         )
 
     async def cancel_item(self, item_id: int) -> bool:
+        """Отменить элемент батча; True, если отмена применена."""
         return await self.photo_loader.cancel_item(item_id)
 
     async def claim_next_due_item(
         self, now: datetime, *, item_id: int | None = None
     ) -> PhotoBatchItem | None:
+        """Атомарно «забрать» ближайший готовый PENDING-элемент в RUNNING.
+
+        Без `item_id` берётся самый ранний готовый (due) элемент; с `item_id` —
+        только указанный, и лишь если он сам due. None, если подходящего нет.
+        """
         return await self.photo_loader.claim_next_due_item(now, item_id=item_id)
 
     async def requeue_running_items_on_startup(self, now: datetime) -> int:
+        """Вернуть зависшие RUNNING-элементы в очередь при старте; вернуть число затронутых."""
         return await self.photo_loader.requeue_running_items_on_startup(now)
 
     async def create_auto_job(self, job: PhotoAutoUploadJob) -> int:
+        """Создать авто-задание загрузки фото из папки; возвращает его id."""
         return await self.photo_loader.create_auto_job(job)
 
     async def update_auto_job(
@@ -610,6 +751,7 @@ class PhotoLoaderBundle:
         last_run_at: datetime | None = None,
         last_seen_marker: str | None = None,
     ) -> None:
+        """Обновить переданные поля авто-задания (папка, режим, подпись, интервал, флаги, маркеры)."""
         await self.photo_loader.update_auto_job(
             job_id,
             folder_path=folder_path,
@@ -623,23 +765,35 @@ class PhotoLoaderBundle:
         )
 
     async def get_auto_job(self, job_id: int) -> PhotoAutoUploadJob | None:
+        """Авто-задание по id, либо None."""
         return await self.photo_loader.get_auto_job(job_id)
 
     async def list_auto_jobs(self, active_only: bool = False) -> list[PhotoAutoUploadJob]:
+        """Список авто-заданий; `active_only` — только активные."""
         return await self.photo_loader.list_auto_jobs(active_only)
 
     async def delete_auto_job(self, job_id: int) -> None:
+        """Удалить авто-задание по id."""
         await self.photo_loader.delete_auto_job(job_id)
 
     async def has_sent_auto_file(self, job_id: int, file_path: str) -> bool:
+        """Был ли файл уже отправлен этим авто-заданием (дедуп повторной отправки)."""
         return await self.photo_loader.has_sent_auto_file(job_id, file_path)
 
     async def mark_auto_file_sent(self, job_id: int, file_path: str) -> None:
+        """Отметить файл как отправленный авто-заданием (чтобы не слать повторно)."""
         await self.photo_loader.mark_auto_file_sent(job_id, file_path)
 
 
 @dataclass(frozen=True)
 class SearchBundle:
+    """Фасад поиска: сообщения, журнал поисков, каналы, настройки.
+
+    Флаги `vec_available`/`numpy_available` (определяются в `from_database`)
+    сообщают потребителю, доступен ли векторный/семантический поиск в этом
+    окружении (расширение sqlite-vec и numpy).
+    """
+
     messages: MessagesRepository
     search_log: SearchLogRepository
     channels: ChannelsRepository
@@ -649,6 +803,7 @@ class SearchBundle:
 
     @classmethod
     def from_database(cls, db: "Database") -> "SearchBundle":
+        """Собрать бандл из репозиториев поиска и определить доступность vec/numpy."""
         repos = db.repos
         try:
             import numpy  # noqa: F401
@@ -665,31 +820,40 @@ class SearchBundle:
         )
 
     async def search_messages(self, params: SearchParams) -> MessageSearchPage:
+        """Поиск сообщений по фильтру `SearchParams`; возвращает страницу результатов."""
         return await self.messages.search_messages(params)
 
     async def add_channel(self, channel: Channel) -> int:
+        """Добавить канал; возвращает его pk."""
         return await self.channels.add_channel(channel)
 
     async def insert_messages_batch(
         self, messages: list[Message], premium_search_query: str | None = None
     ) -> int:
+        """Пакетная вставка сообщений; вернуть число реально добавленных."""
         return await self.messages.insert_messages_batch(messages, premium_search_query)
 
     async def log_search(self, phone: str, query: str, results_count: int) -> None:
+        """Записать факт поиска в журнал (телефон, запрос, число результатов)."""
         await self.search_log.log_search(phone, query, results_count)
 
     async def get_recent_searches(self, limit: int = 20) -> list[dict]:
+        """Последние `limit` записей журнала поисков."""
         return await self.search_log.get_recent_searches(limit)
 
     async def get_setting(self, key: str) -> str | None:
+        """Прочитать настройку по ключу, либо None."""
         return await self.settings.get_setting(key)
 
     async def set_setting(self, key: str, value: str) -> None:
+        """Записать настройку по ключу."""
         await self.settings.set_setting(key, value)
 
 
 @dataclass(frozen=True)
 class SchedulerBundle:
+    """Фасад шедулера: настройки, нотификационные запросы, задачи сбора и журнал поисков."""
+
     settings: SettingsRepository
     search_queries: SearchQueriesRepository
     tasks: CollectionTasksRepository
@@ -697,91 +861,121 @@ class SchedulerBundle:
 
     @classmethod
     def from_database(cls, db: "Database") -> "SchedulerBundle":
+        """Собрать бандл из репозиториев, нужных шедулеру, общего `Database`."""
         repos = db.repos
         return cls(repos.settings, repos.search_queries, repos.tasks, repos.search_log)
 
     async def get_setting(self, key: str) -> str | None:
+        """Прочитать настройку по ключу, либо None."""
         return await self.settings.get_setting(key)
 
     async def set_setting(self, key: str, value: str) -> None:
+        """Записать настройку по ключу."""
         await self.settings.set_setting(key, value)
 
     async def list_notification_queries(self, active_only: bool = True) -> list[SearchQuery]:
+        """Поисковые запросы с нотификацией при сборе (для периодического прогона шедулером)."""
         return await self.search_queries.get_notification_queries(active_only)
 
     async def get_collection_tasks(self, limit: int = 20) -> list[CollectionTask]:
+        """Последние `limit` задач сбора."""
         return await self.tasks.get_collection_tasks(limit)
 
     async def count_collection_tasks(self, status_filter: str | None = None) -> int:
+        """Число задач сбора, опционально только в статусе `status_filter`."""
         return await self.tasks.count_collection_tasks(status_filter)
 
     async def get_collection_tasks_paginated(
         self, limit: int = 20, offset: int = 0, status_filter: str | None = None
     ) -> tuple[list[CollectionTask], int]:
+        """Страница задач сбора и общее их число: `(список, total)`."""
         return await self.tasks.get_collection_tasks_paginated(limit, offset, status_filter)
 
     async def get_recent_searches(self, limit: int = 20) -> list[dict]:
+        """Последние `limit` записей журнала поисков."""
         return await self.search_log.get_recent_searches(limit)
 
 
 @dataclass(frozen=True)
 class SearchQueryBundle:
+    """Фасад сохранённых поисковых запросов: CRUD, статистика совпадений, FTS-метрики.
+
+    Репозиторий `channels` опционален (`None` — пропуск): нужен лишь для
+    вспомогательного `get_channels`, который иначе вернёт пустой список.
+    """
+
     search_queries: SearchQueriesRepository
     messages: MessagesRepository
     channels: ChannelsRepository | None = None
 
     @classmethod
     def from_database(cls, db: "Database") -> "SearchQueryBundle":
+        """Собрать бандл из репозиториев запросов/сообщений/каналов общего `Database`."""
         repos = db.repos
         return cls(repos.search_queries, repos.messages, repos.channels)
 
     async def add(self, sq: SearchQuery) -> int:
+        """Добавить сохранённый поисковый запрос; возвращает его id."""
         return await self.search_queries.add(sq)
 
     async def get_all(self, active_only: bool = False) -> list[SearchQuery]:
+        """Все сохранённые запросы; `active_only` — только активные."""
         return await self.search_queries.get_all(active_only)
 
     async def get_by_id(self, sq_id: int) -> SearchQuery | None:
+        """Сохранённый запрос по id, либо None."""
         return await self.search_queries.get_by_id(sq_id)
 
     async def set_active(self, sq_id: int, active: bool) -> None:
+        """Включить/выключить сохранённый запрос."""
         await self.search_queries.set_active(sq_id, active)
 
     async def update(self, sq_id: int, sq: SearchQuery) -> None:
+        """Перезаписать сохранённый запрос новыми полями."""
         await self.search_queries.update(sq_id, sq)
 
     async def delete(self, sq_id: int) -> None:
+        """Удалить сохранённый запрос по id."""
         await self.search_queries.delete(sq_id)
 
     async def record_stat(self, query_id: int, match_count: int) -> None:
+        """Записать точку статистики запроса (число совпадений за прогон)."""
         await self.search_queries.record_stat(query_id, match_count)
 
     async def get_daily_stats(self, query_id: int, days: int = 30) -> list[SearchQueryDailyStat]:
+        """Дневная статистика совпадений запроса за последние `days` дней."""
         return await self.search_queries.get_daily_stats(query_id, days)
 
     async def get_stats_for_all(self, days: int = 30) -> dict[int, list[SearchQueryDailyStat]]:
+        """Дневная статистика по всем запросам: `{query_id: [SearchQueryDailyStat]}`."""
         return await self.search_queries.get_stats_for_all(days)
 
     async def count_fts_matches_for_query(self, sq: SearchQuery) -> int:
+        """Текущее число совпадений запроса по FTS-индексу сообщений."""
         return await self.messages.count_fts_matches_for_query(sq)
 
     async def get_fts_daily_stats_for_query(
         self, sq: SearchQuery, days: int = 30
     ) -> list[SearchQueryDailyStat]:
+        """Дневная статистика совпадений запроса, посчитанная по FTS-индексу, за `days` дней."""
         return await self.messages.get_fts_daily_stats_for_query(sq, days)
 
     async def get_fts_daily_stats_batch(
         self, queries: list[SearchQuery], days: int = 30
     ) -> dict[int, list[SearchQueryDailyStat]]:
+        """FTS-статистика сразу для набора запросов: `{query_id: [SearchQueryDailyStat]}`."""
         return await self.messages.get_fts_daily_stats_batch(queries, days)
 
     async def get_last_recorded_at(self, query_id: int) -> str | None:
+        """Время последней записанной точки статистики запроса, либо None."""
         return await self.search_queries.get_last_recorded_at(query_id)
 
     async def get_last_recorded_at_all(self) -> dict[int, str]:
+        """Время последней точки статистики по всем запросам: `{query_id: ts}`."""
         return await self.search_queries.get_last_recorded_at_all()
 
     async def get_channels(self) -> list[Channel]:
+        """Все каналы (для UI-фильтра по каналу); пустой список, если репозиторий не задан."""
         if self.channels is None:
             return []
         return await self.channels.get_channels()
@@ -789,6 +983,13 @@ class SearchQueryBundle:
 
 @dataclass(frozen=True)
 class PipelineBundle:
+    """Фасад контент-пайплайнов: сами пайплайны, их источники/цели и справочники.
+
+    Помимо CRUD пайплайнов даёт доступ к спискам каналов и аккаунтов (для выбора
+    источников/целей в UI) и к кэшу диалогов (`dialog_cache`) для разрешения
+    целевых диалогов публикации. `pipeline_templates` опционален.
+    """
+
     content_pipelines: ContentPipelinesRepository
     channels: ChannelsRepository
     accounts: AccountsRepository
@@ -797,6 +998,7 @@ class PipelineBundle:
 
     @classmethod
     def from_database(cls, db: "Database") -> "PipelineBundle":
+        """Собрать бандл из репозиториев пайплайнов/каналов/аккаунтов/кэша диалогов."""
         repos = db.repos
         return cls(
             repos.content_pipelines,
@@ -812,12 +1014,15 @@ class PipelineBundle:
         source_channel_ids: list[int],
         targets: list[PipelineTarget],
     ) -> int:
+        """Создать пайплайн вместе с его источниками и целями; возвращает id пайплайна."""
         return await self.content_pipelines.add(pipeline, source_channel_ids, targets)
 
     async def get_all(self, active_only: bool = False) -> list[ContentPipeline]:
+        """Все пайплайны; `active_only` — только активные."""
         return await self.content_pipelines.get_all(active_only)
 
     async def get_by_id(self, pipeline_id: int) -> ContentPipeline | None:
+        """Пайплайн по id, либо None."""
         return await self.content_pipelines.get_by_id(pipeline_id)
 
     async def update(
@@ -827,6 +1032,7 @@ class PipelineBundle:
         source_channel_ids: list[int],
         targets: list[PipelineTarget],
     ) -> bool:
+        """Обновить пайплайн и пересобрать его источники/цели; True при успехе."""
         return await self.content_pipelines.update(
             pipeline_id,
             pipeline,
@@ -835,15 +1041,19 @@ class PipelineBundle:
         )
 
     async def set_active(self, pipeline_id: int, active: bool) -> None:
+        """Включить/выключить пайплайн."""
         await self.content_pipelines.set_active(pipeline_id, active)
 
     async def delete(self, pipeline_id: int) -> None:
+        """Удалить пайплайн по id (вместе со связями источников/целей)."""
         await self.content_pipelines.delete(pipeline_id)
 
     async def list_sources(self, pipeline_id: int) -> list[PipelineSource]:
+        """Каналы-источники пайплайна."""
         return await self.content_pipelines.list_sources(pipeline_id)
 
     async def list_targets(self, pipeline_id: int) -> list[PipelineTarget]:
+        """Целевые диалоги публикации пайплайна."""
         return await self.content_pipelines.list_targets(pipeline_id)
 
     async def list_channels(
@@ -851,16 +1061,21 @@ class PipelineBundle:
         active_only: bool = False,
         include_filtered: bool = True,
     ):
+        """Список каналов (для выбора источников в UI пайплайна)."""
         return await self.channels.get_channels(active_only, include_filtered)
 
     async def list_accounts(self, active_only: bool = False):
+        """Список аккаунтов (для выбора аккаунта-отправителя пайплайна)."""
         return await self.accounts.get_accounts(active_only)
 
     async def list_account_summaries(self, active_only: bool = False):
+        """Безопасные сводки аккаунтов (`AccountSummary`, без секрета сессии)."""
         return await self.accounts.get_account_summaries(active_only)
 
     async def get_cached_dialog(self, phone: str, dialog_id: int) -> dict | None:
+        """Закэшированный диалог `(phone, dialog_id)` для разрешения цели публикации, либо None."""
         return await self.dialog_cache.get_dialog(phone, dialog_id)
 
     async def list_cached_dialogs(self, phone: str) -> list[dict]:
+        """Все закэшированные диалоги аккаунта (для выпадающего списка целей)."""
         return await self.dialog_cache.list_dialogs(phone)

--- a/src/database/repositories/_transactions.py
+++ b/src/database/repositories/_transactions.py
@@ -1,3 +1,5 @@
+"""Низкоуровневые помощники транзакций для общего aiosqlite-соединения (#569)."""
+
 from __future__ import annotations
 
 import logging

--- a/src/database/repositories/accounts.py
+++ b/src/database/repositories/accounts.py
@@ -1,3 +1,18 @@
+"""Репозиторий Telegram-аккаунтов пула (таблица ``accounts``).
+
+Доступ через `db.repos.accounts`. Поверх обычного CRUD держит один инвариант и
+один слой безопасности:
+
+* «не более одного primary» (#733) — атомарно при вставке/активации/удалении,
+  с partial-unique-индексом как жёстким бэкстопом. 0 primary допустимо: первая
+  вставка с ``is_primary=False`` и деактивация/удаление последнего primary
+  оставляют пул без primary-аккаунта;
+* шифрование StringSession — `session_string` хранится как `enc:v2:*`, когда
+  задан `SESSION_ENCRYPTION_KEY`; чтение разделено на «для UI» (статус сессии без
+  расшифровки) и «для живого использования» (расшифровка, иначе аккаунт
+  пропускается).
+"""
+
 from __future__ import annotations
 
 import logging
@@ -19,6 +34,13 @@ _RESTORE_ACCOUNT_ACTION = "restore_key_or_relogin"
 
 
 class AccountSessionDecryptError(RuntimeError):
+    """Расшифровать StringSession аккаунта не удалось (нет ключа, чужая версия, повреждение).
+
+    Несёт ``resource``/``identifier``/``status``/``action`` для единообразного
+    отчёта; поднимается на пути «живого» использования, где аккаунт без
+    читаемой сессии работать не может.
+    """
+
     def __init__(self, *, phone: str, status: str):
         super().__init__(
             "Failed to decrypt Telegram account session "
@@ -32,6 +54,8 @@ class AccountSessionDecryptError(RuntimeError):
 
 
 class AccountsRepository:
+    """CRUD Telegram-аккаунтов с инвариантом single-primary и шифрованием сессий."""
+
     def __init__(
         self,
         db: aiosqlite.Connection,
@@ -44,6 +68,17 @@ class AccountsRepository:
         self._database = database
 
     async def add_account(self, account: Account) -> int:
+        """Добавить аккаунт (или обновить существующий по телефону через UPSERT); вернуть id.
+
+        Возвращает `cur.lastrowid`: это надёжный id только на ветке вставки; при
+        конфликте-обновлении SQLite оставляет lastrowid от последней вставки в
+        соединении, поэтому для гарантированного id обновлённой строки читайте её
+        отдельно по `phone`.
+
+        Сессия шифруется при наличии cipher. Флаг primary назначается атомарно —
+        запрошенный ``is_primary`` срабатывает, только если primary-аккаунта ещё
+        нет (#733), иначе сохраняется 0.
+        """
         session_string = account.session_string
         if self._session_cipher:
             session_string = self._session_cipher.encrypt(session_string)
@@ -242,6 +277,12 @@ class AccountsRepository:
             raise AccountSessionDecryptError(phone=phone, status=status) from exc
 
     async def get_account_summaries(self, active_only: bool = False) -> list[AccountSummary]:
+        """Список аккаунтов как безопасные [`AccountSummary`][src.models.AccountSummary] (без секрета сессии).
+
+        Сессия не расшифровывается — вместо этого классифицируется её статус
+        (`session_status`), так что нечитаемый аккаунт всё равно отображается.
+        Порядок: primary первым, затем по id. С ``active_only`` — только активные.
+        """
         sql = "SELECT * FROM accounts"
         if active_only:
             sql += " WHERE is_active = 1"
@@ -260,6 +301,14 @@ class AccountsRepository:
         ]
 
     async def get_accounts(self, active_only: bool = False) -> list[Account]:
+        """Полные [`Account`][src.models.Account] с расшифрованными сессиями для живого использования.
+
+        В отличие от :meth:`get_account_summaries`, расшифровывает каждую сессию —
+        нечитаемая сессия поднимает
+        [`AccountSessionDecryptError`][src.database.repositories.accounts.AccountSessionDecryptError]
+        (если нужен отказоустойчивый вариант, фильтрующий битые аккаунты, см.
+        :meth:`get_live_usable_accounts`). Порядок: primary первым, затем по id.
+        """
         sql = "SELECT * FROM accounts"
         if active_only:
             sql += " WHERE is_active = 1"
@@ -326,12 +375,17 @@ class AccountsRepository:
         return accounts
 
     async def update_account_flood(self, phone: str, until: datetime | None) -> None:
+        """Записать (или снять через ``None``) момент окончания Telegram FLOOD_WAIT для аккаунта.
+
+        `ClientPool` пропускает аккаунты, у которых ``flood_wait_until`` ещё в будущем.
+        """
         await self._database.execute_write(
             "UPDATE accounts SET flood_wait_until = ? WHERE phone = ?",
             (until.isoformat() if until else None, phone),
         )
 
     async def update_account_premium(self, phone: str, is_premium: bool) -> None:
+        """Обновить флаг Telegram Premium у аккаунта (нужен для premium-only операций)."""
         await self._database.execute_write(
             "UPDATE accounts SET is_premium = ? WHERE phone = ?",
             (int(is_premium), phone),
@@ -359,6 +413,12 @@ class AccountsRepository:
         )
 
     async def set_account_active(self, account_id: int, active: bool) -> None:
+        """Включить/выключить аккаунт, поддерживая инвариант single-primary (#733).
+
+        При активации — назначает primary, если ни одного нет. При деактивации
+        текущего primary — снимает флаг и продвигает на роль primary самый ранний
+        оставшийся активный аккаунт (если активных не осталось, primary временно нет).
+        """
         assert self._database is not None, (
             "AccountsRepository.set_account_active requires a Database reference"
         )
@@ -411,6 +471,7 @@ class AccountsRepository:
         return True
 
     async def delete_account(self, account_id: int) -> None:
+        """Удалить аккаунт; если удалён был primary — продвинуть на его роль самый ранний оставшийся (#733)."""
         assert self._database is not None, (
             "AccountsRepository.delete_account requires a Database reference"
         )

--- a/src/database/repositories/channel_ratings.py
+++ b/src/database/repositories/channel_ratings.py
@@ -14,6 +14,15 @@ if TYPE_CHECKING:
 
 
 class ChannelRatingsRepository:
+    """Двухосевые вердикты о каналах (полезность × жанр), один на канал (#966).
+
+    Хранит результат [`ChannelRating`][src.models.ChannelRating]: машинная
+    классификация (useful/genre/confidence/reason + emoji-trash) плюс
+    человеческий сигнал `flag_count`. Запись — upsert по `channel_id`, при этом
+    `flag_count` намеренно НЕ затирается машинной переклассификацией (она строит
+    строку с flag_count=0) — ручной аудит важнее.
+    """
+
     def __init__(self, db: aiosqlite.Connection, *, database: "Database | None" = None):
         self._db = db
         self._database = database
@@ -39,6 +48,11 @@ class ChannelRatingsRepository:
         )
 
     async def upsert(self, rating: ChannelRating) -> None:
+        """Сохранить/обновить вердикт по каналу (по `channel_id`).
+
+        `flag_count` сохраняется из существующей строки, а не из переданного
+        рейтинга — машинная переклассификация не должна сбрасывать ручные флаги.
+        """
         now = (rating.updated_at or datetime.now(tz=timezone.utc)).isoformat()
         await self._database.execute_write(
             "INSERT INTO channel_ratings "
@@ -70,6 +84,7 @@ class ChannelRatingsRepository:
         )
 
     async def get(self, channel_id: int) -> ChannelRating | None:
+        """Вердикт по каналу, либо None если канал ещё не классифицирован."""
         cur = await self._db.execute(
             "SELECT * FROM channel_ratings WHERE channel_id = ?", (channel_id,)
         )
@@ -84,6 +99,7 @@ class ChannelRatingsRepository:
         limit: int = 100,
         offset: int = 0,
     ) -> list[ChannelRating]:
+        """Список вердиктов с опциональным фильтром по useful/genre, по убыванию confidence."""
         where: list[str] = []
         params: list[object] = []
         if useful is not None:
@@ -102,6 +118,7 @@ class ChannelRatingsRepository:
         return [self._to_rating(r) for r in await cur.fetchall()]
 
     async def count(self) -> int:
+        """Сколько каналов уже имеют вердикт."""
         cur = await self._db.execute("SELECT COUNT(*) AS c FROM channel_ratings")
         row = await cur.fetchone()
         return row["c"] if row else 0

--- a/src/database/repositories/channel_stats.py
+++ b/src/database/repositories/channel_stats.py
@@ -1,3 +1,5 @@
+"""Репозиторий истории метрик каналов (подписчики, средние просмотры/реакции)."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -12,6 +14,13 @@ if TYPE_CHECKING:
 
 
 class ChannelStatsRepository:
+    """История метрик каналов: подписчики, средние просмотры/реакции/репосты.
+
+    Каждое измерение — отдельная строка с `collected_at` (append-only history),
+    поэтому возможны выборки последней записи, предыдущей и временных рядов для
+    оценки динамики роста канала.
+    """
+
     def __init__(
         self,
         db: aiosqlite.Connection,
@@ -22,6 +31,7 @@ class ChannelStatsRepository:
         self._database = database
 
     async def save_channel_stats(self, stats: ChannelStats) -> int:
+        """Добавить новое измерение метрик канала. Возвращает id новой строки."""
         cur = await self._database.execute_write(
             """INSERT INTO channel_stats
                (channel_id, subscriber_count, avg_views, avg_reactions, avg_forwards)
@@ -37,6 +47,7 @@ class ChannelStatsRepository:
         return cur.lastrowid or 0
 
     async def get_channel_stats(self, channel_id: int, limit: int = 1) -> list[ChannelStats]:
+        """Последние `limit` измерений метрик канала (новые сверху)."""
         cur = await self._db.execute(
             "SELECT * FROM channel_stats WHERE channel_id = ? "
             "ORDER BY collected_at DESC LIMIT ?",
@@ -57,6 +68,7 @@ class ChannelStatsRepository:
         ]
 
     async def get_latest_stats_for_all(self) -> dict[int, ChannelStats]:
+        """Карта `channel_id → самое свежее измерение метрик` по всем каналам."""
         cur = await self._db.execute("""WITH ranked AS (
                    SELECT *, ROW_NUMBER() OVER (
                        PARTITION BY channel_id ORDER BY collected_at DESC, id DESC

--- a/src/database/repositories/channels.py
+++ b/src/database/repositories/channels.py
@@ -1,3 +1,15 @@
+"""Репозиторий отслеживаемых каналов и их тегов (таблицы ``channels``/``tags``).
+
+Доступ через `db.repos.channels`. Хранит метаданные канала, флаги отслеживания
+(`is_active`), фильтрации (`is_filtered`/`filter_flags`) и карантина на ревью
+(`needs_review`), а также курсор инкрементального сбора (`last_collected_id`).
+
+Конвенция ключей (CLAUDE.md): сторонние таблицы соединяются по Telegram
+``channel_id``, а DB-первичный ключ ``id`` (он же ``pk``) используется только в
+адресных операциях над самой строкой канала (`*_by_pk`, set/delete). Параметр с
+именем ``pk`` — это ``channels.id``, ``channel_id`` — Telegram-идентификатор.
+"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -12,6 +24,8 @@ if TYPE_CHECKING:
 
 
 class ChannelsRepository:
+    """CRUD каналов: метаданные, флаги отслеживания/фильтрации/ревью и теги."""
+
     def __init__(
         self,
         db: aiosqlite.Connection,
@@ -22,6 +36,17 @@ class ChannelsRepository:
         self._database = database
 
     async def add_channel(self, channel: Channel) -> int:
+        """Добавить канал или обновить существующий по Telegram ``channel_id`` (UPSERT); вернуть pk.
+
+        При конфликте обновляет метаданные, но сохраняет уже накопленные
+        ``about``/``linked_chat_id``/``created_at`` (COALESCE — не затирает их
+        значениями NULL из частичного апдейта).
+
+        Возвращает `cur.lastrowid`: надёжный pk только на ветке вставки; при
+        конфликте-обновлении lastrowid остаётся от последней вставки в
+        соединении — для гарантированного pk существующего канала читайте его по
+        ``channel_id`` (например `get_channel_by_channel_id`).
+        """
         cur = await self._database.execute_write(
             """INSERT INTO channels (channel_id, title, username, channel_type, is_active,
                                      about, linked_chat_id, has_comments, created_at)
@@ -90,6 +115,8 @@ class ChannelsRepository:
     async def get_channels(
         self, active_only: bool = False, include_filtered: bool = True
     ) -> list[Channel]:
+        """Каналы по возрастанию pk; ``active_only`` — только активные,
+        ``include_filtered=False`` скрывает отфильтрованные."""
         conditions = []
         if active_only:
             conditions.append("is_active = 1")
@@ -104,6 +131,7 @@ class ChannelsRepository:
         return [self._map_channel(r) for r in rows]
 
     async def get_channel_by_pk(self, pk: int) -> Channel | None:
+        """Канал по DB-первичному ключу (``channels.id``), либо ``None``."""
         cur = await self._db.execute("SELECT * FROM channels WHERE id = ?", (pk,))
         row = await cur.fetchone()
         if not row:
@@ -111,6 +139,7 @@ class ChannelsRepository:
         return self._map_channel(row)
 
     async def get_channel_by_channel_id(self, channel_id: int) -> Channel | None:
+        """Канал по Telegram ``channel_id``, либо ``None``."""
         cur = await self._db.execute(
             "SELECT * FROM channels WHERE channel_id = ?",
             (channel_id,),
@@ -123,6 +152,10 @@ class ChannelsRepository:
     async def get_channels_with_counts(
         self, active_only: bool = False, include_filtered: bool = True
     ) -> list[Channel]:
+        """Каналы вместе с числом сообщений (`message_count`); фильтры как у :meth:`get_channels`.
+
+        JOIN агрегата по ``channel_id`` (не по pk) — см. конвенцию ключей в docstring модуля.
+        """
         sql = """
             SELECT c.*, COALESCE(cnt.total, 0) AS message_count
             FROM channels c
@@ -145,6 +178,7 @@ class ChannelsRepository:
     async def count_channels(
         self, active_only: bool = False, include_filtered: bool = True
     ) -> int:
+        """Число каналов под теми же фильтрами, что и :meth:`get_channels`."""
         conditions = []
         if active_only:
             conditions.append("is_active = 1")
@@ -158,6 +192,7 @@ class ChannelsRepository:
         return row[0] if row else 0
 
     async def update_channel_last_id(self, channel_id: int, last_id: int) -> None:
+        """Продвинуть курсор инкрементального сбора (`last_collected_id`) — только вперёд (монотонно)."""
         await self._database.execute_write(
             """
             UPDATE channels
@@ -171,6 +206,7 @@ class ChannelsRepository:
         )
 
     async def set_channel_active(self, pk: int, active: bool) -> None:
+        """Включить/выключить отслеживание канала (неактивный не собирается)."""
         await self._database.execute_write("UPDATE channels SET is_active = ? WHERE id = ?", (int(active), pk))
 
     async def set_channel_review(self, pk: int, reason: str) -> None:
@@ -196,6 +232,7 @@ class ChannelsRepository:
         return [self._map_channel(row) for row in rows]
 
     async def set_channel_filtered(self, pk: int, filtered: bool) -> None:
+        """Ручная (раз)фильтрация канала: ставит/снимает ``is_filtered`` с флагом ``filter_flags='manual'``."""
         assert self._database is not None, (
             "ChannelsRepository.set_channel_filtered requires a Database reference"
         )
@@ -213,6 +250,12 @@ class ChannelsRepository:
     async def set_filtered_bulk(
         self, updates: list[tuple[int, str]], *, commit: bool = True
     ) -> int:
+        """Массово пометить каналы отфильтрованными по ``(channel_id, flags_csv)``; вернуть число изменённых строк.
+
+        С ``commit=True`` владеет транзакцией сам (#569); с ``commit=False`` пишет
+        на write-соединение внутри уже открытой транзакции вызывающего — см.
+        комментарий в теле о write- против read-пула (#760).
+        """
         if not updates:
             return 0
         # When commit=False, the caller already holds a Database.transaction()
@@ -251,6 +294,7 @@ class ChannelsRepository:
         return updated_rows
 
     async def reset_all_filters(self, *, commit: bool = True) -> int:
+        """Снять фильтрацию со всех каналов; вернуть число снятых. ``commit`` — как в :meth:`set_filtered_bulk`."""
         if commit:
             assert self._database is not None, (
                 "ChannelsRepository.reset_all_filters requires a Database reference "
@@ -268,6 +312,7 @@ class ChannelsRepository:
         return rowcount if rowcount > 0 else 0
 
     async def reset_filters_for_pks(self, pks: list[int], *, commit: bool = True) -> int:
+        """Снять фильтрацию только с указанных pk; вернуть число снятых. ``commit`` как в :meth:`set_filtered_bulk`."""
         if not pks:
             return 0
         placeholders = ",".join("?" * len(pks))
@@ -290,6 +335,7 @@ class ChannelsRepository:
         return rowcount if rowcount > 0 else 0
 
     async def set_channel_type(self, channel_id: int, channel_type: str) -> None:
+        """Обновить тип канала (channel/supergroup/group/…) по Telegram ``channel_id``."""
         await self._database.execute_write(
             "UPDATE channels SET channel_type=? WHERE channel_id=?",
             (channel_type, channel_id),
@@ -298,6 +344,7 @@ class ChannelsRepository:
     async def update_channel_meta(
         self, channel_id: int, *, username: str | None, title: str | None
     ) -> None:
+        """Обновить username и title канала (после переименования/смены @username)."""
         await self._database.execute_write(
             "UPDATE channels SET username = ?, title = ? WHERE channel_id = ?",
             (username, title, channel_id),
@@ -306,6 +353,7 @@ class ChannelsRepository:
     async def update_channel_full_meta(
         self, channel_id: int, *, about: str | None, linked_chat_id: int | None, has_comments: bool
     ) -> None:
+        """Обновить расширенные метаданные канала: описание, привязанный чат и наличие комментариев."""
         await self._database.execute_write(
             "UPDATE channels SET about = ?, linked_chat_id = ?, has_comments = ? WHERE channel_id = ?",
             (about, linked_chat_id, int(has_comments), channel_id),
@@ -338,6 +386,7 @@ class ChannelsRepository:
         )
 
     async def get_forum_topics(self, channel_id: int) -> list[dict]:
+        """Темы форум-супергруппы как ``[{"id", "title"}]``, по возрастанию topic_id."""
         cur = await self._db.execute(
             "SELECT topic_id, title FROM forum_topics WHERE channel_id = ? ORDER BY topic_id",
             (channel_id,),
@@ -346,6 +395,7 @@ class ChannelsRepository:
         return [{"id": row["topic_id"], "title": row["title"]} for row in rows]
 
     async def upsert_forum_topics(self, channel_id: int, topics: list[dict]) -> None:
+        """Полностью заменить список тем форума канала на ``topics`` (delete-then-insert в одной транзакции)."""
         assert self._database is not None, (
             "ChannelsRepository.upsert_forum_topics requires a Database reference"
         )
@@ -359,6 +409,14 @@ class ChannelsRepository:
                 )
 
     async def delete_channel(self, pk: int) -> None:
+        """Жёстко удалить канал и все его сайдкар-данные одной атомарной транзакцией (#569/#1039).
+
+        Чистит сообщения, оба стора эмбеддингов, статистику, темы и леджеры
+        (reactions каскадом, rename/rating/notified/action_log явно), чтобы не
+        осталось сирот, указывающих на исчезнувший канал. Поднимает
+        ``IntegrityError``, если на канал ссылается ``pipeline_sources``
+        (RESTRICT FK) — тогда удаление откатывается целиком.
+        """
         # Atomic delete via the connection-wide write lock + BEGIN
         # IMMEDIATE (issue #569). The only RESTRICT FK on `channels` is
         # `pipeline_sources.channel_id` (src/database/schema.py:326);
@@ -443,19 +501,23 @@ class ChannelsRepository:
     # ── Tag helpers ──────────────────────────────────────────────────────────
 
     async def list_all_tags(self) -> list[str]:
+        """Все существующие имена тегов, отсортированные по алфавиту."""
         cur = await self._db.execute("SELECT name FROM tags ORDER BY name")
         return [row["name"] for row in await cur.fetchall()]
 
     async def create_tag(self, name: str) -> None:
+        """Создать тег по имени (пустое игнорируется, дубликат — no-op через INSERT OR IGNORE)."""
         name = name.strip()
         if not name:
             return
         await self._database.execute_write("INSERT OR IGNORE INTO tags (name) VALUES (?)", (name,))
 
     async def delete_tag(self, name: str) -> None:
+        """Удалить тег по имени (связи каналов с ним уходят каскадом по FK)."""
         await self._database.execute_write("DELETE FROM tags WHERE name = ?", (name,))
 
     async def get_channel_tags(self, channel_pk: int) -> list[str]:
+        """Имена тегов, присвоенных каналу (по его pk), по алфавиту."""
         cur = await self._db.execute(
             """SELECT t.name FROM tags t
                JOIN channel_tags ct ON ct.tag_id = t.id
@@ -466,6 +528,7 @@ class ChannelsRepository:
         return [row["name"] for row in await cur.fetchall()]
 
     async def set_channel_tags(self, channel_pk: int, tag_names: list[str]) -> None:
+        """Полностью заменить набор тегов канала на ``tag_names`` (недостающие теги создаются), одной транзакцией."""
         assert self._database is not None, (
             "ChannelsRepository.set_channel_tags requires a Database reference"
         )
@@ -481,6 +544,7 @@ class ChannelsRepository:
                 )
 
     async def get_channels_by_tag(self, tag: str) -> list[Channel]:
+        """Каналы, помеченные данным тегом, по возрастанию pk."""
         cur = await self._db.execute(
             """SELECT c.* FROM channels c
                JOIN channel_tags ct ON ct.channel_pk = c.id

--- a/src/database/repositories/collection_tasks.py
+++ b/src/database/repositories/collection_tasks.py
@@ -1,3 +1,17 @@
+"""Репозиторий фоновых задач (таблица ``collection_tasks``).
+
+Доступ через `db.repos.tasks`. Одна таблица обслуживает несколько видов работы:
+сбор каналов (CHANNEL_COLLECT, тянет `CollectionQueue`), периодические
+служебные задачи (STATS_ALL, FILTER_ANALYZE) и «генерические» задачи диспетчера
+(PIPELINE_RUN, CONTENT_*, EXPORT…, тянет `UnifiedDispatcher`). Payload хранится
+как JSON и десериализуется в типизированную модель по полю ``task_kind``.
+
+Многие методы устойчивы к гонкам и сбоям: атомарный claim через UPDATE…RETURNING,
+создание «если нет активной» через INSERT…WHERE NOT EXISTS, восстановление
+зависших RUNNING-задач на старте, и защита терминального CANCELLED от перезаписи
+запоздалым апдейтом воркера (#633).
+"""
+
 from __future__ import annotations
 
 import json
@@ -37,6 +51,8 @@ if TYPE_CHECKING:
 
 
 class CollectionTasksRepository:
+    """CRUD и атомарные переходы статусов фоновых задач (`collection_tasks`)."""
+
     def __init__(
         self,
         db: aiosqlite.Connection,
@@ -153,6 +169,11 @@ class CollectionTasksRepository:
         payload: dict[str, Any] | None = None,
         parent_task_id: int | None = None,
     ) -> int:
+        """Поставить задачу сбора канала (CHANNEL_COLLECT); вернуть её id.
+
+        ``run_after`` откладывает запуск (хранится в UTC); если нужна дедупликация
+        по уже активной задаче канала — см. :meth:`create_collection_task_if_not_active`.
+        """
         run_after_iso = run_after.astimezone(timezone.utc).isoformat() if run_after else None
         payload_json = self._serialize_payload(payload)
         cur = await self._database.execute_write(
@@ -222,6 +243,7 @@ class CollectionTasksRepository:
         run_after: datetime | None = None,
         parent_task_id: int | None = None,
     ) -> int:
+        """Поставить задачу обновления статистики всех каналов (STATS_ALL); вернуть её id."""
         run_after_iso = run_after.astimezone(timezone.utc).isoformat() if run_after else None
         cur = await self._database.execute_write(
             "INSERT INTO collection_tasks "
@@ -270,6 +292,7 @@ class CollectionTasksRepository:
         return None
 
     async def get_active_filter_analyze_task(self) -> CollectionTask | None:
+        """Самая ранняя активная (pending/running) задача анализа фильтров, либо ``None``."""
         cur = await self._db.execute(
             "SELECT * FROM collection_tasks "
             "WHERE task_type = ? AND status IN (?, ?) "
@@ -286,6 +309,7 @@ class CollectionTasksRepository:
         return self._to_task(row)
 
     async def get_latest_filter_analyze_task(self) -> CollectionTask | None:
+        """Самая последняя (по id) задача анализа фильтров в любом статусе, либо ``None``."""
         cur = await self._db.execute(
             "SELECT * FROM collection_tasks WHERE task_type = ? ORDER BY id DESC LIMIT 1",
             (CollectionTaskType.FILTER_ANALYZE.value,),
@@ -296,6 +320,7 @@ class CollectionTasksRepository:
         return self._to_task(row)
 
     async def update_collection_task_progress(self, task_id: int, messages_collected: int) -> None:
+        """Записать прогресс задачи (число собранных сообщений) и обновить «часы прогресса» (`last_progress_at`)."""
         now = datetime.now(tz=timezone.utc).isoformat()
         await self._database.execute_write(
             "UPDATE collection_tasks SET messages_collected = ?, last_progress_at = ? WHERE id = ?",
@@ -386,6 +411,10 @@ class CollectionTasksRepository:
         note: str | None = None,
         messages_collected: int = 0,
     ) -> None:
+        """Вернуть задачу в PENDING с новым ``run_after`` (отложить и сбросить отметки выполнения).
+
+        Терминальный CANCELLED не трогается (#633).
+        """
         sets = [
             "status = ?",
             "run_after = ?",
@@ -418,6 +447,7 @@ class CollectionTasksRepository:
         *,
         note: str | None = None,
     ) -> None:
+        """Сбросить задачу в PENDING немедленно, очистив отметки выполнения; CANCELLED не трогается."""
         sets = [
             "status = ?",
             "started_at = NULL",
@@ -439,6 +469,7 @@ class CollectionTasksRepository:
         )
 
     async def get_collection_task(self, task_id: int) -> CollectionTask | None:
+        """Одна задача по id, либо ``None`` если такой нет."""
         cur = await self._db.execute("SELECT * FROM collection_tasks WHERE id = ?", (task_id,))
         row = await cur.fetchone()
         if row is None:
@@ -446,6 +477,10 @@ class CollectionTasksRepository:
         return self._to_task(row)
 
     async def get_collection_tasks(self, limit: int = 20) -> list[CollectionTask]:
+        """Последние ``limit`` задач любого типа, новые первыми.
+
+        Без постраничности — для неё см. :meth:`get_collection_tasks_paginated`.
+        """
         cur = await self._db.execute(
             "SELECT * FROM collection_tasks ORDER BY id DESC LIMIT ?", (limit,)
         )
@@ -502,6 +537,7 @@ class CollectionTasksRepository:
         self,
         channel_id: int,
     ) -> list[CollectionTask]:
+        """Активные (pending/running) задачи сбора для конкретного канала, по возрастанию id."""
         cur = await self._db.execute(
             "SELECT * FROM collection_tasks "
             "WHERE task_type = ? AND channel_id = ? AND status IN (?, ?) "
@@ -517,6 +553,7 @@ class CollectionTasksRepository:
         return [self._to_task(r) for r in rows]
 
     async def get_channel_ids_with_active_tasks(self) -> set[int]:
+        """Множество ``channel_id``, по которым есть активная задача сбора (для дедупликации постановки)."""
         cur = await self._db.execute(
             "SELECT DISTINCT channel_id FROM collection_tasks "
             "WHERE task_type = ? AND status IN (?, ?) AND channel_id IS NOT NULL",
@@ -530,6 +567,7 @@ class CollectionTasksRepository:
         return {int(row["channel_id"]) for row in rows}
 
     async def get_active_stats_task(self) -> CollectionTask | None:
+        """Самая ранняя активная (pending/running) задача обновления статистики, либо ``None``."""
         cur = await self._db.execute(
             "SELECT * FROM collection_tasks "
             "WHERE task_type = ? AND status IN (?, ?) "
@@ -569,6 +607,7 @@ class CollectionTasksRepository:
         )
 
     async def get_pending_channel_tasks(self) -> list[CollectionTask]:
+        """Ожидающие (pending) задачи сбора в порядке готовности к запуску (по ``run_after``, затем id)."""
         cur = await self._db.execute(
             "SELECT * FROM collection_tasks "
             "WHERE task_type = ? AND status = ? "
@@ -582,6 +621,7 @@ class CollectionTasksRepository:
         return [self._to_task(r) for r in rows]
 
     async def delete_pending_channel_tasks(self) -> int:
+        """Удалить все ожидающие задачи сбора (очистить очередь); вернуть число удалённых."""
         cur = await self._database.execute_write(
             "DELETE FROM collection_tasks "
             "WHERE task_type = ? AND status = ?",
@@ -593,6 +633,11 @@ class CollectionTasksRepository:
         return cur.rowcount or 0
 
     async def fail_running_collection_tasks_on_startup(self) -> int:
+        """На старте пометить «провисшие» RUNNING-задачи сбора как failed; вернуть число помеченных.
+
+        Вариант, требующий ручного перезапуска; см. :meth:`reset_orphaned_running_tasks`,
+        который вместо этого возвращает их в PENDING для авто-восстановления.
+        """
         now = datetime.now(tz=timezone.utc).isoformat()
         cur = await self._database.execute_write(
             "UPDATE collection_tasks "
@@ -643,6 +688,7 @@ class CollectionTasksRepository:
         run_after: datetime | None = None,
         parent_task_id: int | None = None,
     ) -> int:
+        """Поставить «генерическую» задачу диспетчера (PIPELINE_RUN, CONTENT_*, EXPORT…); вернуть её id."""
         tt = task_type
         task_type_value = tt.value if isinstance(tt, CollectionTaskType) else tt
         run_after_iso = run_after.astimezone(timezone.utc).isoformat() if run_after else None
@@ -666,6 +712,12 @@ class CollectionTasksRepository:
     async def claim_next_due_generic_task(
         self, now: datetime, handled_types: list[str]
     ) -> CollectionTask | None:
+        """Атомарно захватить следующую готовую задачу из ``handled_types``, переведя её в RUNNING.
+
+        Один UPDATE…RETURNING исключает гонку двух воркеров за одну задачу. Берётся
+        самая ранняя PENDING с наступившим ``run_after``; возвращает ``None``, если
+        готовых нет или список типов пуст.
+        """
         if not handled_types:
             return None
         assert self._database is not None, (
@@ -693,6 +745,7 @@ class CollectionTasksRepository:
     async def requeue_running_generic_tasks_on_startup(
         self, now: datetime, handled_types: list[str]
     ) -> int:
+        """На старте вернуть зависшие RUNNING генерические задачи в PENDING (авто-восстановление); вернуть число."""
         if not handled_types:
             return 0
         now_iso = now.astimezone(timezone.utc).isoformat()
@@ -713,6 +766,7 @@ class CollectionTasksRepository:
         error: str,
         note: str | None = None,
     ) -> int:
+        """На старте пометить зависшие RUNNING генерические задачи как failed с заданным ``error``; вернуть число."""
         if not handled_types:
             return 0
         now_iso = now.astimezone(timezone.utc).isoformat()
@@ -741,6 +795,12 @@ class CollectionTasksRepository:
         payload_filter_key: str | None = None,
         payload_filter_value: str | int | None = None,
     ) -> bool:
+        """Есть ли активная (pending/running) задача данного типа.
+
+        Необязательный фильтр по полю payload (``sq_id``/``pipeline_id`` —
+        только из белого списка, иначе ``ValueError``) сужает проверку до
+        конкретной сущности, например «уже идёт генерация этого пайплайна».
+        """
         tt = task_type
         task_type_value = tt.value if isinstance(tt, CollectionTaskType) else tt
         sql = (
@@ -762,6 +822,11 @@ class CollectionTasksRepository:
         return (row["cnt"] if row else 0) > 0
 
     async def cancel_collection_task(self, task_id: int, note: str | None = None) -> bool:
+        """Отменить активную (pending/running) задачу; вернуть ``True``, если что-то отменили.
+
+        Терминальные задачи не трогаются (WHERE по статусу), поэтому ``False``
+        означает «нечего было отменять».
+        """
         now = datetime.now(tz=timezone.utc).isoformat()
         sets = ["status = 'cancelled'", "completed_at = ?"]
         params: list[Any] = [now]

--- a/src/database/repositories/content_pipelines.py
+++ b/src/database/repositories/content_pipelines.py
@@ -1,3 +1,12 @@
+"""Репозиторий контент-пайплайнов и их связей источник/цель.
+
+Доступ через `db.repos.content_pipelines`. Хранит сам пайплайн
+(`content_pipelines` — промпт, модели, режим публикации, DAG `pipeline_json`,
+A/B-настройки) и две дочерние таблицы: `pipeline_sources` (каналы-источники,
+по channel_id) и `pipeline_targets` (диалоги-получатели публикации). Источники и
+цели всегда заменяются целиком в одной транзакции с самим пайплайном.
+"""
+
 from __future__ import annotations
 
 import json
@@ -23,6 +32,8 @@ logger = logging.getLogger(__name__)
 
 
 class ContentPipelinesRepository:
+    """CRUD контент-пайплайнов вместе с их источниками и целями публикации."""
+
     def __init__(
         self,
         db: aiosqlite.Connection,
@@ -108,6 +119,7 @@ class ContentPipelinesRepository:
         source_channel_ids: list[int],
         targets: list[PipelineTarget],
     ) -> int:
+        """Создать пайплайн вместе с его источниками и целями (одной транзакцией); вернуть новый id."""
         assert self._database is not None, (
             "ContentPipelinesRepository.add requires a Database reference"
         )
@@ -144,6 +156,7 @@ class ContentPipelinesRepository:
             return pipeline_id
 
     async def get_all(self, active_only: bool = False) -> list[ContentPipeline]:
+        """Все пайплайны по возрастанию id; с ``active_only`` — только активные."""
         sql = "SELECT * FROM content_pipelines"
         params: tuple[object, ...] = ()
         if active_only:
@@ -153,6 +166,7 @@ class ContentPipelinesRepository:
         return [self._to_pipeline(row) for row in await cur.fetchall()]
 
     async def get_by_id(self, pipeline_id: int) -> ContentPipeline | None:
+        """Один пайплайн по id, либо ``None`` если такого нет."""
         cur = await self._db.execute(
             "SELECT * FROM content_pipelines WHERE id = ?",
             (pipeline_id,),
@@ -161,6 +175,7 @@ class ContentPipelinesRepository:
         return self._to_pipeline(row) if row else None
 
     async def update_generate_interval(self, pipeline_id: int, minutes: int) -> None:
+        """Изменить интервал автогенерации (в минутах) для пайплайна."""
         await self._database.execute_write(
             "UPDATE content_pipelines SET generate_interval_minutes = ? WHERE id = ?",
             (minutes, pipeline_id),
@@ -173,6 +188,11 @@ class ContentPipelinesRepository:
         source_channel_ids: list[int],
         targets: list[PipelineTarget],
     ) -> bool:
+        """Полностью обновить пайплайн и заменить его источники/цели (одной транзакцией).
+
+        Возвращает ``False``, если пайплайна с таким id нет (поля ``last_generated_id``
+        и ``refinement_steps`` тут не трогаются — для них есть отдельные сеттеры).
+        """
         assert self._database is not None, (
             "ContentPipelinesRepository.update requires a Database reference"
         )
@@ -218,12 +238,14 @@ class ContentPipelinesRepository:
         return True
 
     async def set_refinement_steps(self, pipeline_id: int, steps: list[dict]) -> None:
+        """Сохранить шаги доработки текста (список ``{name, prompt}``) для пайплайна как JSON."""
         await self._database.execute_write(
             "UPDATE content_pipelines SET refinement_steps = ? WHERE id = ?",
             (json.dumps(steps, ensure_ascii=False), pipeline_id),
         )
 
     async def set_pipeline_json(self, pipeline_id: int, graph: PipelineGraph | None) -> None:
+        """Сохранить (или очистить через ``None``) DAG-конфигурацию пайплайна (issue #343)."""
         value = graph.to_json() if graph else None
         await self._database.execute_write(
             "UPDATE content_pipelines SET pipeline_json = ? WHERE id = ?",
@@ -231,21 +253,25 @@ class ContentPipelinesRepository:
         )
 
     async def set_active(self, pipeline_id: int, active: bool) -> None:
+        """Включить/выключить пайплайн (неактивный не запускается планировщиком)."""
         await self._database.execute_write(
             "UPDATE content_pipelines SET is_active = ? WHERE id = ?",
             (int(active), pipeline_id),
         )
 
     async def set_last_generated_id(self, pipeline_id: int, value: int) -> None:
+        """Сдвинуть курсор последнего обработанного сообщения-источника (инкрементальная генерация)."""
         await self._database.execute_write(
             "UPDATE content_pipelines SET last_generated_id = ? WHERE id = ?",
             (value, pipeline_id),
         )
 
     async def delete(self, pipeline_id: int) -> None:
+        """Удалить пайплайн по id (источники/цели уходят каскадом по FK)."""
         await self._database.execute_write("DELETE FROM content_pipelines WHERE id = ?", (pipeline_id,))
 
     async def list_sources(self, pipeline_id: int) -> list[PipelineSource]:
+        """Каналы-источники пайплайна (`pipeline_sources`), по возрастанию id."""
         cur = await self._db.execute(
             "SELECT * FROM pipeline_sources WHERE pipeline_id = ? ORDER BY id",
             (pipeline_id,),
@@ -253,6 +279,7 @@ class ContentPipelinesRepository:
         return [self._to_source(row) for row in await cur.fetchall()]
 
     async def list_targets(self, pipeline_id: int) -> list[PipelineTarget]:
+        """Цели публикации пайплайна (`pipeline_targets`), по возрастанию id."""
         cur = await self._db.execute(
             "SELECT * FROM pipeline_targets WHERE pipeline_id = ? ORDER BY id",
             (pipeline_id,),

--- a/src/database/repositories/dialog_cache.py
+++ b/src/database/repositories/dialog_cache.py
@@ -1,3 +1,5 @@
+"""Репозиторий кэша диалогов Telegram по аккаунту (снимок для UI без обращения к TG)."""
+
 from __future__ import annotations
 
 from datetime import datetime, timezone
@@ -12,6 +14,14 @@ if TYPE_CHECKING:
 
 
 class DialogCacheRepository:
+    """Кэш диалогов Telegram по аккаунту (`phone`).
+
+    Хранит снимок списка диалогов (id, название, username, тип, флаги
+    deactivate/is_own), чтобы web/CLI показывали диалоги без обращения к
+    Telegram. Записывается воркером целиком (`replace_dialogs` — атомарная
+    замена всех строк телефона), читается остальными слоями.
+    """
+
     def __init__(
         self,
         db: aiosqlite.Connection,
@@ -22,6 +32,7 @@ class DialogCacheRepository:
         self._database = database
 
     async def get_dialog(self, phone: str, dialog_id: int) -> dict | None:
+        """Один кэшированный диалог аккаунта по его id, либо None."""
         cur = await self._db.execute(
             """
             SELECT dialog_id, title, username, channel_type, deactivate, is_own
@@ -44,6 +55,7 @@ class DialogCacheRepository:
         }
 
     async def list_dialogs(self, phone: str) -> list[dict]:
+        """Все кэшированные диалоги аккаунта в порядке их сохранения."""
         cur = await self._db.execute(
             """
             SELECT dialog_id, title, username, channel_type, deactivate, is_own
@@ -67,6 +79,12 @@ class DialogCacheRepository:
         ]
 
     async def replace_dialogs(self, phone: str, dialogs: list[dict]) -> None:
+        """Атомарно заменить весь кэш диалогов аккаунта новым снимком.
+
+        Под транзакцией удаляет прежние строки телефона и вставляет переданные,
+        проставляя `cached_at`. Так кэш всегда консистентен — без частично
+        обновлённого состояния.
+        """
         assert self._database is not None, (
             "DialogCacheRepository.replace_dialogs requires a Database reference"
         )
@@ -97,9 +115,11 @@ class DialogCacheRepository:
                 )
 
     async def clear_dialogs(self, phone: str) -> None:
+        """Удалить кэш диалогов одного аккаунта."""
         await self._database.execute_write("DELETE FROM dialog_cache WHERE phone = ?", (phone,))
 
     async def has_dialogs(self, phone: str) -> bool:
+        """True, если для аккаунта есть хотя бы один кэшированный диалог."""
         cur = await self._db.execute(
             "SELECT 1 FROM dialog_cache WHERE phone = ? LIMIT 1",
             (phone,),
@@ -107,6 +127,7 @@ class DialogCacheRepository:
         return bool(await cur.fetchone())
 
     async def get_cached_at(self, phone: str) -> datetime | None:
+        """Время самого свежего кэшированного диалога аккаунта (для оценки устаревания)."""
         cur = await self._db.execute(
             "SELECT MAX(cached_at) AS cached_at FROM dialog_cache WHERE phone = ?",
             (phone,),

--- a/src/database/repositories/filters.py
+++ b/src/database/repositories/filters.py
@@ -1,3 +1,5 @@
+"""Репозиторий аггрегатных метрик каналов для фильтрации качества (ChannelAnalyzer)."""
+
 from __future__ import annotations
 
 import asyncio
@@ -105,6 +107,16 @@ if TYPE_CHECKING:
 
 
 class FilterRepository:
+    """Аггрегатные выборки для `ChannelAnalyzer`: метрики качества каналов.
+
+    Считает по сообщениям/статистике карты признаков (уникальность, доля
+    коротких сообщений, кросс-канальные дубли, доля кириллицы, подписчики),
+    которыми анализатор отсеивает спам/низкокачественные каналы. Тяжёлые карты
+    можно считать параллельно на отдельных read-only соединениях
+    (`fetch_maps_parallel`) — это безопасно только для файловой БД, не `:memory:`.
+    Кириллица определяется через SQLite UDF `has_cyrillic`, регистрируемый лениво.
+    """
+
     def __init__(
         self,
         db: aiosqlite.Connection,
@@ -125,6 +137,7 @@ class FilterRepository:
     async def fetch_channels_for_analysis(
         self, channel_id: int | None = None
     ) -> list[aiosqlite.Row]:
+        """Базовые поля каналов + счётчик сообщений (все или один по channel_id)."""
         sql = _SQL_CHANNELS
         params: tuple = ()
         if channel_id is not None:
@@ -137,6 +150,10 @@ class FilterRepository:
     async def fetch_uniqueness_map(
         self, channel_id: int | None = None
     ) -> dict[int, tuple[int, int]]:
+        """Карта `channel_id → (всего сообщений, уникальных по префиксу текста)`.
+
+        Низкая доля уникальных — признак канала-репостера/спама.
+        """
         sql = _SQL_UNIQUENESS
         params: tuple = ()
         if channel_id is not None:
@@ -148,6 +165,7 @@ class FilterRepository:
         return {row["channel_id"]: (row["total"], row["uniq"]) for row in rows}
 
     async def fetch_subscriber_map(self, channel_id: int | None = None) -> dict[int, int]:
+        """Карта `channel_id → последнее известное число подписчиков` (по свежей записи stats)."""
         sql = _SQL_SUBSCRIBER_BASE
         params: tuple = ()
         if channel_id is not None:
@@ -164,6 +182,10 @@ class FilterRepository:
     async def fetch_short_message_map(
         self, channel_id: int | None = None
     ) -> dict[int, tuple[int, int]]:
+        """Карта `channel_id → (всего сообщений, из них коротких ≤10 символов)`.
+
+        Высокая доля коротких сообщений — признак чата-шума, а не контент-канала.
+        """
         sql = _SQL_SHORT_MESSAGE
         params: tuple = ()
         if channel_id is not None:
@@ -195,6 +217,11 @@ class FilterRepository:
     async def fetch_cross_dupe_map(
         self, channel_id: int | None = None
     ) -> dict[int, tuple[int, int]]:
+        """Карта `channel_id → (уникальных префиксов, из них встречаются в других каналах)`.
+
+        Доля кросс-канальных дублей выявляет агрегаторы/сетки, перепечатывающие
+        чужой контент. Это самый тяжёлый запрос (self-join по префиксам).
+        """
         sql = _SQL_CROSS_DUPE
         params: tuple = ()
         if channel_id is not None:
@@ -206,6 +233,10 @@ class FilterRepository:
         return {row["channel_id"]: (row["uniq_total"], row["duped"] or 0) for row in rows}
 
     async def fetch_cyrillic_map(self, channel_id: int | None = None) -> dict[int, tuple[int, int]]:
+        """Карта `channel_id → (всего сообщений, из них с кириллицей)` через UDF `has_cyrillic`.
+
+        Низкая доля кириллицы отсеивает иноязычные каналы для русскоязычного сбора.
+        """
         await self._ensure_udf()
         sql = _SQL_CYRILLIC
         params: tuple = ()

--- a/src/database/repositories/generated_images.py
+++ b/src/database/repositories/generated_images.py
@@ -1,3 +1,5 @@
+"""Репозиторий каталога сгенерированных изображений (промпт/модель/путь)."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -11,6 +13,11 @@ if TYPE_CHECKING:
 
 
 class GeneratedImagesRepository:
+    """Каталог сгенерированных изображений: промпт, модель, URL/локальный путь.
+
+    Append-only история результатов image-генерации для галереи и переиспользования.
+    """
+
     def __init__(
         self,
         db: aiosqlite.Connection,
@@ -32,6 +39,7 @@ class GeneratedImagesRepository:
         )
 
     async def save(self, prompt: str, model: str | None, image_url: str | None, local_path: str | None) -> int:
+        """Сохранить запись о сгенерированном изображении. Возвращает id новой строки."""
         cur = await self._database.execute_write(
             "INSERT INTO generated_images (prompt, model, image_url, local_path) VALUES (?, ?, ?, ?)",
             (prompt, model, image_url, local_path),
@@ -39,12 +47,14 @@ class GeneratedImagesRepository:
         return cur.lastrowid or 0
 
     async def list_recent(self, limit: int = 50) -> list[GeneratedImage]:
+        """Последние `limit` сгенерированных изображений (новые сверху)."""
         cur = await self._db.execute(
             "SELECT * FROM generated_images ORDER BY id DESC LIMIT ?", (limit,)
         )
         return [self._to_model(row) for row in await cur.fetchall()]
 
     async def get_by_id(self, image_id: int) -> GeneratedImage | None:
+        """Изображение по id, либо None."""
         cur = await self._db.execute(
             "SELECT * FROM generated_images WHERE id = ?", (image_id,)
         )

--- a/src/database/repositories/generation_runs.py
+++ b/src/database/repositories/generation_runs.py
@@ -1,3 +1,12 @@
+"""Репозиторий запусков генерации контента (таблица ``generation_runs``).
+
+Доступ через `db.repos.generation_runs`. Хранит жизненный цикл одного запуска
+пайплайна: сгенерированный текст/картинку, статус выполнения (status) и
+отдельный статус модерации (moderation_status: pending → approved/rejected →
+published, #1036), A/B-варианты и оценку качества. Запись идёт через
+locked-хелперы Database (execute_write/transaction).
+"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -13,6 +22,8 @@ if TYPE_CHECKING:
 
 
 class GenerationRunsRepository:
+    """CRUD и переходы статусов запусков генерации (`generation_runs`)."""
+
     def __init__(
         self,
         db: aiosqlite.Connection,
@@ -50,6 +61,7 @@ class GenerationRunsRepository:
         )
 
     async def create_run(self, pipeline_id: int | None, prompt: str) -> int:
+        """Создать запуск в статусе ``pending`` для пайплайна и промпта; вернуть его id."""
         cur = await self._database.execute_write(
             ("INSERT INTO generation_runs (pipeline_id, status, prompt, created_at) "
              "VALUES (?, 'pending', ?, datetime('now'))"),
@@ -58,6 +70,7 @@ class GenerationRunsRepository:
         return cur.lastrowid or 0
 
     async def set_status(self, run_id: int, status: str, metadata: dict | None = None) -> None:
+        """Обновить статус выполнения запуска; при переданном ``metadata`` — заодно перезаписать JSON-метаданные."""
         if metadata is not None:
             await self._database.execute_write(
                 ("UPDATE generation_runs SET status = ?, metadata = ?, "
@@ -73,6 +86,7 @@ class GenerationRunsRepository:
     async def save_result(
         self, run_id: int, generated_text: str, metadata: dict | None = None
     ) -> None:
+        """Сохранить сгенерированный текст и метаданные, переводя запуск в статус ``completed``."""
         await self._database.execute_write(
             ("UPDATE generation_runs SET generated_text = ?, metadata = ?, status = 'completed', "
              "updated_at = datetime('now') WHERE id = ?"),
@@ -123,6 +137,7 @@ class GenerationRunsRepository:
             )
 
     async def set_image_url(self, run_id: int, image_url: str) -> None:
+        """Привязать к запуску URL/путь сгенерированной картинки."""
         await self._database.execute_write(
             "UPDATE generation_runs SET image_url = ?, updated_at = datetime('now') WHERE id = ?",
             (image_url, run_id),
@@ -199,6 +214,14 @@ class GenerationRunsRepository:
             )
 
     async def set_published_at(self, run_id: int) -> None:
+        """Отметить запуск опубликованным: ставит ``published_at`` и ``moderation_status='published'`` атомарно.
+
+        Единственный путь, проставляющий ``published_at`` синхронно со статусом
+        ``published`` — используйте его, а не ручной
+        ``set_moderation_status('published')`` (тот пишет произвольную строку
+        статуса и ``published_at`` не трогает), иначе получите published-запуск
+        без отметки времени.
+        """
         await self._database.execute_write(
             ("UPDATE generation_runs SET published_at = datetime('now'), "
              "moderation_status = 'published', updated_at = datetime('now') WHERE id = ?"),
@@ -219,6 +242,7 @@ class GenerationRunsRepository:
     async def set_quality_score(
         self, run_id: int, score: float, issues: list[str] | None = None
     ) -> None:
+        """Сохранить оценку качества запуска и (опционально) список выявленных проблем."""
         issues_json = safe_json_dumps(issues, ensure_ascii=False) if issues else None
         await self._database.execute_write(
             ("UPDATE generation_runs SET quality_score = ?, quality_issues = ?, "
@@ -227,12 +251,18 @@ class GenerationRunsRepository:
         )
 
     async def set_variants(self, run_id: int, variants: list[str]) -> None:
+        """Сохранить список A/B-вариантов текста запуска (issue #1068)."""
         await self._database.execute_write(
             "UPDATE generation_runs SET variants = ?, updated_at = datetime('now') WHERE id = ?",
             (safe_json_dumps(variants, ensure_ascii=False), run_id),
         )
 
     async def select_variant(self, run_id: int, variant_index: int, generated_text: str) -> None:
+        """Сделать выбранный A/B-вариант финальным текстом запуска (issue #1068).
+
+        Заодно обнуляет ``quality_score``/``quality_issues`` — они относились к
+        прежнему тексту и были бы устаревшими (см. комментарий ниже).
+        """
         # Selecting a variant changes generated_text, so any existing
         # quality_score/quality_issues belong to the PREVIOUS text and would be
         # stale — a low-quality selected variant could otherwise hide behind a
@@ -253,6 +283,11 @@ class GenerationRunsRepository:
         limit: int = 50,
         offset: int = 0,
     ) -> list[GenerationRun]:
+        """Очередь модерации: запуски со статусом ``pending`` или ``approved``.
+
+        Это черновики и одобренные, но ещё не доставленные. Без ``pipeline_id`` —
+        по всем пайплайнам; страница задаётся ``limit``/``offset``, новые первыми.
+        """
         if pipeline_id is None:
             cur = await self._db.execute(
                 "SELECT * FROM generation_runs WHERE moderation_status IN ('pending', 'approved')"
@@ -276,6 +311,7 @@ class GenerationRunsRepository:
         return cur.rowcount or 0
 
     async def get(self, run_id: int) -> GenerationRun | None:
+        """Один запуск по id, либо ``None`` если такого нет."""
         cur = await self._db.execute("SELECT * FROM generation_runs WHERE id = ?", (run_id,))
         row = await cur.fetchone()
         if not row:
@@ -283,6 +319,7 @@ class GenerationRunsRepository:
         return self._to_generation_run(row)
 
     async def list_runs_for_calendar(self, days: int = 30) -> list[GenerationRun]:
+        """Запуски за последние ``days`` дней (для календаря контента), новые первыми."""
         cur = await self._db.execute(
             "SELECT * FROM generation_runs WHERE created_at >= date('now', ?) ORDER BY created_at DESC",
             (f"-{days} days",),
@@ -298,6 +335,8 @@ class GenerationRunsRepository:
         status: str | None = None,
         moderation_status: str | None = None,
     ) -> list[GenerationRun]:
+        """Запуски одного пайплайна, новые первыми; фильтры по ``status`` и
+        ``moderation_status`` опциональны, страница — ``limit``/``offset``."""
         where = "pipeline_id = ?"
         params: list[object] = [pipeline_id]
         if status:

--- a/src/database/repositories/messages.py
+++ b/src/database/repositories/messages.py
@@ -1,3 +1,18 @@
+"""Репозиторий сообщений: вставка, поиск (FTS/семантика/гибрид) и аналитика.
+
+Доступ через `db.repos.messages`. Самый горячий репозиторий проекта: пакетная
+вставка с дедупликацией по ``UNIQUE(channel_id, message_id)``, обновление
+изменяемых полей (реакции/просмотры) уже известных сообщений, три режима поиска
+(полнотекстовый FTS5 с LIKE-фолбэком, семантический по эмбеддингам, гибридный
+RRF) и агрегаты для аналитики по нормализованной таблице ``message_reactions``.
+
+Замечания по производительности: поиск отдаёт страницу с нижней оценкой total
+вместо точного ``COUNT(*)`` (см.
+[`MessageSearchPage`][src.database.repositories.messages.MessageSearchPage], #766);
+фильтр отсекает отфильтрованные каналы JOIN-ом на ``channels`` по ``channel_id``
+(конвенция ключей, CLAUDE.md).
+"""
+
 from __future__ import annotations
 
 import json
@@ -65,6 +80,8 @@ def _normalize_username(username: str | None) -> str | None:
 
 
 class MessagesRepository:
+    """Вставка, поиск и аналитика сообщений (`messages` + сайдкары реакций/эмбеддингов)."""
+
     def __init__(
         self,
         db: aiosqlite.Connection,
@@ -124,6 +141,7 @@ class MessagesRepository:
         )
 
     async def get_embedding_dimensions(self) -> int | None:
+        """Размерность векторов индекса эмбеддингов (из настроек), либо ``None`` если индекс ещё не создан."""
         raw_value = await self._get_setting(_EMBEDDING_DIMENSIONS_SETTING)
         if raw_value in (None, ""):
             return None
@@ -134,6 +152,7 @@ class MessagesRepository:
             return None
 
     async def count_embeddings(self) -> int:
+        """Число сохранённых эмбеддингов (0, если таблицы ещё нет)."""
         try:
             cur = await self._db.execute("SELECT COUNT(*) AS cnt FROM message_embeddings")
         except Exception:
@@ -142,6 +161,7 @@ class MessagesRepository:
         return int(row["cnt"]) if row else 0
 
     async def reset_embeddings_index(self) -> None:
+        """Полностью сбросить семантический индекс: оба стора эмбеддингов и их настройки (одной транзакцией с DDL)."""
         assert self._database is not None, (
             "MessagesRepository.reset_embeddings_index requires a Database reference"
         )
@@ -158,6 +178,12 @@ class MessagesRepository:
             )
 
     async def insert_message(self, msg: Message) -> bool:
+        """Вставить одно сообщение (дубликат по ключу обновляет изменяемые поля); вернуть ``True``, если строка новая.
+
+        Реакции апсёртятся в нормализованную таблицу. Транзиентную блокировку БД
+        пробрасывает наружу (не маскирует под «не сохранилось»), чтобы вызывающий
+        пересобрал заново.
+        """
         # Local import — see insert_messages_batch for the partial-init rationale.
         from src.database import DatabaseBusyError
 
@@ -253,6 +279,13 @@ class MessagesRepository:
     async def insert_messages_batch(
         self, messages: list[Message], premium_search_query: str | None = None
     ) -> int:
+        """Пакетно вставить сообщения (INSERT OR IGNORE), обновив уже известные и их реакции; вернуть число новых строк.
+
+        Дубликаты по ``UNIQUE(channel_id, message_id)`` пропускаются вставкой и
+        затем обновляются (просмотры/реакции/язык). ``premium_search_query`` тегирует
+        строки, добытые Premium-поиском (для последующей очистки). Транзиентная
+        блокировка пробрасывается наружу, как и в :meth:`insert_message`.
+        """
         if not messages:
             return 0
         data = [
@@ -425,6 +458,7 @@ class MessagesRepository:
             logger.error("Failed to refresh %d existing messages: %s", len(messages), exc)
 
     async def ensure_embeddings_table(self, dimensions: int) -> None:
+        """Зафиксировать размерность индекса эмбеддингов при первом вызове; несовпадение с существующей — ошибка."""
         if dimensions < 1:
             raise ValueError("Embedding dimensions must be positive.")
         existing_dimensions = await self.get_embedding_dimensions()
@@ -442,6 +476,7 @@ class MessagesRepository:
         after_id: int = 0,
         limit: int = 100,
     ) -> list[tuple[int, str]]:
+        """Страница ``(id, text)`` непустых сообщений после ``after_id`` для построения эмбеддингов (курсор по id)."""
         cur = await self._db.execute(
             """
             SELECT id, text
@@ -457,6 +492,10 @@ class MessagesRepository:
         return [(int(row["id"]), str(row["text"])) for row in rows]
 
     async def upsert_message_embeddings(self, embeddings: list[tuple[int, list[float]]]) -> int:
+        """Сохранить эмбеддинги ``(message_id, vector)`` в бинарный BLOB-индекс; вернуть число записей.
+
+        Все векторы должны быть одной размерности (она фиксируется индексом).
+        """
         if not embeddings:
             return 0
         dimensions = len(embeddings[0][1])
@@ -633,6 +672,12 @@ class MessagesRepository:
         return [int(row["id"]) for row in rows]
 
     async def search_messages(self, params: SearchParams) -> MessageSearchPage:
+        """Полнотекстовый поиск (FTS5, при недоступности — LIKE) по фильтрам [`SearchParams`][src.models.SearchParams].
+
+        Возвращает [`MessageSearchPage`][src.database.repositories.messages.MessageSearchPage]
+        с нижней оценкой total (limit+1-проба вместо точного COUNT, #766), новые
+        первыми. Отфильтрованные каналы исключаются, если не задан ``include_filtered``.
+        """
         query = params.query
         limit = params.limit
         offset = params.offset
@@ -819,6 +864,11 @@ class MessagesRepository:
         candidate_limit: int | None = None,
         include_filtered: bool = False,
     ) -> tuple[list[Message], int]:
+        """Семантический поиск по эмбеддингу запроса (косинусная близость); вернуть ``(страница, всего кандидатов)``.
+
+        ``candidate_limit`` ограничивает размер пула кандидатов до ранжирования;
+        страница вырезается ``offset``/``limit`` уже из отсортированного списка.
+        """
         fetch_limit = candidate_limit or max(offset + limit, 50)
         candidates = await self._search_semantic_candidates(
             query_embedding,
@@ -853,6 +903,11 @@ class MessagesRepository:
         rrf_k: int = 60,
         include_filtered: bool = False,
     ) -> tuple[list[Message], int]:
+        """Гибридный поиск: объединяет текстовых и семантических кандидатов через Reciprocal Rank Fusion.
+
+        ``rrf_k`` — сглаживающая константа RRF (вклад позиции = 1/(rrf_k+rank)).
+        Возвращает ``(страница сообщений, число уникальных кандидатов)``.
+        """
         fetch_limit = candidate_limit or max(offset + limit, 50)
         text_ids = await self._search_text_candidate_ids(
             query,
@@ -1080,6 +1135,7 @@ class MessagesRepository:
         return messages, total
 
     async def count_fts_matches_for_query(self, sq: SearchQuery) -> int:
+        """Точное число FTS-совпадений сохранённого запроса ``sq`` (учитывает его фильтры/исключения)."""
         self._require_fts()
         fts_query, extra_conds, extra_params = self._build_sq_parts(sq)
         where_parts = [self._BASE_FILTER, *extra_conds]
@@ -1094,6 +1150,7 @@ class MessagesRepository:
         return row["cnt"] if row else 0
 
     async def get_fts_daily_stats_for_query(self, sq: SearchQuery, days: int = 30) -> list:
+        """Ряд «день → число совпадений» сохранённого запроса за последние ``days`` дней (по дате сообщений)."""
         self._require_fts()
         from src.models import SearchQueryDailyStat
 
@@ -1120,6 +1177,11 @@ class MessagesRepository:
     async def get_fts_daily_stats_batch(
         self, queries: list[SearchQuery], days: int = 30
     ) -> dict[int, list]:
+        """Дневная статистика сразу для многих запросов: карта ``sq_id → [SearchQueryDailyStat]`` за ``days`` дней.
+
+        Считает UNION ALL чанками (≤100 запросов на чанк, лимит SQLite), чтобы не
+        делать по запросу на каждый ``sq``.
+        """
         self._require_fts()
         from src.models import SearchQueryDailyStat
 
@@ -1162,6 +1224,13 @@ class MessagesRepository:
         return result
 
     async def delete_messages_for_channel(self, channel_id: int) -> int:
+        """Мягко удалить (purge) сообщения канала и их эмбеддинги; вернуть число удалённых строк.
+
+        Это soft-delete: канал остаётся отслеживаемым, а леджеры дедупликации
+        (`notified_messages`, `pipeline_action_log`) сознательно НЕ трогаются —
+        иначе после повторного сбора задвоились бы уведомления и внешние
+        Telegram-действия (#1039). Реакции уходят каскадом по FK.
+        """
         assert self._database is not None, (
             "MessagesRepository.delete_messages_for_channel requires a Database reference"
         )
@@ -1234,6 +1303,7 @@ class MessagesRepository:
         return rowcount
 
     async def get_stats(self) -> dict:
+        """Сводные счётчики для дашборда: аккаунты, каналы (всего/фильтр/трекинг), сообщения, запросы."""
         cur = await self._db.execute(
             "SELECT"
             " (SELECT COUNT(*) FROM accounts) AS accounts,"

--- a/src/database/repositories/notification_bots.py
+++ b/src/database/repositories/notification_bots.py
@@ -1,3 +1,5 @@
+"""Репозиторий персональных ботов уведомлений (один на пользователя Telegram)."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -12,6 +14,13 @@ if TYPE_CHECKING:
 
 
 class NotificationBotsRepository:
+    """Персональные боты для уведомлений, созданные через BotFather.
+
+    Один бот на пользователя Telegram (`tg_user_id` уникален): хранит токен и
+    идентификаторы бота, через который [`Notifier`][] шлёт оповещения о новых
+    совпадениях. Запись — upsert по `tg_user_id`.
+    """
+
     def __init__(
         self,
         db: aiosqlite.Connection,
@@ -22,6 +31,7 @@ class NotificationBotsRepository:
         self._database = database
 
     async def get_bot(self, tg_user_id: int) -> NotificationBot | None:
+        """Бот пользователя по его Telegram id, либо None."""
         cur = await self._db.execute(
             "SELECT * FROM notification_bots WHERE tg_user_id = ? LIMIT 1",
             (tg_user_id,),
@@ -32,6 +42,12 @@ class NotificationBotsRepository:
         return self._row_to_model(row)
 
     async def save_bot(self, bot: NotificationBot) -> int:
+        """Сохранить/обновить бота пользователя (upsert по `tg_user_id`).
+
+        Возвращает `cur.lastrowid` — надёжный id только на ветке вставки; при
+        конфликте-обновлении lastrowid остаётся от последней вставки в
+        соединении, для точного id читайте строку по `tg_user_id`.
+        """
         cur = await self._database.execute_write(
             """
             INSERT INTO notification_bots (tg_user_id, tg_username, bot_id, bot_username, bot_token)
@@ -47,11 +63,13 @@ class NotificationBotsRepository:
         return cur.lastrowid or 0
 
     async def count(self) -> int:
+        """Число зарегистрированных ботов уведомлений."""
         cur = await self._db.execute("SELECT COUNT(*) FROM notification_bots")
         row = await cur.fetchone()
         return row[0] if row else 0
 
     async def delete_bot(self, tg_user_id: int) -> None:
+        """Удалить бота пользователя по его Telegram id."""
         await self._database.execute_write(
             "DELETE FROM notification_bots WHERE tg_user_id = ?",
             (tg_user_id,),

--- a/src/database/repositories/notified_messages.py
+++ b/src/database/repositories/notified_messages.py
@@ -1,3 +1,5 @@
+"""Леджер уже отправленных уведомлений (дедуп доставки)."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -57,6 +59,11 @@ class NotifiedMessagesRepository:
         return await cur.fetchone() is not None
 
     async def record(self, query_id: int, channel_id: int, message_ids: list[int]) -> None:
+        """Отметить сообщения как уведомлённые для (query_id, channel_id).
+
+        Append-only вставка `INSERT OR IGNORE` — повторная запись тех же id не
+        дублируется и не падает. Пустой список — no-op.
+        """
         if not message_ids:
             return
         assert self._database is not None, "NotifiedMessagesRepository.record requires a Database"

--- a/src/database/repositories/photo_loader.py
+++ b/src/database/repositories/photo_loader.py
@@ -1,3 +1,13 @@
+"""Репозиторий загрузчика фото: ручные батчи и авто-загрузка из папки.
+
+Доступ через `db.repos.photo_loader`. Обслуживает три таблицы:
+`photo_batches` (батч — общая цель/режим отправки), `photo_batch_items`
+(конкретные отправки с расписанием и статусом) и `photo_auto_upload_jobs`
+(периодическая авто-отправка новых файлов из папки, с леджером уже отправленных
+в `photo_auto_upload_files`). Захват готового item на отправку — атомарный
+(UPDATE…RETURNING), чтобы две корутины не отправили одно фото дважды.
+"""
+
 from __future__ import annotations
 
 from datetime import datetime, timezone
@@ -25,6 +35,8 @@ if TYPE_CHECKING:
 
 
 class PhotoLoaderRepository:
+    """CRUD фото-батчей, их элементов и заданий авто-загрузки из папки."""
+
     def __init__(
         self,
         db: aiosqlite.Connection,
@@ -91,6 +103,7 @@ class PhotoLoaderRepository:
         )
 
     async def create_batch(self, batch: PhotoBatch) -> int:
+        """Создать фото-батч (общая цель/режим отправки); вернуть его id."""
         cur = await self._database.execute_write(
             """
             INSERT INTO photo_batches (
@@ -119,6 +132,7 @@ class PhotoLoaderRepository:
         error: str | None = None,
         last_run_at: datetime | None = None,
     ) -> None:
+        """Частично обновить батч (статус/ошибку/время запуска); ни одного поля — no-op."""
         sets: list[str] = []
         params: list[object] = []
         if status is not None:
@@ -139,11 +153,13 @@ class PhotoLoaderRepository:
         )
 
     async def get_batch(self, batch_id: int) -> PhotoBatch | None:
+        """Один батч по id, либо ``None``."""
         cur = await self._db.execute("SELECT * FROM photo_batches WHERE id = ?", (batch_id,))
         row = await cur.fetchone()
         return self._to_batch(row) if row else None
 
     async def list_batches(self, limit: int = 50) -> list[PhotoBatch]:
+        """Последние ``limit`` батчей, новые первыми."""
         cur = await self._db.execute(
             "SELECT * FROM photo_batches ORDER BY id DESC LIMIT ?",
             (limit,),
@@ -151,6 +167,7 @@ class PhotoLoaderRepository:
         return [self._to_batch(row) for row in await cur.fetchall()]
 
     async def create_item(self, item: PhotoBatchItem) -> int:
+        """Создать элемент батча (одна отправка с файлами и опциональным расписанием); вернуть id."""
         cur = await self._database.execute_write(
             """
             INSERT INTO photo_batch_items (
@@ -176,11 +193,13 @@ class PhotoLoaderRepository:
         return cur.lastrowid or 0
 
     async def get_item(self, item_id: int) -> PhotoBatchItem | None:
+        """Один элемент батча по id, либо ``None``."""
         cur = await self._db.execute("SELECT * FROM photo_batch_items WHERE id = ?", (item_id,))
         row = await cur.fetchone()
         return self._to_item(row) if row else None
 
     async def list_items(self, limit: int = 100) -> list[PhotoBatchItem]:
+        """Последние ``limit`` элементов по всем батчам, новые первыми."""
         cur = await self._db.execute(
             "SELECT * FROM photo_batch_items ORDER BY id DESC LIMIT ?",
             (limit,),
@@ -188,6 +207,7 @@ class PhotoLoaderRepository:
         return [self._to_item(row) for row in await cur.fetchall()]
 
     async def list_items_for_batch(self, batch_id: int, limit: int | None = None) -> list[PhotoBatchItem]:
+        """Элементы одного батча по возрастанию id (порядок отправки); ``limit`` ограничивает выборку."""
         sql = "SELECT * FROM photo_batch_items WHERE batch_id = ? ORDER BY id ASC"
         params: tuple[object, ...] = (batch_id,)
         if limit is not None:
@@ -206,6 +226,7 @@ class PhotoLoaderRepository:
         started_at: datetime | None = None,
         completed_at: datetime | None = None,
     ) -> None:
+        """Частично обновить элемент батча (статус, ошибка, id отправленных сообщений, тайминги); пусто — no-op."""
         sets: list[str] = []
         params: list[object] = []
         if status is not None:
@@ -232,6 +253,7 @@ class PhotoLoaderRepository:
         )
 
     async def cancel_item(self, item_id: int) -> bool:
+        """Отменить ещё не завершённый элемент (pending/scheduled/running); вернуть ``True``, если отменили."""
         cur = await self._database.execute_write(
             """
             UPDATE photo_batch_items
@@ -299,6 +321,7 @@ class PhotoLoaderRepository:
         return self._to_item(claimed) if claimed else None
 
     async def requeue_running_items_on_startup(self, now: datetime) -> int:
+        """На старте вернуть зависшие RUNNING-элементы в PENDING (авто-восстановление после сбоя); вернуть число."""
         cur = await self._database.execute_write(
             """
             UPDATE photo_batch_items
@@ -314,6 +337,7 @@ class PhotoLoaderRepository:
         return cur.rowcount or 0
 
     async def create_auto_job(self, job: PhotoAutoUploadJob) -> int:
+        """Создать задание авто-загрузки новых файлов из папки по интервалу; вернуть id."""
         cur = await self._database.execute_write(
             """
             INSERT INTO photo_auto_upload_jobs (
@@ -352,6 +376,7 @@ class PhotoLoaderRepository:
         last_run_at: datetime | None = None,
         last_seen_marker: str | None = None,
     ) -> None:
+        """Частично обновить задание авто-загрузки (папка, режим, интервал, активность, маркер…); пусто — no-op."""
         sets: list[str] = []
         params: list[object] = []
         if folder_path is not None:
@@ -387,11 +412,13 @@ class PhotoLoaderRepository:
         )
 
     async def get_auto_job(self, job_id: int) -> PhotoAutoUploadJob | None:
+        """Одно задание авто-загрузки по id, либо ``None``."""
         cur = await self._db.execute("SELECT * FROM photo_auto_upload_jobs WHERE id = ?", (job_id,))
         row = await cur.fetchone()
         return self._to_auto_job(row) if row else None
 
     async def list_auto_jobs(self, active_only: bool = False) -> list[PhotoAutoUploadJob]:
+        """Задания авто-загрузки, новые первыми; с ``active_only`` — только активные."""
         sql = "SELECT * FROM photo_auto_upload_jobs"
         params: tuple[object, ...] = ()
         if active_only:
@@ -401,14 +428,22 @@ class PhotoLoaderRepository:
         return [self._to_auto_job(row) for row in await cur.fetchall()]
 
     async def delete_auto_job(self, job_id: int) -> None:
+        """Удалить задание авто-загрузки вместе с его леджером отправленных файлов (одной транзакцией).
+
+        Леджер `photo_auto_upload_files` ссылается на задание внешним ключом без
+        ON DELETE CASCADE, а соединение работает с `PRAGMA foreign_keys=ON` —
+        поэтому child-строки удаляются ПЕРВЫМИ, иначе DELETE родителя падает с
+        «FOREIGN KEY constraint failed» (#1134).
+        """
         assert self._database is not None, (
             "PhotoLoaderRepository.delete_auto_job requires a Database reference"
         )
         async with self._database.transaction() as conn:
-            await conn.execute("DELETE FROM photo_auto_upload_jobs WHERE id = ?", (job_id,))
             await conn.execute("DELETE FROM photo_auto_upload_files WHERE job_id = ?", (job_id,))
+            await conn.execute("DELETE FROM photo_auto_upload_jobs WHERE id = ?", (job_id,))
 
     async def has_sent_auto_file(self, job_id: int, file_path: str) -> bool:
+        """Был ли файл уже отправлен этим заданием (проверка леджера перед отправкой)."""
         cur = await self._db.execute(
             "SELECT 1 FROM photo_auto_upload_files WHERE job_id = ? AND file_path = ?",
             (job_id, file_path),
@@ -416,6 +451,7 @@ class PhotoLoaderRepository:
         return bool(await cur.fetchone())
 
     async def mark_auto_file_sent(self, job_id: int, file_path: str) -> None:
+        """Отметить файл отправленным в леджере задания (идемпотентно, INSERT OR IGNORE)."""
         await self._database.execute_write(
             """
             INSERT OR IGNORE INTO photo_auto_upload_files (job_id, file_path, sent_at)

--- a/src/database/repositories/pipeline_action_log.py
+++ b/src/database/repositories/pipeline_action_log.py
@@ -1,3 +1,5 @@
+"""Леджер обработанных нодами пайплайна сообщений (дедуп react/forward/delete)."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/src/database/repositories/pipeline_templates.py
+++ b/src/database/repositories/pipeline_templates.py
@@ -1,3 +1,5 @@
+"""Репозиторий шаблонов контент-пайплайнов (встроенных и пользовательских)."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -12,6 +14,13 @@ if TYPE_CHECKING:
 
 
 class PipelineTemplatesRepository:
+    """CRUD над шаблонами контент-пайплайнов (граф нод сохранён как JSON).
+
+    Шаблоны бывают встроенные (`is_builtin`, поставляются с приложением и
+    досеиваются через `ensure_builtins`) и пользовательские; из шаблона
+    создаётся готовый [`ContentPipeline`][src.models.ContentPipeline].
+    """
+
     def __init__(
         self,
         db: aiosqlite.Connection,
@@ -34,6 +43,7 @@ class PipelineTemplatesRepository:
         )
 
     async def list_all(self, category: str | None = None) -> list[PipelineTemplate]:
+        """Все шаблоны (опционально одной категории); встроенные идут первыми."""
         if category:
             cur = await self._db.execute(
                 "SELECT * FROM pipeline_templates WHERE category = ? ORDER BY is_builtin DESC, id",
@@ -46,6 +56,7 @@ class PipelineTemplatesRepository:
         return [self._to_template(row) for row in await cur.fetchall()]
 
     async def get_by_id(self, template_id: int) -> PipelineTemplate | None:
+        """Шаблон по id, либо None."""
         cur = await self._db.execute(
             "SELECT * FROM pipeline_templates WHERE id = ?", (template_id,)
         )
@@ -53,6 +64,7 @@ class PipelineTemplatesRepository:
         return self._to_template(row) if row else None
 
     async def get_by_name(self, name: str) -> PipelineTemplate | None:
+        """Шаблон по уникальному имени, либо None."""
         cur = await self._db.execute(
             "SELECT * FROM pipeline_templates WHERE name = ?", (name,)
         )
@@ -60,6 +72,7 @@ class PipelineTemplatesRepository:
         return self._to_template(row) if row else None
 
     async def add(self, template: PipelineTemplate) -> int:
+        """Сохранить шаблон (граф сериализуется в JSON). Возвращает id новой строки."""
         cur = await self._database.execute_write(
             """
             INSERT INTO pipeline_templates (name, description, category, template_json, is_builtin)
@@ -76,6 +89,7 @@ class PipelineTemplatesRepository:
         return cur.lastrowid or 0
 
     async def delete(self, template_id: int) -> None:
+        """Удалить шаблон по id."""
         await self._database.execute_write("DELETE FROM pipeline_templates WHERE id = ?", (template_id,))
 
     async def ensure_builtins(self, builtins: list[PipelineTemplate]) -> None:

--- a/src/database/repositories/runtime_snapshots.py
+++ b/src/database/repositories/runtime_snapshots.py
@@ -1,3 +1,5 @@
+"""Снимки состояния воркера для чтения web-стороной (канал worker → web)."""
+
 from __future__ import annotations
 
 import json
@@ -25,6 +27,14 @@ if TYPE_CHECKING:
 
 
 class RuntimeSnapshotsRepository:
+    """Снимки живого состояния воркера, публикуемые для web-стороны.
+
+    Воркер пишет (`upsert_snapshot`) heartbeat, статусы аккаунтов/планировщика и
+    т.п., а web-контейнер (который не держит Telegram-соединений) читает их
+    (`get_snapshot`), чтобы отрисовать статус. Идентичность снимка —
+    `(snapshot_type, scope)`; запись — upsert по этой паре.
+    """
+
     def __init__(
         self,
         db: aiosqlite.Connection,
@@ -44,6 +54,10 @@ class RuntimeSnapshotsRepository:
         )
 
     async def upsert_snapshot(self, snapshot: RuntimeSnapshot) -> None:
+        """Записать/обновить снимок по паре (snapshot_type, scope).
+
+        `updated_at` берётся из снимка либо проставляется текущим временем БД.
+        """
         await self._database.execute_write(
             """
             INSERT INTO runtime_snapshots (snapshot_type, scope, payload, updated_at)
@@ -61,6 +75,7 @@ class RuntimeSnapshotsRepository:
         )
 
     async def get_snapshot(self, snapshot_type: str, scope: str = "global") -> RuntimeSnapshot | None:
+        """Снимок по типу и области (по умолчанию глобальной), либо None."""
         cur = await self._db.execute(
             """
             SELECT * FROM runtime_snapshots

--- a/src/database/repositories/search_log.py
+++ b/src/database/repositories/search_log.py
@@ -1,3 +1,5 @@
+"""Журнал поисковых запросов (история поиска по аккаунтам)."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -9,6 +11,12 @@ if TYPE_CHECKING:
 
 
 class SearchLogRepository:
+    """Append-only журнал поисков: кто (`phone`), что (`query`), сколько нашёл.
+
+    Историческая лента для аналитики/UI «недавние запросы»; только запись и
+    чтение последних записей, без апдейтов.
+    """
+
     def __init__(
         self,
         db: aiosqlite.Connection,
@@ -19,12 +27,14 @@ class SearchLogRepository:
         self._database = database
 
     async def log_search(self, phone: str, query: str, results_count: int) -> None:
+        """Записать факт поиска: телефон, запрос и число найденных результатов."""
         await self._database.execute_write(
             "INSERT INTO search_log (phone, query, results_count) VALUES (?, ?, ?)",
             (phone, query, results_count),
         )
 
     async def get_recent_searches(self, limit: int = 20) -> list[dict]:
+        """Последние `limit` записей журнала поиска (новые сверху)."""
         cur = await self._db.execute("SELECT * FROM search_log ORDER BY id DESC LIMIT ?", (limit,))
         rows = await cur.fetchall()
         return [

--- a/src/database/repositories/search_queries.py
+++ b/src/database/repositories/search_queries.py
@@ -1,3 +1,10 @@
+"""Репозиторий сохранённых поисковых запросов и их дневной статистики.
+
+Доступ через `db.repos.search_queries`. Хранит две сущности: сами запросы
+(`search_queries` — текст/regex/FTS, расписание, уведомления) и временной ряд
+числа совпадений по дням (`search_query_stats`) для графиков активности темы.
+"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -12,6 +19,8 @@ if TYPE_CHECKING:
 
 
 class SearchQueriesRepository:
+    """CRUD сохранённых поисковых запросов и запись/чтение их дневной статистики."""
+
     def __init__(
         self,
         db: aiosqlite.Connection,
@@ -22,6 +31,7 @@ class SearchQueriesRepository:
         self._database = database
 
     async def add(self, sq: SearchQuery) -> int:
+        """Создать сохранённый запрос; вернуть его новый id."""
         cur = await self._database.execute_write(
             "INSERT INTO search_queries "
             "(name, query, is_regex, is_fts, is_active, notify_on_collect, "
@@ -44,6 +54,7 @@ class SearchQueriesRepository:
         return cur.lastrowid or 0
 
     async def get_all(self, active_only: bool = False) -> list[SearchQuery]:
+        """Все запросы по возрастанию id; с ``active_only`` — только активные."""
         sql = "SELECT * FROM search_queries"
         if active_only:
             sql += " WHERE is_active = 1"
@@ -53,16 +64,19 @@ class SearchQueriesRepository:
         return [self._row_to_model(r) for r in rows]
 
     async def get_by_id(self, sq_id: int) -> SearchQuery | None:
+        """Один запрос по id, либо ``None`` если такого нет."""
         cur = await self._db.execute("SELECT * FROM search_queries WHERE id = ?", (sq_id,))
         row = await cur.fetchone()
         return self._row_to_model(row) if row else None
 
     async def set_active(self, sq_id: int, active: bool) -> None:
+        """Включить/выключить запрос (неактивный не запускается планировщиком)."""
         await self._database.execute_write(
             "UPDATE search_queries SET is_active = ? WHERE id = ?", (int(active), sq_id)
         )
 
     async def update(self, sq_id: int, sq: SearchQuery) -> None:
+        """Перезаписать редактируемые поля запроса (флаг is_active не трогается — для него есть set_active)."""
         await self._database.execute_write(
             "UPDATE search_queries SET name = ?, query = ?, is_regex = ?, is_fts = ?, "
             "notify_on_collect = ?, track_stats = ?, interval_minutes = ?, "
@@ -84,6 +98,7 @@ class SearchQueriesRepository:
         )
 
     async def delete(self, sq_id: int) -> None:
+        """Удалить запрос вместе с его дневной статистикой (одной транзакцией)."""
         assert self._database is not None, (
             "SearchQueriesRepository.delete requires a Database reference"
         )
@@ -92,6 +107,7 @@ class SearchQueriesRepository:
             await conn.execute("DELETE FROM search_queries WHERE id = ?", (sq_id,))
 
     async def record_stat(self, query_id: int, match_count: int) -> None:
+        """Записать число совпадений запроса за сегодня (одна запись на день — перезаписывает текущую)."""
         # One stat per query per day: delete existing entry for today, then insert
         assert self._database is not None, (
             "SearchQueriesRepository.record_stat requires a Database reference"
@@ -108,6 +124,7 @@ class SearchQueriesRepository:
             )
 
     async def get_daily_stats(self, query_id: int, days: int = 30) -> list[SearchQueryDailyStat]:
+        """Ряд «день → число совпадений» для одного запроса за последние ``days`` дней."""
         cur = await self._db.execute(
             """
             SELECT date(recorded_at) AS day, SUM(match_count) AS count
@@ -123,6 +140,7 @@ class SearchQueriesRepository:
         return [SearchQueryDailyStat(day=r["day"], count=r["count"]) for r in rows]
 
     async def get_stats_for_all(self, days: int = 30) -> dict[int, list[SearchQueryDailyStat]]:
+        """Дневная статистика всех запросов за ``days`` дней, сгруппированная по query_id (один запрос вместо N)."""
         cur = await self._db.execute(
             """
             SELECT query_id, date(recorded_at) AS day, SUM(match_count) AS count
@@ -142,6 +160,7 @@ class SearchQueriesRepository:
         return result
 
     async def get_last_recorded_at(self, query_id: int) -> str | None:
+        """ISO-время последней записи статистики запроса (для решения «пора ли пересчитать»), либо ``None``."""
         cur = await self._db.execute(
             "SELECT MAX(recorded_at) AS last FROM search_query_stats WHERE query_id = ?",
             (query_id,),
@@ -150,6 +169,7 @@ class SearchQueriesRepository:
         return row["last"] if row else None
 
     async def get_last_recorded_at_all(self) -> dict[int, str]:
+        """Карта query_id → ISO-время последней записи статистики (только запросы, у которых она есть)."""
         cur = await self._db.execute(
             "SELECT query_id, MAX(recorded_at) AS last " "FROM search_query_stats GROUP BY query_id"
         )
@@ -157,6 +177,7 @@ class SearchQueriesRepository:
         return {r["query_id"]: r["last"] for r in rows if r["last"]}
 
     async def get_notification_queries(self, active_only: bool = True) -> list[SearchQuery]:
+        """Запросы с включёнными уведомлениями о новых совпадениях (по умолчанию только активные)."""
         sql = "SELECT * FROM search_queries WHERE notify_on_collect = 1"
         if active_only:
             sql += " AND is_active = 1"

--- a/src/database/repositories/settings.py
+++ b/src/database/repositories/settings.py
@@ -1,3 +1,5 @@
+"""Репозиторий key/value настроек приложения (таблица settings)."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -9,6 +11,13 @@ if TYPE_CHECKING:
 
 
 class SettingsRepository:
+    """Хранилище key/value настроек приложения в таблице `settings`.
+
+    Простое строковое key/value (значения сериализуются вызывающим кодом):
+    держит секреты вроде ключа подписи сессий, флаги dev-режима, конфиги
+    агента/фильтров и т.п. Запись — upsert через `set_setting`.
+    """
+
     def __init__(
         self,
         db: aiosqlite.Connection,
@@ -19,16 +28,19 @@ class SettingsRepository:
         self._database = database
 
     async def get_setting(self, key: str) -> str | None:
+        """Значение настройки по ключу, либо None если ключа нет."""
         cur = await self._db.execute("SELECT value FROM settings WHERE key = ?", (key,))
         row = await cur.fetchone()
         return row["value"] if row else None
 
     async def list_all(self) -> list[tuple[str, str]]:
+        """Все настройки как список пар (key, value), отсортированный по ключу."""
         cur = await self._db.execute("SELECT key, value FROM settings ORDER BY key")
         rows = await cur.fetchall()
         return [(r["key"], r["value"]) for r in rows]
 
     async def get_settings_by_prefix(self, prefix: str) -> dict[str, str]:
+        """Настройки, чей ключ начинается с `prefix`, как dict (спецсимволы LIKE экранируются)."""
         escaped = prefix.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
         cur = await self._db.execute(
             "SELECT key, value FROM settings WHERE key LIKE ? ESCAPE '\\'",
@@ -38,6 +50,7 @@ class SettingsRepository:
         return {r["key"]: r["value"] for r in rows}
 
     async def set_setting(self, key: str, value: str) -> None:
+        """Записать/обновить настройку (upsert по ключу)."""
         await self._database.execute_write(
             "INSERT INTO settings (key, value) VALUES (?, ?) "
             "ON CONFLICT(key) DO UPDATE SET value = excluded.value",

--- a/src/database/repositories/telegram_commands.py
+++ b/src/database/repositories/telegram_commands.py
@@ -1,3 +1,5 @@
+"""Репозиторий очереди команд Telegram-воркеру (постановка, claim, обновление статуса)."""
+
 from __future__ import annotations
 
 import json
@@ -26,6 +28,14 @@ if TYPE_CHECKING:
 
 
 class TelegramCommandsRepository:
+    """Очередь команд Telegram-воркеру (BotFather, отправка, auth и т.п.).
+
+    Web/CLI ставят команды в очередь (`create_command`), воркер атомарно
+    забирает их (`claim_next_command`: PENDING → RUNNING под транзакцией) и
+    обновляет статус/результат (`update_command`). Поддерживает фильтрацию по
+    типу/статусу/телефону и счётчики для панели мониторинга.
+    """
+
     def __init__(
         self,
         db: aiosqlite.Connection,
@@ -52,6 +62,7 @@ class TelegramCommandsRepository:
         )
 
     async def create_command(self, command: TelegramCommand) -> int:
+        """Поставить команду в очередь воркеру. Возвращает id новой строки."""
         cur = await self._database.execute_write(
             """
             INSERT INTO telegram_commands (
@@ -72,6 +83,7 @@ class TelegramCommandsRepository:
         return cur.lastrowid or 0
 
     async def get_command(self, command_id: int) -> TelegramCommand | None:
+        """Прочитать команду по id, либо None если её нет."""
         cur = await self._db.execute(
             "SELECT * FROM telegram_commands WHERE id = ?",
             (command_id,),
@@ -108,6 +120,7 @@ class TelegramCommandsRepository:
         status: TelegramCommandStatus | None = None,
         phone: str | None = None,
     ) -> list[TelegramCommand]:
+        """Список команд (новые сверху) с опциональным фильтром по типу/статусу/телефону."""
         where, params = self._filtered_query(command_type=command_type, status=status, phone=phone)
         cur = await self._db.execute(
             f"SELECT * FROM telegram_commands {where} ORDER BY id DESC LIMIT ?",
@@ -123,6 +136,7 @@ class TelegramCommandsRepository:
         status: TelegramCommandStatus | None = None,
         phone: str | None = None,
     ) -> dict[TelegramCommandStatus, int]:
+        """Сколько команд в каждом статусе (под фильтр). Все статусы присутствуют, нулевые — с 0."""
         where, params = self._filtered_query(command_type=command_type, status=status, phone=phone)
         cur = await self._db.execute(
             f"""
@@ -146,6 +160,10 @@ class TelegramCommandsRepository:
         status: TelegramCommandStatus | None = None,
         phone: str | None = None,
     ) -> dict[str, int]:
+        """Распределение по `result_payload.$.state` (под фильтр) — детализация исходов команд.
+
+        Пустые состояния опускаются; ключ — значение `$.state` из JSON-результата.
+        """
         where, params = self._filtered_query(command_type=command_type, status=status, phone=phone)
         cur = await self._db.execute(
             f"""
@@ -260,6 +278,13 @@ class TelegramCommandsRepository:
         return cur.rowcount or 0
 
     async def claim_next_command(self) -> TelegramCommand | None:
+        """Атомарно забрать следующую готовую команду: PENDING → RUNNING.
+
+        Под транзакцией выбирает старейшую PENDING-строку, у которой `run_after`
+        не в будущем, и помечает её RUNNING со `started_at`, чтобы два воркера не
+        взяли одну команду. Возвращает обновлённую команду либо None, если очередь
+        пуста.
+        """
         assert self._database is not None, (
             "TelegramCommandsRepository.claim_next_command requires a Database reference"
         )
@@ -305,6 +330,14 @@ class TelegramCommandsRepository:
         payload: dict[str, Any] | None = None,
         run_after: datetime | None = None,
     ) -> None:
+        """Обновить статус команды и сопутствующие поля.
+
+        Терминальные статусы (SUCCEEDED/FAILED/CANCELLED) проставляют `finished_at`.
+        Возврат в PENDING (повторная постановка) сбрасывает started_at/finished_at,
+        чтобы ретрай показывал свежий запуск, а не прерванную попытку. `result_payload`
+        и `finished_at` пишутся через COALESCE — терминальный апдейт без свежего payload
+        сохраняет прежнюю диагностику, а не затирает её в NULL (audit #835/15).
+        """
         finished_at = None
         if status in {
             TelegramCommandStatus.SUCCEEDED,

--- a/src/models.py
+++ b/src/models.py
@@ -1,3 +1,12 @@
+"""Pydantic-модели предметной области — фасад данных всего приложения.
+
+Каждый класс здесь — типизированный контракт между слоями (репозитории ↔
+сервисы ↔ web/CLI/agent). Репозитории мапят строки SQLite в эти модели через
+`_to_<model>` хелперы; web/CLI и agent-tools читают их как единственный источник
+истины о форме данных. Эти же docstring питают авто-документацию /api
+(mkdocstrings, #1071), так что описания тут дают двойную выгоду — в коде и в доках.
+"""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -32,6 +41,15 @@ class SearchParams:
 
 
 class Account(BaseModel):
+    """Telegram-аккаунт пула: телефон + StringSession и его флаги.
+
+    `session_string` — секрет (хранится зашифрованным как `enc:v2:*`, если задан
+    `SESSION_ENCRYPTION_KEY`); никогда не отдаётся наружу — для UI/agent есть
+    усечённая [`AccountSummary`][src.models.AccountSummary]. `is_primary`
+    выбирает аккаунт по умолчанию; `flood_wait_until` — момент, до которого
+    `ClientPool` пропускает аккаунт из-за Telegram FLOOD_WAIT.
+    """
+
     id: int | None = None
     phone: str
     session_string: str
@@ -43,6 +61,13 @@ class Account(BaseModel):
 
 
 class AccountSessionStatus(StrEnum):
+    """Состояние StringSession аккаунта с точки зрения дешифровки/совместимости.
+
+    Отделяет «аккаунт активен» от «сессию удалось прочитать»: при включённом
+    `SESSION_ENCRYPTION_KEY` сессия может оказаться нечитаемой (нет ключа,
+    повреждена, чужая версия) — UI показывает это без раскрытия секрета.
+    """
+
     OK = "ok"
     ENCRYPTED_UNKNOWN = "encrypted_unknown"
     DECRYPT_FAILED = "decrypt_failed"
@@ -51,6 +76,13 @@ class AccountSessionStatus(StrEnum):
 
 
 class AccountSummary(BaseModel):
+    """Безопасная для UI/agent проекция [`Account`][src.models.Account] без `session_string`.
+
+    Несёт те же метаданные (телефон, флаги, flood-wait) плюс
+    [`session_status`][src.models.AccountSessionStatus], но без секрета сессии —
+    это форма, которую отдают наружу списки аккаунтов.
+    """
+
     id: int | None = None
     phone: str
     is_primary: bool = False
@@ -62,6 +94,14 @@ class AccountSummary(BaseModel):
 
 
 class TelegramUserInfo(BaseModel):
+    """Профиль пользователя Telegram, привязанного к аккаунту пула.
+
+    Возвращается при запросе «кто этот аккаунт»: имя/username, флаги
+    primary/premium и аватар в виде data-URI (`avatar_base64`) для прямого показа
+    в UI без отдельного запроса картинки. В отличие от
+    [`Account`][src.models.Account] — описательная карточка, а не носитель сессии.
+    """
+
     phone: str
     first_name: str = ""
     last_name: str = ""
@@ -72,6 +112,18 @@ class TelegramUserInfo(BaseModel):
 
 
 class Channel(BaseModel):
+    """Telegram-канал/чат, отслеживаемый системой, со сбором и фильтрацией.
+
+    `channel_id` — Telegram-идентификатор (на него ссылаются все сайдкар-таблицы);
+    `id` — первичный ключ БД (используется только в pk-операциях). Сбор —
+    инкрементальный: `last_collected_id` хранит максимальный собранный message_id.
+    `is_filtered` + `filter_flags` ставит [`ChannelAnalyzer`][src.filters.analyzer]
+    (низкая уникальность, спам и т.п.) — отфильтрованные каналы пропускаются при
+    сборе. `needs_review`/`review_reason` помечают канал для ручной проверки.
+    `created_at` — дата создания канала в Telegram, `added_at` — когда добавлен в
+    систему.
+    """
+
     id: int | None = None
     channel_id: int
     title: str | None = None
@@ -94,6 +146,16 @@ class Channel(BaseModel):
 
 
 class Message(BaseModel):
+    """Одно сообщение канала: текст и/или медиа плюс метаданные и метрики.
+
+    Уникально по паре `(channel_id, message_id)`. `message_kind`/`sender_kind`/
+    `media_type` классифицируют содержимое и отправителя; служебные сообщения
+    раскладываются в `service_action_*`. Метрики (`views`/`forwards`/
+    `reply_count`/`reactions_json`) собираются вместе с текстом. `detected_lang`
+    и `translation_*` заполняет слой перевода. `channel_title`/`channel_username`
+    — денормализованные поля для вывода без JOIN (заполняются при чтении).
+    """
+
     id: int | None = None
     channel_id: int
     message_id: int
@@ -125,6 +187,10 @@ class Message(BaseModel):
 
 
 class CollectionTaskStatus(StrEnum):
+    """Жизненный цикл фоновой задачи [`CollectionTask`][src.models.CollectionTask]:
+    от `PENDING` (в очереди) через `RUNNING` к терминальным
+    `COMPLETED`/`FAILED`/`CANCELLED`."""
+
     PENDING = "pending"
     RUNNING = "running"
     COMPLETED = "completed"
@@ -133,6 +199,16 @@ class CollectionTaskStatus(StrEnum):
 
 
 class CollectionTaskType(StrEnum):
+    """Вид фоновой задачи в `collection_tasks` — определяет, какой обработчик её
+    исполняет.
+
+    Большинство типов исполняют внутренние воркеры фабрики (UnifiedDispatcher,
+    CollectionQueue). Interop-типы (`DM_REPLY`, `CHAT_ANSWER`, `FETCH_DIALOGS`,
+    `FETCH_HISTORY`) фабрика только создаёт — их забирает внешний воркер
+    tg_messenger через REST-claim API (см.
+    [`EXTERNAL_INTEROP_TASK_TYPES`][src.models.EXTERNAL_INTEROP_TASK_TYPES]).
+    """
+
     CHANNEL_COLLECT = "channel_collect"
     STATS_ALL = "stats_all"
     SQ_STATS = "sq_stats"
@@ -168,6 +244,9 @@ EXTERNAL_INTEROP_TASK_TYPES: frozenset[CollectionTaskType] = frozenset(
 
 
 class TelegramCommandStatus(StrEnum):
+    """Жизненный цикл [`TelegramCommand`][src.models.TelegramCommand]: `PENDING`
+    → `RUNNING` → терминальные `SUCCEEDED`/`FAILED`/`CANCELLED`."""
+
     PENDING = "pending"
     RUNNING = "running"
     SUCCEEDED = "succeeded"
@@ -176,6 +255,14 @@ class TelegramCommandStatus(StrEnum):
 
 
 class TelegramCommand(BaseModel):
+    """Команда из web-слоя воркеру: единица очереди `telegram_commands`.
+
+    Web-контейнер не держит живых Telegram-соединений — UI-действия кладутся
+    сюда как команды (`command_type` + произвольный `payload`), а живой воркер их
+    исполняет и пишет результат в `result_payload`/`error`. `run_after` позволяет
+    отложить исполнение.
+    """
+
     id: int | None = None
     command_type: str
     payload: dict[str, Any] = Field(default_factory=dict)
@@ -190,6 +277,14 @@ class TelegramCommand(BaseModel):
 
 
 class RuntimeSnapshot(BaseModel):
+    """Снимок состояния воркера, публикуемый для чтения web-слоем.
+
+    Воркер пишет в `runtime_snapshots` строки разных `snapshot_type` (heartbeat,
+    accounts_status, scheduler_status, …); web-контейнер читает их, чтобы
+    отрисовать статус, не открывая Telegram-соединений сам. `scope` разделяет
+    глобальные снимки и привязанные к конкретной сущности.
+    """
+
     snapshot_type: str
     scope: str = "global"
     payload: dict[str, Any] = Field(default_factory=dict)
@@ -203,6 +298,15 @@ ChannelGenre = Literal["ad", "infobiz", "aggregator", "copy", "original"]
 
 
 class ChannelRating(BaseModel):
+    """Двухосный вердикт о канале (#966): полезность × жанр.
+
+    Продукт `ChannelAnalysisService`: `useful` (полезен/нет) и `genre`
+    (реклама/инфобизнес/агрегатор/копия/оригинал) с уверенностью `confidence` и
+    текстовым обоснованием `reason`. `emoji_trash_score` и `flag_count` —
+    вспомогательные сигналы шума, `n_total` — размер выборки, на которой посчитан
+    вердикт.
+    """
+
     channel_id: int
     title: str | None = None
     username: str | None = None
@@ -223,6 +327,10 @@ class ChannelRating(BaseModel):
 # one table. Read-only — no source rows are written through this model.
 # ---------------------------------------------------------------------------
 class JobSource(StrEnum):
+    """Источник, из которого собрана строка единого jobs-вью
+    [`JobView`][src.models.JobView]: одна из четырёх разнородных таблиц
+    фоновой работы (collection_tasks, telegram_commands, photo_*, APScheduler)."""
+
     COLLECTION_TASK = "collection_task"
     TELEGRAM_COMMAND = "telegram_command"
     PHOTO_BATCH_ITEM = "photo_batch_item"
@@ -245,6 +353,16 @@ class JobRuntimeState(StrEnum):
 
 
 class JobView(BaseModel):
+    """Одна строка унифицированного read-model «работ» (#963).
+
+    Приводит четыре разнородных источника
+    ([`JobSource`][src.models.JobSource]) к общей форме, чтобы панель показывала
+    всё в одной таблице: нормализованный `runtime_state`
+    ([`JobRuntimeState`][src.models.JobRuntimeState]) поверх сырого `status`,
+    стабильный кросс-источниковый `id` с префиксом и человекочитаемый `summary`.
+    Только для чтения — записи в исходные таблицы через эту модель не идут.
+    """
+
     source: JobSource
     id: str  # source-prefixed, e.g. "collection_task:42" (stable across sources)
     raw_id: int | None = None
@@ -261,16 +379,27 @@ class JobView(BaseModel):
 
 
 class ContentGenerateTaskPayload(BaseModel):
+    """Полезная нагрузка задачи CONTENT_GENERATE: какой пайплайн генерировать."""
+
     task_kind: str = "content_generate"
     pipeline_id: int
 
 
 class ContentPublishTaskPayload(BaseModel):
+    """Полезная нагрузка задачи CONTENT_PUBLISH: публикация результата пайплайна
+    (`pipeline_id` опционален для разовых публикаций вне пайплайна)."""
+
     task_kind: str = "content_publish"
     pipeline_id: int | None = None
 
 
 class StatsAllTaskPayload(BaseModel):
+    """Нагрузка STATS_ALL: обход списка каналов для сбора статистики с курсором.
+
+    Задача переживает рестарты: `next_index`/`remaining_channel_ids` — позиция
+    обхода, `channels_ok`/`channels_err` — накопленные счётчики результата.
+    """
+
     task_kind: str = CollectionTaskType.STATS_ALL.value
     channel_ids: list[int]
     next_index: int = 0
@@ -280,11 +409,21 @@ class StatsAllTaskPayload(BaseModel):
 
 
 class SqStatsTaskPayload(BaseModel):
+    """Нагрузка SQ_STATS: пересчёт статистики для одного поискового запроса `sq_id`."""
+
     task_kind: str = CollectionTaskType.SQ_STATS.value
     sq_id: int
 
 
 class FilterAnalyzeTaskPayload(BaseModel):
+    """Нагрузка FILTER_ANALYZE: прогон анализатора фильтров по каналам.
+
+    Поля-слоты для итогов (`total_channels`/`filtered_count`/`purged_count`) —
+    необязательны: они зарезервированы под сводку «проанализировано/отфильтровано/
+    вычищено», но текущий handler сводку пишет в `note`/`messages_collected`
+    задачи, а не в этот payload, поэтому по умолчанию остаются `None`.
+    """
+
     task_kind: str = CollectionTaskType.FILTER_ANALYZE.value
     total_channels: int | None = None
     filtered_count: int | None = None
@@ -292,6 +431,12 @@ class FilterAnalyzeTaskPayload(BaseModel):
 
 
 class TranslateBatchTaskPayload(BaseModel):
+    """Нагрузка TRANSLATE_BATCH: пакетный перевод сообщений с курсором.
+
+    `last_processed_id` — позиция продолжения между батчами; `source_filter`
+    ограничивает исходные языки, `batch_size` — размер пакета за проход.
+    """
+
     task_kind: str = "translate_batch"
     target_lang: str = "en"
     source_filter: list[str] = []
@@ -300,6 +445,12 @@ class TranslateBatchTaskPayload(BaseModel):
 
 
 class ExportTaskPayload(BaseModel):
+    """Нагрузка EXPORT: выгрузка сообщений канала в файл (`fmt`: json/html/both).
+
+    Поддерживает фильтры по датам/лимиту, опциональную выгрузку медиа
+    (`with_media`) с ограничением размера и каталог назначения `out_dir`.
+    """
+
     task_kind: str = CollectionTaskType.EXPORT.value
     channel_id: int
     fmt: Literal["json", "html", "both"] = "json"
@@ -322,6 +473,12 @@ class ExportTaskPayload(BaseModel):
 # API stores the request body as an opaque JSON dict) and never executes them, so
 # it never needs typed read access — the external worker owns validation/execution.
 class DmReplyTaskPayload(BaseModel):
+    """Interop-нагрузка DM_REPLY (#960): ответ в личку, исполняет внешний воркер.
+
+    `peer` — @username или числовой id собеседника; `v` — версия схемы нагрузки,
+    чтобы внешний воркер мог эволюционировать независимо.
+    """
+
     v: int = 1
     task_kind: str = CollectionTaskType.DM_REPLY.value
     peer: str = Field(min_length=1)  # @username or numeric user id of the DM peer
@@ -330,6 +487,9 @@ class DmReplyTaskPayload(BaseModel):
 
 
 class ChatAnswerTaskPayload(BaseModel):
+    """Interop-нагрузка CHAT_ANSWER (#960): ответ в чат `chat_id`, исполняет
+    внешний воркер. `v` — версия схемы нагрузки."""
+
     v: int = 1
     task_kind: str = CollectionTaskType.CHAT_ANSWER.value
     chat_id: int
@@ -338,6 +498,9 @@ class ChatAnswerTaskPayload(BaseModel):
 
 
 class FetchDialogsTaskPayload(BaseModel):
+    """Interop-нагрузка FETCH_DIALOGS (#960): запрос списка диалогов у внешнего
+    воркера (`archived` включает архивные). `v` — версия схемы нагрузки."""
+
     v: int = 1
     task_kind: str = CollectionTaskType.FETCH_DIALOGS.value
     limit: int = 100
@@ -345,6 +508,9 @@ class FetchDialogsTaskPayload(BaseModel):
 
 
 class FetchHistoryTaskPayload(BaseModel):
+    """Interop-нагрузка FETCH_HISTORY (#960): запрос истории диалога `peer` у
+    внешнего воркера с пагинацией от `offset_id`. `v` — версия схемы нагрузки."""
+
     v: int = 1
     task_kind: str = CollectionTaskType.FETCH_HISTORY.value
     peer: str = Field(min_length=1)  # @username or numeric chat/channel id
@@ -353,6 +519,16 @@ class FetchHistoryTaskPayload(BaseModel):
 
 
 class CollectionTask(BaseModel):
+    """Строка таблицы `collection_tasks` — единица фоновой работы.
+
+    Несёт тип ([`CollectionTaskType`][src.models.CollectionTaskType]) и статус
+    ([`CollectionTaskStatus`][src.models.CollectionTaskStatus]) плюс
+    типизированный `payload` (union нагрузок под конкретный тип задачи, обычный
+    dict — для interop-типов). `last_progress_at` отличает реально застрявший
+    сбор от упавшего воркера; `result_payload` пишет внешний interop-воркер.
+    `parent_task_id` связывает порождённые подзадачи с родителем.
+    """
+
     id: int | None = None
     channel_id: int | None = None
     channel_title: str | None = None
@@ -387,6 +563,10 @@ class CollectionTask(BaseModel):
 
 
 class ChannelStats(BaseModel):
+    """Снимок метрик канала на момент `collected_at`: число подписчиков и средние
+    показатели по сообщениям (просмотры/реакции/пересылки). Хранится историей —
+    каждый сбор добавляет новую строку."""
+
     id: int | None = None
     channel_id: int
     subscriber_count: int | None = None
@@ -397,17 +577,27 @@ class ChannelStats(BaseModel):
 
 
 class PipelinePublishMode(StrEnum):
+    """Режим публикации пайплайна: `AUTO` — публиковать сразу после генерации,
+    `MODERATED` — отправлять результат на ручную модерацию перед публикацией."""
+
     AUTO = "auto"
     MODERATED = "moderated"
 
 
 class PipelineGenerationBackend(StrEnum):
+    """Движок генерации контента в пайплайне: простая LLM-цепочка (`CHAIN`),
+    агент (`AGENT`) или deepagents-бэкенд (`DEEP_AGENTS`)."""
+
     CHAIN = "chain"
     AGENT = "agent"
     DEEP_AGENTS = "deep_agents"
 
 
 class PipelineNodeType(StrEnum):
+    """Тип узла в графе-DAG пайплайна (#343): источник, шаги генерации/рефайна,
+    генерация картинки, публикация, уведомление, ветвления и Telegram-действия —
+    определяет, как узел исполняется обходчиком графа."""
+
     SOURCE = "source"
     RETRIEVE_CONTEXT = "retrieve_context"
     LLM_GENERATE = "llm_generate"
@@ -427,6 +617,10 @@ class PipelineNodeType(StrEnum):
 
 
 class PipelineNode(BaseModel):
+    """Узел графа пайплайна: тип ([`PipelineNodeType`][src.models.PipelineNodeType]),
+    имя, произвольный `config` под конкретный тип и `position` для отрисовки в
+    редакторе графа."""
+
     id: str
     type: PipelineNodeType
     name: str
@@ -435,6 +629,12 @@ class PipelineNode(BaseModel):
 
 
 class PipelineEdge(BaseModel):
+    """Направленное ребро графа пайплайна `from_node` → `to_node`.
+
+    В JSON сериализуется как `from`/`to` (отсюда алиасы полей); опциональный
+    `condition` делает ребро условным переходом из узла-ветвления.
+    """
+
     model_config = {"populate_by_name": True}
 
     from_node: str = Field(alias="from")
@@ -443,10 +643,17 @@ class PipelineEdge(BaseModel):
 
 
 class PipelineGraph(BaseModel):
+    """Граф-DAG пайплайна: узлы + рёбра, с (де)сериализацией в JSON для хранения.
+
+    Хранится строкой JSON в БД; `from`/`to` рёбер сохраняются в коротком виде.
+    """
+
     nodes: list[PipelineNode] = Field(default_factory=list)
     edges: list[PipelineEdge] = Field(default_factory=list)
 
     def to_json(self) -> str:
+        """Сериализовать граф в JSON-строку (рёбра — в коротком виде `from`/`to`,
+        `condition` опускается, если пуст)."""
         import json
         return json.dumps(
             {
@@ -461,6 +668,8 @@ class PipelineGraph(BaseModel):
 
     @classmethod
     def from_json(cls, data: str | dict) -> "PipelineGraph":
+        """Собрать граф из JSON-строки или уже разобранного dict (валидирует узлы
+        и рёбра через их модели)."""
         import json
         if isinstance(data, str):
             data = json.loads(data)
@@ -470,6 +679,10 @@ class PipelineGraph(BaseModel):
 
 
 class PipelineTemplate(BaseModel):
+    """Шаблон графа пайплайна для быстрого старта: готовый
+    [`PipelineGraph`][src.models.PipelineGraph] с именем/описанием/категорией.
+    `is_builtin` помечает встроенные шаблоны (поставляются с приложением)."""
+
     id: int | None = None
     name: str
     description: str = ""
@@ -480,6 +693,19 @@ class PipelineTemplate(BaseModel):
 
 
 class ContentPipeline(BaseModel):
+    """Конфигурация контент-пайплайна: генерация → (картинка) → черновик →
+    публикация.
+
+    Задаёт модели (`llm_model`/`image_model`), режим публикации
+    ([`PipelinePublishMode`][src.models.PipelinePublishMode]) и движок
+    ([`PipelineGenerationBackend`][src.models.PipelineGenerationBackend]).
+    `prompt_template`/`refinement_steps` описывают LLM-цепочку, а
+    `pipeline_json` — альтернативный узловой DAG (#343). `publish_times` —
+    JSON-массив времён публикации; `last_generated_id` — курсор инкрементальной
+    генерации. A/B-поля (`ab_num_variants`/`ab_auto_select`, #1068) включают
+    генерацию N вариантов текста (по умолчанию выключено — множит расход токенов).
+    """
+
     id: int | None = None
     name: str
     prompt_template: str = ""
@@ -503,6 +729,9 @@ class ContentPipeline(BaseModel):
 
 
 class PipelineSource(BaseModel):
+    """Привязка канала-источника к пайплайну: откуда берётся контекст/материал
+    для генерации (связь `pipeline_id` ↔ `channel_id`)."""
+
     id: int | None = None
     pipeline_id: int
     channel_id: int
@@ -510,6 +739,10 @@ class PipelineSource(BaseModel):
 
 
 class PipelineTarget(BaseModel):
+    """Цель публикации пайплайна: диалог (`dialog_id`) у аккаунта `phone`, куда
+    отправляется готовый контент. `title`/`dialog_type` — описательные поля
+    диалога."""
+
     id: int | None = None
     pipeline_id: int
     phone: str
@@ -520,6 +753,12 @@ class PipelineTarget(BaseModel):
 
 
 class PipelineRunTaskPayload(BaseModel):
+    """Нагрузка PIPELINE_RUN: запуск пайплайна `pipeline_id`.
+
+    `dry_run` — прогон без публикации; `since_hours` ограничивает окно исходных
+    сообщений, из которых берётся материал.
+    """
+
     task_kind: str = CollectionTaskType.PIPELINE_RUN.value
     pipeline_id: int
     dry_run: bool = False
@@ -527,6 +766,12 @@ class PipelineRunTaskPayload(BaseModel):
 
 
 class NotificationBot(BaseModel):
+    """Персональный бот уведомлений, созданный через BotFather под аккаунтом.
+
+    Связывает Telegram-пользователя (`tg_user_id`) с ботом (`bot_username`/
+    `bot_token`), через которого [`Notifier`][src.telegram.notifier] шлёт алерты.
+    """
+
     id: int = 0
     tg_user_id: int
     tg_username: str | None = None
@@ -537,6 +782,15 @@ class NotificationBot(BaseModel):
 
 
 class SearchQuery(BaseModel):
+    """Сохранённый поисковый запрос с расписанием и опциональными уведомлениями.
+
+    Режим поиска взаимоисключающий: `is_regex` (regex) либо `is_fts`
+    (полнотекстовый), иначе — подстрочный. `notify_on_collect` шлёт алерт о новых
+    совпадениях при сборе, `track_stats` копит дневную статистику попаданий,
+    `interval_minutes` задаёт период периодического прогона. `exclude_patterns`
+    (по строке на паттерн) и `max_length`/`chat_filter` сужают результат.
+    """
+
     id: int | None = None
     name: str = ""
     query: str
@@ -553,12 +807,14 @@ class SearchQuery(BaseModel):
 
     @model_validator(mode="after")
     def check_mode_exclusive(self) -> "SearchQuery":
+        """Запретить одновременно regex и FTS — режимы поиска взаимоисключающие."""
         if self.is_regex and self.is_fts:
             raise ValueError("is_regex and is_fts are mutually exclusive")
         return self
 
     @model_validator(mode="after")
     def default_name_to_query(self) -> "SearchQuery":
+        """Подставить текст запроса как имя, если имя не задано явно."""
         if not self.name:
             self.name = self.query
         return self
@@ -571,11 +827,22 @@ class SearchQuery(BaseModel):
 
 
 class SearchQueryDailyStat(BaseModel):
+    """Одна точка дневной статистики сохранённого запроса: число совпадений
+    (`count`) за дату `day` (формат `YYYY-MM-DD`)."""
+
     day: str  # "2026-03-07"
     count: int
 
 
 class SearchResult(BaseModel):
+    """Результат поиска: найденные сообщения плюс мета о выдаче.
+
+    `total` — нижняя оценка числа совпадений для локального поиска по БД (точна
+    только когда `has_more=False`); другие режимы трактуют его по-своему.
+    `ai_summary` заполняется AI-поиском, `flood_wait` сигнализирует о Telegram
+    FLOOD_WAIT, `error` — о неуспехе запроса.
+    """
+
     messages: list[Message]
     # Lower bound for local DB search since #766 (offset + page size; exact only
     # when has_more is False); other modes keep their own semantics.
@@ -588,6 +855,16 @@ class SearchResult(BaseModel):
 
 
 class GenerationRun(BaseModel):
+    """Один прогон генерации контента (строка `generation_runs`).
+
+    Фиксирует вход (`prompt`) и выход (`generated_text`/`image_url`) с двумя
+    осями состояния: `status` (жизненный цикл прогона) и `moderation_status`
+    (одобрение к публикации). `quality_score`/`quality_issues` — оценка качества;
+    `variants`/`selected_variant` — A/B-варианты и выбранный (#1068). `metadata`
+    хранит произвольные данные прогона (например, цитаты-источники), из которых
+    свойства `result_kind`/`result_count` выводят сводку результата.
+    """
+
     id: int | None = None
     pipeline_id: int | None = None
     status: str = "pending"
@@ -629,11 +906,18 @@ class GenerationRun(BaseModel):
 
 
 class PhotoSendMode(StrEnum):
+    """Способ отправки набора фото: одним альбомом (`ALBUM`) или отдельными
+    сообщениями (`SEPARATE`)."""
+
     ALBUM = "album"
     SEPARATE = "separate"
 
 
 class PhotoBatchStatus(StrEnum):
+    """Жизненный цикл фото-батча/элемента: `PENDING`/`SCHEDULED` → `RUNNING` →
+    терминальные `COMPLETED`/`FAILED`/`CANCELLED` (`SCHEDULED` — отложенная
+    отправка по времени)."""
+
     PENDING = "pending"
     RUNNING = "running"
     COMPLETED = "completed"
@@ -643,6 +927,15 @@ class PhotoBatchStatus(StrEnum):
 
 
 class PhotoBatch(BaseModel):
+    """Батч отправки фото в один диалог (`target_dialog_id`) под аккаунтом
+    `phone`.
+
+    Группирующая запись с режимом отправки
+    ([`PhotoSendMode`][src.models.PhotoSendMode]) и статусом
+    ([`PhotoBatchStatus`][src.models.PhotoBatchStatus]); конкретные файлы несут
+    элементы [`PhotoBatchItem`][src.models.PhotoBatchItem].
+    """
+
     id: int | None = None
     phone: str
     target_dialog_id: int
@@ -657,6 +950,13 @@ class PhotoBatch(BaseModel):
 
 
 class PhotoBatchItem(BaseModel):
+    """Элемент фото-батча: конкретный набор файлов (`file_paths`) к отправке.
+
+    Может выполняться отложенно (`schedule_at`); по факту отправки заполняется
+    `telegram_message_ids`. `batch_id` связывает с
+    [`PhotoBatch`][src.models.PhotoBatch] (может быть пуст для одиночной отправки).
+    """
+
     id: int | None = None
     batch_id: int | None = None
     phone: str
@@ -676,6 +976,9 @@ class PhotoBatchItem(BaseModel):
 
 
 class GeneratedImage(BaseModel):
+    """Сгенерированная картинка: `prompt` и `model`, которыми создана, плюс ссылка
+    `image_url` и/или локальный путь `local_path`."""
+
     id: int | None = None
     prompt: str
     model: str | None = None
@@ -685,6 +988,16 @@ class GeneratedImage(BaseModel):
 
 
 class PhotoAutoUploadJob(BaseModel):
+    """Авто-задание: периодически отправлять новые фото из папки в диалог.
+
+    Сканирует `folder_path` каждые `interval_minutes` и шлёт появившиеся файлы в
+    `target_dialog_id` под аккаунтом `phone`. Дедуп от повторной отправки ведётся
+    не здесь, а по таблице `photo_auto_upload_files` (`has_sent_auto_file` /
+    `mark_auto_file_sent`); `last_seen_marker` — лишь вспомогательная отметка
+    последнего просмотра (записывается, но сам по себе отправку не блокирует).
+    `is_active` включает/выключает задание.
+    """
+
     id: int | None = None
     phone: str
     target_dialog_id: int

--- a/tests/test_cli_process_database_repository_paths.py
+++ b/tests/test_cli_process_database_repository_paths.py
@@ -1577,6 +1577,28 @@ async def test_photo_loader_delete_auto_job(db):
 
 
 @pytest.mark.anyio
+async def test_photo_loader_delete_auto_job_with_ledger(db):
+    """delete_auto_job must drop the sent-files ledger before the parent job.
+
+    Regression (#1134 review): the ledger row in photo_auto_upload_files has a
+    FOREIGN KEY → photo_auto_upload_jobs(id) without ON DELETE CASCADE, and the
+    connection runs PRAGMA foreign_keys=ON. Deleting the parent job first raised
+    "FOREIGN KEY constraint failed", so any auto-job that had ever sent a file
+    could not be deleted. The child ledger must go first.
+    """
+    job = _make_auto_job()
+    job_id = await db.repos.photo_loader.create_auto_job(job)
+    # Mark a file sent → creates a ledger row that FK-references the job.
+    await db.repos.photo_loader.mark_auto_file_sent(job_id, "/tmp/photos/a.jpg")
+
+    await db.repos.photo_loader.delete_auto_job(job_id)
+
+    assert await db.repos.photo_loader.get_auto_job(job_id) is None
+    # Ledger is gone too — no orphaned rows survive the delete.
+    assert await db.repos.photo_loader.has_sent_auto_file(job_id, "/tmp/photos/a.jpg") is False
+
+
+@pytest.mark.anyio
 async def test_photo_loader_has_sent_auto_file(db):
     job = _make_auto_job()
     job_id = await db.repos.photo_loader.create_auto_job(job)


### PR DESCRIPTION
## Что и зачем

Sub-issue эпика техдолга #1130 (ось 4: doc-coverage). Цель — поднять doc-coverage добавлением docstring к **ключевым публичным API** (≥35%, ratchet floor), сфокусировавшись на том, что реально читают люди и agent-LLM, а не на формальном 100%.

doc-coverage был **27.0%**. Незадокументированным оставался **фасад данных** — публичный API, который читается чаще всего: Pydantic-модели, бандлы `db.repos.*`, CRUD репозиториев. Эти же docstring питают авто-документацию `/api` (mkdocstrings, #1071) — двойная выгода: чище код И богаче генерируемые доки.

## Метрика

| | До | После |
|---|---|---|
| Покрытие (interrogate) | 27.0% | **40.6%** |
| Задокументировано | 857 / 3175 | **1288 / 3175** |
| `fail_under` (ratchet floor) | 23 | **35** |

Замер: `python scripts/doc_coverage.py`.

## Что сделано

docstring — только описание; сигнатуры не менялись. Покрыт высокоROI-публичный API:
- **`src/models.py`** — каждая Pydantic-модель/enum + module-docstring + методы `PipelineGraph.to_json/from_json` и валидаторы `SearchQuery`.
- **`src/config.py`** — все конфиг-dataclass'ы + `is_provider_model_ref` + module-docstring.
- **`src/database/bundles.py`** — агрегатор `db.repos` и каждый `*Bundle`-обёртка (155 узлов — был крупнейший долг).
- **`src/database/repositories/*.py`** (все 22) — класс-репозиторий + каждый публичный CRUD-метод (типы возврата, неочевидные параметры, инварианты).

**Пропущено** (низкий ROI, шум — по решению из issue): web `forms.py`/`runtime_shims.py`/`deps.py` (glue-код), вложенные обработчики agent-tools (их `@tool`-описание уже документирует инструмент для LLM).

## Ratchet

`[tool.interrogate] fail_under` 23 → 35 — фиксирует достигнутое с запасом ниже 40.6%. Doc-coverage **остаётся локальным скриптом, НЕ CI-гейтом** (#1097) — `ci.yml` не тронут.

## Фикс по итогам cycle-review (Codex)

Локальный dual cycle-review (Codex ∥ Claude). Codex точечно сверил docstring с кодом и нашёл **1 реальный баг + 7 over-claim неточностей**. Все исправлены — docstring приведены в соответствие с кодом, баг починен с регресс-тестом:

- **🐞 BUG (Major):** `PhotoLoaderRepository.delete_auto_job` удалял parent-задание **до** child-леджера `photo_auto_upload_files`. Леджер ссылается FK без `ON DELETE CASCADE`, соединение работает с `PRAGMA foreign_keys=ON` → удаление любого авто-задания, **которое хоть раз отправляло файл**, падало с `FOREIGN KEY constraint failed`. Теперь child удаляется первым; добавлен регресс-тест `test_photo_loader_delete_auto_job_with_ledger` (падает на старом порядке — TDD red→green).
- **Точность docstring:** `set_filtered_bulk` (`channel_id`, не `pk`); accounts — «не более одного primary» (0 допустим), не «ровно один»; `FilterAnalyzeTaskPayload` поля-итоги — слоты, не заполняются handler'ом; дедуп `PhotoAutoUploadJob` — леджер, не `last_seen_marker`; `set_published_at` — единственный путь, ставящий `published_at` *вместе* со статусом; upsert-хелперы возвращают `cur.lastrowid` (надёжно только на вставке — проверено эмпирически на conflict-update); `WEB_USER` (не захардкоженный admin); `:memory:` пропускает read-пул, не кэш.

## Проверки

- `scripts/doc_coverage.py` — 40.6% ≥ 35% (гейт ок, exit 0)
- `ruff check` — чисто
- `mypy` — 0 новых ошибок в изменённых файлах (baseline type-долг — в нетронутых модулях)
- pytest — 617 целевых тестов зелёные: репозитории, bundles, config, photo_loader (вкл. новый регресс), `test_doc_coverage`, `test_docs_api_reference` (mkdocstrings) + smoke preflight

Closes #1134

🤖 Generated with [Claude Code](https://claude.com/claude-code)
