### PR TITLE
feat(account): CLI export-session / import for SSO session string

### DIFF
--- a/src/cli/commands/account.py
+++ b/src/cli/commands/account.py
@@ -79,7 +79,7 @@ async def _run_export_session(args: argparse.Namespace, db: Database) -> None:
         return
 
     try:
-        session_string = await db.get_decrypted_session(account_id=match.id, phone=None)
+        session_string = await db.repos.accounts.get_decrypted_session(account_id=match.id, phone=None)
     except AccountSessionDecryptError as exc:
         print(f"ERROR: cannot decrypt session for {match.phone} ({exc.status})")
         return

--- a/src/cli/commands/account.py
+++ b/src/cli/commands/account.py
@@ -6,6 +6,7 @@ import json
 import logging
 import sys
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING
 
 from src.agent.runtime_context import AgentRuntimeContext
 from src.agent.tools.accounts import get_live_account_info_text
@@ -13,7 +14,10 @@ from src.cli import runtime
 from src.models import Account
 from src.services.notification_target_service import NotificationTargetService
 from src.settings_utils import parse_int_setting
-from src.telegram.auth import TelegramAuth
+from src.telegram.auth import TelegramAuth, validate_session_string
+
+if TYPE_CHECKING:
+    from src.database import Database
 
 
 def _pending_key(phone: str) -> str:
@@ -46,6 +50,62 @@ async def _resolve_credentials(args: argparse.Namespace, config, db) -> tuple[in
     return api_id, api_hash
 
 
+async def _run_export_session(args: argparse.Namespace, db: Database) -> None:
+    """Print the decrypted plaintext StringSession for an account (SSO export, #828).
+
+    The session string grants full access to the account — it is printed to stdout
+    ONLY on this explicit request and is NEVER logged. Selects by ``--id`` or ``--phone``.
+    """
+    account_id = getattr(args, "id", None)
+    phone = getattr(args, "phone", None)
+    accounts = await db.get_accounts(active_only=False)
+    if account_id is not None:
+        acc = next((a for a in accounts if a.id == account_id), None)
+    elif phone:
+        acc = next((a for a in accounts if a.phone == phone), None)
+    else:
+        print("ERROR: provide --id or --phone")
+        return
+    if not acc:
+        target = f"id={account_id}" if account_id is not None else phone
+        print(f"Account {target} not found")
+        return
+
+    if getattr(args, "json", False):
+        print(json.dumps({"phone": acc.phone, "session_string": acc.session_string}))
+    else:
+        print(acc.session_string)
+
+
+async def _run_import(args: argparse.Namespace, db: Database) -> None:
+    """Add an account from a ready StringSession instead of the login flow (SSO import, #828).
+
+    Validates the session via the telegram layer (CLI must not import telethon directly),
+    then takes the normal ``add_account`` path — the repository encrypts at rest as usual.
+    The raw session string is never echoed back or logged.
+    """
+    phone = getattr(args, "phone", None)
+    session_string = getattr(args, "session_string", None)
+    if not phone or not session_string:
+        print("ERROR: provide --phone and --session-string")
+        return
+
+    if not validate_session_string(session_string):
+        print(f"ERROR: invalid Telegram session string for {phone}")
+        return
+
+    existing = await db.get_account_summaries(active_only=False)
+    is_primary = len(existing) == 0
+    account = Account(
+        phone=phone,
+        session_string=session_string,
+        is_primary=is_primary,
+        is_premium=False,
+    )
+    await db.add_account(account)
+    print(f"Account {phone} imported successfully (primary={is_primary}).")
+
+
 def run(args: argparse.Namespace) -> None:
     async def _run() -> None:
         config, db = await runtime.init_db(args.config)
@@ -53,6 +113,14 @@ def run(args: argparse.Namespace) -> None:
         try:
             if args.account_action == "add":
                 args.account_action = "verify-code" if getattr(args, "code", None) else "send-code"
+
+            if args.account_action == "export-session":
+                await _run_export_session(args, db)
+                return
+
+            if args.account_action == "import":
+                await _run_import(args, db)
+                return
 
             if args.account_action == "send-code":
                 phone = args.phone

--- a/src/cli/commands/account.py
+++ b/src/cli/commands/account.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 from src.agent.runtime_context import AgentRuntimeContext
 from src.agent.tools.accounts import get_live_account_info_text
 from src.cli import runtime
+from src.database.repositories.accounts import AccountSessionDecryptError
 from src.models import Account
 from src.services.notification_target_service import NotificationTargetService
 from src.settings_utils import parse_int_setting
@@ -54,27 +55,43 @@ async def _run_export_session(args: argparse.Namespace, db: Database) -> None:
     """Print the decrypted plaintext StringSession for an account (SSO export, #828).
 
     The session string grants full access to the account — it is printed to stdout
-    ONLY on this explicit request and is NEVER logged. Selects by ``--id`` or ``--phone``.
+    ONLY on this explicit request and is NEVER logged. Selects by ``--id`` or ``--phone``
+    (exactly one). Decrypts only the chosen account, so a broken sibling session can't
+    abort the lookup — this is the recovery path operators reach for.
     """
     account_id = getattr(args, "id", None)
     phone = getattr(args, "phone", None)
-    accounts = await db.get_accounts(active_only=False)
-    if account_id is not None:
-        acc = next((a for a in accounts if a.id == account_id), None)
-    elif phone:
-        acc = next((a for a in accounts if a.phone == phone), None)
-    else:
-        print("ERROR: provide --id or --phone")
+    if (account_id is None) == (phone is None):
+        print("ERROR: provide exactly one of --id or --phone")
         return
-    if not acc:
-        target = f"id={account_id}" if account_id is not None else phone
+
+    # Resolve identity without decrypting the whole DB (a broken sibling session
+    # must not crash export of a healthy account, #1143 review).
+    summaries = await db.get_account_summaries(active_only=False)
+    if account_id is not None:
+        match = next((s for s in summaries if s.id == account_id), None)
+        target = f"id={account_id}"
+    else:
+        match = next((s for s in summaries if s.phone == phone), None)
+        target = phone
+    if match is None:
         print(f"Account {target} not found")
         return
 
+    try:
+        session_string = await db.get_decrypted_session(account_id=match.id, phone=None)
+    except AccountSessionDecryptError as exc:
+        print(f"ERROR: cannot decrypt session for {match.phone} ({exc.status})")
+        return
+    if not session_string:
+        print(f"ERROR: account {match.phone} has no session string to export")
+        return
+
+    print("WARNING: this session string grants full access to the account.", file=sys.stderr)
     if getattr(args, "json", False):
-        print(json.dumps({"phone": acc.phone, "session_string": acc.session_string}))
+        print(json.dumps({"phone": match.phone, "session_string": session_string}))
     else:
-        print(acc.session_string)
+        print(session_string)
 
 
 async def _run_import(args: argparse.Namespace, db: Database) -> None:
@@ -85,9 +102,9 @@ async def _run_import(args: argparse.Namespace, db: Database) -> None:
     The raw session string is never echoed back or logged.
     """
     phone = getattr(args, "phone", None)
-    session_string = getattr(args, "session_string", None)
+    session_string = _read_session_arg(args)
     if not phone or not session_string:
-        print("ERROR: provide --phone and --session-string")
+        print("ERROR: provide --phone and a session string (--session-string or --session-string-stdin)")
         return
 
     if not validate_session_string(session_string):
@@ -95,6 +112,18 @@ async def _run_import(args: argparse.Namespace, db: Database) -> None:
         return
 
     existing = await db.get_account_summaries(active_only=False)
+    # add_account is an ON CONFLICT(phone) UPSERT: importing onto an existing phone
+    # would silently overwrite its session and reset is_active/is_premium. Refuse
+    # unless --force is given, so an import can't clobber a working account (#1143 review).
+    if any(s.phone == phone for s in existing):
+        if not getattr(args, "force", False):
+            print(
+                f"Account {phone} already exists; import would overwrite its session. "
+                f"Delete it first, or re-run with --force to replace."
+            )
+            return
+        print(f"WARNING: overwriting existing session for {phone} (--force).", file=sys.stderr)
+
     is_primary = len(existing) == 0
     account = Account(
         phone=phone,
@@ -104,6 +133,17 @@ async def _run_import(args: argparse.Namespace, db: Database) -> None:
     )
     await db.add_account(account)
     print(f"Account {phone} imported successfully (primary={is_primary}).")
+
+
+def _read_session_arg(args: argparse.Namespace) -> str | None:
+    """Resolve the session string from --session-string-stdin (preferred) or --session-string.
+
+    Reading from stdin keeps the secret out of argv / shell history / ``/proc`` (#1143 review).
+    """
+    if getattr(args, "session_string_stdin", False):
+        return sys.stdin.read().strip() or None
+    value = getattr(args, "session_string", None)
+    return value.strip() if value else None
 
 
 def run(args: argparse.Namespace) -> None:

--- a/src/cli/parser_domains/account.py
+++ b/src/cli/parser_domains/account.py
@@ -59,8 +59,9 @@ def register(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser 
         "export-session",
         help="Print the decrypted StringSession for SSO (⚠️ full account access — keep secret)",
     )
-    acc_export.add_argument("--id", type=int, default=None, help="Account id")
-    acc_export.add_argument("--phone", default=None, help="Account phone number")
+    acc_export_sel = acc_export.add_mutually_exclusive_group(required=True)
+    acc_export_sel.add_argument("--id", type=int, default=None, help="Account id")
+    acc_export_sel.add_argument("--phone", default=None, help="Account phone number")
     acc_export.add_argument("--json", action="store_true", help="Emit {phone, session_string} JSON")
 
     acc_import = acc_sub.add_parser(
@@ -68,7 +69,16 @@ def register(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser 
         help="Add an account from a ready StringSession (SSO import, skips login)",
     )
     acc_import.add_argument("--phone", required=True, help="Phone number with country code")
+    acc_import_src = acc_import.add_mutually_exclusive_group(required=True)
+    acc_import_src.add_argument(
+        "--session-string", dest="session_string", default=None,
+        help="Telegram StringSession to import (⚠️ appears in shell history — prefer --session-string-stdin)",
+    )
+    acc_import_src.add_argument(
+        "--session-string-stdin", dest="session_string_stdin", action="store_true",
+        help="Read the StringSession from stdin (keeps the secret out of argv / shell history)",
+    )
     acc_import.add_argument(
-        "--session-string", required=True, dest="session_string",
-        help="Telegram StringSession to import (⚠️ full account access — keep secret)",
+        "--force", action="store_true",
+        help="Overwrite the session of an account that already exists for this phone",
     )

--- a/src/cli/parser_domains/account.py
+++ b/src/cli/parser_domains/account.py
@@ -54,3 +54,21 @@ def register(subparsers: argparse._SubParsersAction) -> argparse.ArgumentParser 
 
     acc_flood_clear = acc_sub.add_parser("flood-clear", help="Clear flood wait for an account")
     acc_flood_clear.add_argument("--phone", required=True, help="Account phone number")
+
+    acc_export = acc_sub.add_parser(
+        "export-session",
+        help="Print the decrypted StringSession for SSO (⚠️ full account access — keep secret)",
+    )
+    acc_export.add_argument("--id", type=int, default=None, help="Account id")
+    acc_export.add_argument("--phone", default=None, help="Account phone number")
+    acc_export.add_argument("--json", action="store_true", help="Emit {phone, session_string} JSON")
+
+    acc_import = acc_sub.add_parser(
+        "import",
+        help="Add an account from a ready StringSession (SSO import, skips login)",
+    )
+    acc_import.add_argument("--phone", required=True, help="Phone number with country code")
+    acc_import.add_argument(
+        "--session-string", required=True, dest="session_string",
+        help="Telegram StringSession to import (⚠️ full account access — keep secret)",
+    )

--- a/src/database/facade.py
+++ b/src/database/facade.py
@@ -388,12 +388,6 @@ class Database:
         self._require()
         return await self._accounts.get_account_summaries(active_only)
 
-    async def get_decrypted_session(
-        self, *, account_id: int | None = None, phone: str | None = None
-    ) -> str | None:
-        self._require()
-        return await self._accounts.get_decrypted_session(account_id=account_id, phone=phone)
-
     async def update_account_flood(self, phone: str, until) -> None:
         self._require()
         await self._accounts.update_account_flood(phone, until)

--- a/src/database/facade.py
+++ b/src/database/facade.py
@@ -388,6 +388,12 @@ class Database:
         self._require()
         return await self._accounts.get_account_summaries(active_only)
 
+    async def get_decrypted_session(
+        self, *, account_id: int | None = None, phone: str | None = None
+    ) -> str | None:
+        self._require()
+        return await self._accounts.get_decrypted_session(account_id=account_id, phone=phone)
+
     async def update_account_flood(self, phone: str, until) -> None:
         self._require()
         await self._accounts.update_account_flood(phone, until)

--- a/src/database/repositories/accounts.py
+++ b/src/database/repositories/accounts.py
@@ -336,6 +336,33 @@ class AccountsRepository:
 
         return accounts
 
+    async def get_decrypted_session(
+        self, *, account_id: int | None = None, phone: str | None = None
+    ) -> str | None:
+        """Decrypt and return ONE account's session string, or ``None`` if no such account.
+
+        Unlike :meth:`get_accounts`, this reads and decrypts only the single selected
+        row, so a broken/undecryptable *sibling* account cannot abort the lookup — the
+        exact recovery path SSO export needs (#828). Exactly one of ``account_id`` /
+        ``phone`` must be given. A decrypt failure on the *target* still raises
+        :class:`AccountSessionDecryptError` (the caller wants to know).
+        """
+        if (account_id is None) == (phone is None):
+            raise ValueError("provide exactly one of account_id / phone")
+        if account_id is not None:
+            cur = await self._db.execute(
+                "SELECT phone, session_string FROM accounts WHERE id = ?", (account_id,)
+            )
+        else:
+            cur = await self._db.execute(
+                "SELECT phone, session_string FROM accounts WHERE phone = ?", (phone,)
+            )
+        row = await cur.fetchone()
+        if row is None:
+            return None
+        raw_session = str(row["session_string"] or "")
+        return self._decrypt_session_for_live_use(raw_session, str(row["phone"]))
+
     async def get_live_usable_accounts(self, active_only: bool = False) -> list[Account]:
         """Return accounts whose sessions can be decrypted for live Telegram use."""
         sql = "SELECT * FROM accounts"

--- a/src/telegram/auth.py
+++ b/src/telegram/auth.py
@@ -37,6 +37,26 @@ AUTH_RPC_TIMEOUT_SECONDS = 60
 _T = TypeVar("_T")
 
 
+def validate_session_string(session_string: str) -> bool:
+    """Return True iff ``session_string`` is a structurally usable Telegram StringSession.
+
+    A usable session must parse AND carry the four fields a live client needs:
+    ``auth_key``, ``server_address``, ``port`` and ``dc_id`` (mirrors the check in
+    :meth:`SessionMaterializer.materialize`). This lives in the telegram layer on
+    purpose: the CLI / web / agent entrypoints are forbidden from importing
+    ``telethon`` directly (import-linter), so they call this helper instead.
+
+    The value is a secret (full account access) — never log it here.
+    """
+    if not session_string:
+        return False
+    try:
+        source = StringSession(session_string)
+    except Exception:  # noqa: BLE001 - malformed input must never raise, just fail validation
+        return False
+    return bool(source.auth_key and source.server_address and source.port and source.dc_id)
+
+
 class TelegramAuthTimeoutError(TimeoutError):
     """Raised when a Telegram auth operation exceeds its explicit timeout."""
 

--- a/tests/cli_real_tg_integration/command_manifest.py
+++ b/tests/cli_real_tg_integration/command_manifest.py
@@ -152,7 +152,15 @@ CLI_REAL_TG_MANUAL_OR_EXCLUDED_COMMANDS: dict[tuple[str, ...], str] = {
     ),
     ("account", "add"): "manual account onboarding/session import",
     ("account", "delete"): "dangerous live account deletion; intentionally blocked from live testing",
+    ("account", "export-session"): (
+        "exports a decrypted StringSession (full account access); DB+crypto only, no live "
+        "Telegram, covered by unit tests — kept out of live suite as a secret-handling op (#828)"
+    ),
     ("account", "flood-clear"): "local flood state mutation",
+    ("account", "import"): (
+        "imports an account from a ready StringSession (full account access); DB+crypto only, "
+        "no live Telegram, covered by unit tests — secret-handling op kept out of live suite (#828)"
+    ),
     ("account", "send-code"): "Telegram auth flow",
     ("account", "set-primary"): "local account state mutation",
     ("account", "toggle"): "local account state mutation",

--- a/tests/test_session_string_io_1143.py
+++ b/tests/test_session_string_io_1143.py
@@ -29,6 +29,28 @@ def _make_valid_session_string() -> str:
     return s.save()
 
 
+def _import_ns(phone: str, session_string: str | None, *, stdin: bool = False, force: bool = False):
+    return argparse.Namespace(
+        config=None,
+        account_action="import",
+        phone=phone,
+        session_string=session_string,
+        session_string_stdin=stdin,
+        force=force,
+        json=False,
+    )
+
+
+def _export_ns(*, account_id=None, phone=None, as_json: bool = False):
+    return argparse.Namespace(
+        config=None,
+        account_action="export-session",
+        id=account_id,
+        phone=phone,
+        json=as_json,
+    )
+
+
 # ---------------------------------------------------------------------------
 # telegram-layer helper
 # ---------------------------------------------------------------------------
@@ -71,6 +93,8 @@ async def test_cli_import_adds_account(tmp_path, capsys):
             account_action="import",
             phone="+15551230000",
             session_string=session,
+            session_string_stdin=False,
+            force=False,
             json=False,
         )
         # run() builds its own db via runtime.init_db — patch it to our db.
@@ -95,6 +119,8 @@ async def test_cli_import_rejects_invalid_session(tmp_path, capsys):
             account_action="import",
             phone="+15551230001",
             session_string="garbage",
+            session_string_stdin=False,
+            force=False,
             json=False,
         )
         await account_cmd._run_import(args, db)
@@ -151,5 +177,112 @@ async def test_cli_export_session_unknown_id(tmp_path, capsys):
         await account_cmd._run_export_session(args, db)
         out = capsys.readouterr().out.lower()
         assert "not found" in out
+    finally:
+        await db.close()
+
+
+@pytest.mark.anyio
+async def test_cli_export_survives_broken_sibling_session(tmp_path, capsys):
+    """Exporting a healthy account must not crash because *another* row is undecryptable.
+
+    Regression guard for the review HIGH: get_accounts() eagerly decrypts every row, so
+    export resolved identity via summaries + a single-account decrypt instead.
+    """
+    db = Database(str(tmp_path / "test.db"))
+    await db.initialize()
+    try:
+        good = _make_valid_session_string()
+        await db.add_account(Account(phone="+15551230010", session_string=good))
+        # A row that looks encrypted but has no key configured → undecryptable sibling.
+        broken_id = await db.add_account(
+            Account(phone="+15551230011", session_string="enc:v2:not-decryptable")
+        )
+        assert broken_id  # sibling exists
+
+        await account_cmd._run_export_session(_export_ns(phone="+15551230010"), db)
+        out = capsys.readouterr().out
+        assert good in out
+    finally:
+        await db.close()
+
+
+@pytest.mark.anyio
+async def test_cli_import_refuses_overwrite_without_force(tmp_path, capsys):
+    """Importing onto an existing phone must NOT silently overwrite (data-loss guard)."""
+    db = Database(str(tmp_path / "test.db"))
+    await db.initialize()
+    try:
+        original = _make_valid_session_string()
+        await db.add_account(Account(phone="+15551230020", session_string=original))
+
+        replacement = _make_valid_session_string()
+        assert replacement != original or True  # both valid; content irrelevant to the guard
+        await account_cmd._run_import(_import_ns("+15551230020", replacement), db)
+
+        out = capsys.readouterr().out.lower()
+        assert "already exists" in out
+        # session unchanged
+        assert await db.get_decrypted_session(phone="+15551230020") == original
+    finally:
+        await db.close()
+
+
+@pytest.mark.anyio
+async def test_cli_import_force_overwrites(tmp_path):
+    """--force replaces the session of an existing account."""
+    db = Database(str(tmp_path / "test.db"))
+    await db.initialize()
+    try:
+        await db.add_account(
+            Account(phone="+15551230021", session_string=_make_valid_session_string())
+        )
+        new_session = _make_valid_session_string()
+        # make it distinct from the original
+        s = StringSession(new_session)
+        s.set_dc(4, "149.154.167.91", 443)
+        new_session = s.save()
+
+        await account_cmd._run_import(_import_ns("+15551230021", new_session, force=True), db)
+        assert await db.get_decrypted_session(phone="+15551230021") == new_session
+    finally:
+        await db.close()
+
+
+@pytest.mark.anyio
+async def test_cli_import_from_stdin(tmp_path, monkeypatch):
+    """--session-string-stdin reads the secret from stdin (keeps it out of argv)."""
+    import io
+
+    db = Database(str(tmp_path / "test.db"))
+    await db.initialize()
+    try:
+        session = _make_valid_session_string()
+        monkeypatch.setattr("sys.stdin", io.StringIO(session + "\n"))
+        await account_cmd._run_import(_import_ns("+15551230022", None, stdin=True), db)
+        assert await db.get_decrypted_session(phone="+15551230022") == session
+    finally:
+        await db.close()
+
+
+@pytest.mark.anyio
+async def test_import_encrypts_at_rest_then_export_roundtrips(tmp_path, capsys):
+    """With SESSION_ENCRYPTION_KEY set: stored column is enc:v2:*, export returns plaintext."""
+    db = Database(str(tmp_path / "test.db"), session_encryption_secret="test-secret-key")
+    await db.initialize()
+    try:
+        session = _make_valid_session_string()
+        await account_cmd._run_import(_import_ns("+15551230023", session), db)
+
+        # Stored at rest must be encrypted, not the plaintext.
+        cur = await db.execute("SELECT session_string FROM accounts WHERE phone = ?", ("+15551230023",))
+        row = await cur.fetchone()
+        assert row is not None
+        stored = str(row["session_string"])
+        assert stored.startswith("enc:v2:")
+        assert session not in stored
+
+        # Export still yields the decrypted plaintext.
+        await account_cmd._run_export_session(_export_ns(phone="+15551230023"), db)
+        assert session in capsys.readouterr().out
     finally:
         await db.close()

--- a/tests/test_session_string_io_1143.py
+++ b/tests/test_session_string_io_1143.py
@@ -222,7 +222,7 @@ async def test_cli_import_refuses_overwrite_without_force(tmp_path, capsys):
         out = capsys.readouterr().out.lower()
         assert "already exists" in out
         # session unchanged
-        assert await db.get_decrypted_session(phone="+15551230020") == original
+        assert await db.repos.accounts.get_decrypted_session(phone="+15551230020") == original
     finally:
         await db.close()
 
@@ -243,7 +243,7 @@ async def test_cli_import_force_overwrites(tmp_path):
         new_session = s.save()
 
         await account_cmd._run_import(_import_ns("+15551230021", new_session, force=True), db)
-        assert await db.get_decrypted_session(phone="+15551230021") == new_session
+        assert await db.repos.accounts.get_decrypted_session(phone="+15551230021") == new_session
     finally:
         await db.close()
 
@@ -259,7 +259,7 @@ async def test_cli_import_from_stdin(tmp_path, monkeypatch):
         session = _make_valid_session_string()
         monkeypatch.setattr("sys.stdin", io.StringIO(session + "\n"))
         await account_cmd._run_import(_import_ns("+15551230022", None, stdin=True), db)
-        assert await db.get_decrypted_session(phone="+15551230022") == session
+        assert await db.repos.accounts.get_decrypted_session(phone="+15551230022") == session
     finally:
         await db.close()
 

--- a/tests/test_session_string_io_1143.py
+++ b/tests/test_session_string_io_1143.py
@@ -1,0 +1,155 @@
+"""Tests for SSO session-string export/import (#1143, epic #828).
+
+Covers:
+- telegram-layer ``validate_session_string`` helper (CLI/web/agent must not
+  import telethon directly — import-linter forbids it, so the validator lives
+  in the telegram layer).
+- CLI ``account export-session`` (decrypted plaintext round-trip).
+- CLI ``account import`` (StringSession validation → add_account, encrypted at rest).
+"""
+from __future__ import annotations
+
+import argparse
+
+import pytest
+from telethon.crypto import AuthKey
+from telethon.sessions import StringSession
+
+from src.cli.commands import account as account_cmd
+from src.database import Database
+from src.models import Account
+from src.telegram.auth import validate_session_string
+
+
+def _make_valid_session_string() -> str:
+    """Build a structurally-valid StringSession (dc/address/port/auth_key set)."""
+    s = StringSession()
+    s.set_dc(2, "149.154.167.51", 443)
+    s.auth_key = AuthKey(b"\x01" * 256)
+    return s.save()
+
+
+# ---------------------------------------------------------------------------
+# telegram-layer helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.telegram_unit
+def test_validate_session_string_accepts_valid():
+    assert validate_session_string(_make_valid_session_string()) is True
+
+
+@pytest.mark.telegram_unit
+def test_validate_session_string_rejects_garbage():
+    assert validate_session_string("not-a-session") is False
+
+
+@pytest.mark.telegram_unit
+def test_validate_session_string_rejects_empty():
+    assert validate_session_string("") is False
+
+
+@pytest.mark.telegram_unit
+def test_validate_session_string_rejects_structurally_incomplete():
+    # An empty StringSession is parseable but has no auth_key/dc — not usable.
+    assert validate_session_string(StringSession().save()) is False
+
+
+# ---------------------------------------------------------------------------
+# CLI import
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_cli_import_adds_account(tmp_path, capsys):
+    db = Database(str(tmp_path / "test.db"))
+    await db.initialize()
+    try:
+        session = _make_valid_session_string()
+        args = argparse.Namespace(
+            config=None,
+            account_action="import",
+            phone="+15551230000",
+            session_string=session,
+            json=False,
+        )
+        # run() builds its own db via runtime.init_db — patch it to our db.
+        await account_cmd._run_import(args, db)
+
+        accounts = await db.get_accounts(active_only=False)
+        assert any(a.phone == "+15551230000" for a in accounts)
+        out = capsys.readouterr().out
+        # The raw session string must never be echoed back on import.
+        assert session not in out
+    finally:
+        await db.close()
+
+
+@pytest.mark.anyio
+async def test_cli_import_rejects_invalid_session(tmp_path, capsys):
+    db = Database(str(tmp_path / "test.db"))
+    await db.initialize()
+    try:
+        args = argparse.Namespace(
+            config=None,
+            account_action="import",
+            phone="+15551230001",
+            session_string="garbage",
+            json=False,
+        )
+        await account_cmd._run_import(args, db)
+
+        accounts = await db.get_accounts(active_only=False)
+        assert not any(a.phone == "+15551230001" for a in accounts)
+        out = capsys.readouterr().out.lower()
+        assert "invalid" in out or "недейств" in out or "не валид" in out
+    finally:
+        await db.close()
+
+
+# ---------------------------------------------------------------------------
+# CLI export-session
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_cli_export_session_roundtrip(tmp_path, capsys):
+    db = Database(str(tmp_path / "test.db"))
+    await db.initialize()
+    try:
+        session = _make_valid_session_string()
+        acc_id = await db.add_account(Account(phone="+15551230002", session_string=session))
+
+        args = argparse.Namespace(
+            config=None,
+            account_action="export-session",
+            id=acc_id,
+            phone=None,
+            json=False,
+        )
+        await account_cmd._run_export_session(args, db)
+
+        out = capsys.readouterr().out
+        # export returns the *decrypted* plaintext session — must equal what we put in.
+        assert session in out
+    finally:
+        await db.close()
+
+
+@pytest.mark.anyio
+async def test_cli_export_session_unknown_id(tmp_path, capsys):
+    db = Database(str(tmp_path / "test.db"))
+    await db.initialize()
+    try:
+        args = argparse.Namespace(
+            config=None,
+            account_action="export-session",
+            id=99999,
+            phone=None,
+            json=False,
+        )
+        await account_cmd._run_export_session(args, db)
+        out = capsys.readouterr().out.lower()
+        assert "not found" in out
+    finally:
+        await db.close()


### PR DESCRIPTION
## Что и зачем

Первый sub эпика **#828** (SSO между tg_content_factory и tg_messenger через Telegram StringSession). Самое простое — CLI-слой, parity-якорь для остальных (REST/web/agent).

Чтобы аккаунт, залогиненный в одном проекте, работал во втором без повторного логина, фабрике не хватало экспорта/импорта session string наружу. Этот PR добавляет два leaf-а:

- **`account export-session --id|--phone [--json]`** — печатает *расшифрованный* plaintext StringSession. Достаётся через `db.get_accounts()` (фасад уже расшифровывает через `_decrypt_session_for_live_use`).
- **`account import --phone --session-string`** — добавляет аккаунт по готовому StringSession вместо send-code/verify-code; репозиторий шифрует как обычно (`enc:v2:` при `SESSION_ENCRYPTION_KEY`).

## 🔴 Безопасность (session_string = полный доступ к аккаунту)

- session_string **никогда не логируется**; export печатает его только в stdout по явному запросу.
- Импорт не эхоит значение обратно (тест-гард: значение отсутствует в stdout).
- Валидатор `StringSession` живёт в **telegram-слое** (`validate_session_string`), т.к. CLI/web/agent запрещено импортировать `telethon` напрямую (import-linter contract — KEPT).

## Тесты (TDD)

- `tests/test_session_string_io_1143.py` — валидатор, import→export round-trip, невалидный session, неизвестный id, секрет не в stdout.
- `command_manifest.py` — обе команды как secret-handling ops; parity-инвариант зелёный.
- ruff ✅, import-linter ✅, mypy без новых ошибок, smoke ✅.

Closes #1143

🤖 Generated with [Claude Code](https://claude.com/claude-code)