### PR TITLE
test(pipeline): instance-method regression guard for source-scope fail-closed (#1118)

### DIFF
--- a/tests/test_pipeline_service_edge_cases.py
+++ b/tests/test_pipeline_service_edge_cases.py
@@ -1282,6 +1282,39 @@ async def test_resolve_scope_error_does_not_widen_to_unscoped():
 
 
 @pytest.mark.anyio
+async def test_get_retrieval_scope_method_source_lookup_error_fails_closed(svc):
+    """Instance-method regression guard (#1118, dup of #1077).
+
+    ``resolve_retrieval_scope`` (the free function) is already covered above,
+    but the public surface every caller actually uses is the
+    ``PipelineService.get_retrieval_scope`` *method*, which wires the bundle's
+    ``list_sources`` into the function. #1118 re-reported the original
+    fail-OPEN (a failed source lookup widened scope to channel_id=None → an
+    all-channels retrieval → cross-channel content leak) against this method's
+    surface. We assert end-to-end through the method that a source-lookup
+    failure FAILS CLOSED with ``PipelineScopeError`` instead of returning an
+    unscoped scope — closing the dup at the layer the issue named."""
+    from src.services.pipeline_service import PipelineScopeError
+
+    pipeline = ContentPipeline(id=4242, name="MethodBoom", prompt_template="t")
+
+    async def exploding_lister(_pid):
+        raise RuntimeError("transient DB blip")
+
+    # PipelineBundle is a frozen dataclass, so patch the underlying repository
+    # method the bundle delegates to (bundle.list_sources → repo.list_sources).
+    svc._bundle.content_pipelines.list_sources = exploding_lister
+
+    returned_scope = None
+    with pytest.raises(PipelineScopeError):
+        returned_scope = await svc.get_retrieval_scope(pipeline)
+    # Mutation-guard: drop the raise in resolve_retrieval_scope and this method
+    # would hand back an unscoped (channel_id=None) result — caught here because
+    # the only acceptable outcome is the raise above, never an assigned scope.
+    assert returned_scope is None
+
+
+@pytest.mark.anyio
 async def test_resolve_scope_multi_source_is_unscoped():
     """More than one source → no single-channel scope (retrieve across all)."""
     from src.services.pipeline_service import resolve_retrieval_scope


### PR DESCRIPTION
## Summary

**The bug in #1118 is already fixed** — it is an exact duplicate of #1077, closed by PR #1102. This PR adds the one missing regression guard and closes #1118 legitimately via merge (manual issue-closing was disallowed by the owner).

### Why #1118 is a duplicate

- PR #1102 (fix for #1077) merged to `main` at **2026-06-24 07:32 UTC**.
- Issue #1118 was created at **2026-06-24 15:37 UTC** — ~8h **after** the fix landed. The Codex bug-hunt evidently ran against a pre-#1102 snapshot.
- The exact fail-open fragment quoted in #1118 (`logger.warning(... "continuing without channel scoping" ...)` + `return ... channel_id=None`) **no longer exists**. `pipeline_service.py` now **fail-CLOSED**: `raise PipelineScopeError` on a source-lookup error.

### Content-isolation contract (already enforced on all 5 surfaces)

A `channel_id` of `None` means UNSCOPED retrieval across ALL channels. A failed source lookup must never widen a single-source pipeline into a cross-channel search (a trust-boundary breach). Verified fail-closed end-to-end:

| Surface | Behaviour on source-load error |
|---|---|
| `pipeline_service.resolve_retrieval_scope` | `raise PipelineScopeError` |
| `content_generation_service._run_graph` / `_run_rag` | propagates up → run marked `failed` |
| Web `handlers.py:513-516` | catches → clean redirect with `error=`, no run created |
| CLI `pipeline.py:555-559` | catches → error event + `return` before run creation |
| Agent-tool `pipeline_runs.py:98` | caught by `except Exception` → error message, no generation |

Legitimate `channel_id=None` paths (no lister / 0 / >1 sources) are **preserved** — fail-closed only on an *errored* lookup.

### What this PR adds

The free function `resolve_retrieval_scope` already has a mutation-guarded test. The public surface every caller uses is the **`PipelineService.get_retrieval_scope` method** — the exact layer #1118 named. This adds an end-to-end guard through that method proving a source-lookup failure FAILS CLOSED with `PipelineScopeError` instead of returning an unscoped scope.

**Test-only change** (the bug is already fixed). Verified by mutation: swapping the `raise` back to swallow-and-return turns the new test RED (`DID NOT RAISE PipelineScopeError`).

## Testing

- `pytest tests/test_pipeline_service_edge_cases.py tests/test_generation_service_rag_context.py tests/routes/test_pipelines_routes.py -n auto` → **146 passed**
- Mutation-verified RED↔GREEN on the new guard
- `ruff check` clean; mypy adds 0 new errors

Closes #1118
Related: #1077, #1037

🤖 Generated with [Claude Code](https://claude.com/claude-code)