### PR TITLE
feat(agent): export_session / import_session tools for SSO

### DIFF
--- a/docs/reference/agent-tools.md
+++ b/docs/reference/agent-tools.md
@@ -108,6 +108,8 @@
 | `list_accounts` | READ | Список аккаунтов |
 | `toggle_account` | WRITE | Вкл/выкл |
 | `delete_account` | DELETE | Удалить |
+| `export_session` | WRITE | ⚠️ Экспорт расшифрованной StringSession (SSO; полный доступ к аккаунту, требует confirm=true) |
+| `import_session` | WRITE | Импорт аккаунта по готовой StringSession (SSO; отказ без force при существующем phone) |
 | `get_flood_status` | READ | Статус flood wait |
 | `get_account_availability` | READ | Доступность аккаунта (как в Settings UI): available/flood/disconnected/inactive/session_unavailable |
 | `get_runtime_diagnostics` | READ | Диагностика рантайма: runtime_kind (live/snapshot/none), live-пул отдельно от DB-флагов, свежесть снапшота воркера |

--- a/src/agent/tools/accounts.py
+++ b/src/agent/tools/accounts.py
@@ -22,9 +22,11 @@ from src.agent.tools._registry import (
     normalize_phone,
     require_confirmation,
 )
+from src.models import Account
 from src.services.account_availability import compute_account_availability
 from src.services.notification_target_service import NotificationTargetService
 from src.services.runtime_diagnostics import evaluate_worker_heartbeat
+from src.telegram.auth import validate_session_string
 
 _NO_LIVE_RUNTIME = "live Telegram runtime unavailable"
 
@@ -167,6 +169,8 @@ TOOL_GROUPS: list[tuple[str, dict[str, ToolMeta]]] = [
         "list_accounts": ToolMeta(ToolCategory.READ),
         "toggle_account": ToolMeta(ToolCategory.WRITE),
         "delete_account": ToolMeta(ToolCategory.DELETE),
+        "export_session": ToolMeta(ToolCategory.WRITE),
+        "import_session": ToolMeta(ToolCategory.WRITE),
         "get_flood_status": ToolMeta(ToolCategory.READ),
         "get_account_availability": ToolMeta(ToolCategory.READ),
         "get_runtime_diagnostics": ToolMeta(ToolCategory.READ),
@@ -279,6 +283,80 @@ def register(db, client_pool, embedding_service, **kwargs):
             return _text_response(f"Ошибка удаления аккаунта: {e}")
 
     tools.append(delete_account)
+
+    @tool(
+        "export_session",
+        "⚠️ SENSITIVE: Return the decrypted Telegram StringSession for an account so it can be "
+        "reused elsewhere (SSO with tg_messenger). The session string grants FULL access to the "
+        "account — only export when the user explicitly asks. account_id = id from list_accounts. "
+        "Requires confirm=true.",
+        {
+            "account_id": Annotated[int, "ID аккаунта из list_accounts"],
+            "confirm": Annotated[bool, "Установите true для подтверждения экспорта секрета"],
+        },
+        annotations=ToolAnnotations(destructiveHint=True),
+    )
+    async def export_session(args):
+        account_id = args.get("account_id")
+        if account_id is None:
+            return _text_response("Ошибка: account_id обязателен.")
+        try:
+            accounts = await _get_accounts(db)
+            acc = next((a for a in accounts if a.id == int(account_id)), None)
+            name = acc.phone if acc else f"id={account_id}"
+            gate = require_confirmation(
+                f"экспортирует session string аккаунта '{name}' (полный доступ к аккаунту)", args
+            )
+            if gate:
+                return gate
+            session_string = await db.repos.accounts.get_decrypted_session(account_id=int(account_id))
+            if not session_string:
+                return _text_response(f"Аккаунт id={account_id} не найден или без сессии.")
+            # The session string is the secret being requested; return it in the tool
+            # response but never log it.
+            return _text_response(
+                f"Session string для {name} (⚠️ полный доступ — храните как пароль):\n{session_string}"
+            )
+        except Exception as e:
+            return _text_response(f"Ошибка экспорта сессии: {e}")
+
+    tools.append(export_session)
+
+    @tool(
+        "import_session",
+        "Add a Telegram account from a ready StringSession instead of an interactive login "
+        "(SSO with tg_messenger). Validates the session, then stores it (encrypted at rest). "
+        "Refuses to overwrite an existing phone unless force=true.",
+        {
+            "phone": Annotated[str, "Телефон аккаунта с кодом страны"],
+            "session_string": Annotated[str, "Telegram StringSession (⚠️ полный доступ к аккаунту)"],
+            "force": Annotated[bool, "true чтобы перезаписать сессию уже существующего аккаунта"],
+        },
+    )
+    async def import_session(args):
+        phone = normalize_phone(args.get("phone") or "")
+        session_string = (args.get("session_string") or "").strip()
+        if not phone or not session_string:
+            return _text_response("Ошибка: phone и session_string обязательны.")
+        if not validate_session_string(session_string):
+            return _text_response(f"Ошибка: невалидная Telegram session string для {phone}.")
+        try:
+            existing = await db.get_account_summaries(active_only=False)
+            if any(s.phone == phone for s in existing):
+                if not args.get("force"):
+                    return _text_response(
+                        f"Аккаунт {phone} уже существует (already exists); импорт перезапишет его "
+                        f"сессию. Удалите его или повторите с force=true."
+                    )
+            is_primary = len(existing) == 0
+            await db.add_account(
+                Account(phone=phone, session_string=session_string, is_primary=is_primary, is_premium=False)
+            )
+            return _text_response(f"Аккаунт {phone} импортирован (primary={is_primary}).")
+        except Exception as e:
+            return _text_response(f"Ошибка импорта сессии: {e}")
+
+    tools.append(import_session)
 
     @tool("get_flood_status", "Get database flood-wait status for all accounts; this is not live connection state.", {})
     async def get_flood_status(args):

--- a/tests/test_agent_tools_session_io_1144.py
+++ b/tests/test_agent_tools_session_io_1144.py
@@ -1,0 +1,130 @@
+"""Agent-tool tests for SSO session export/import (#1144, epic #828).
+
+`export_session` is a WRITE/sensitive tool (full account access) gated behind
+`confirm=true`, mirroring `delete_account`. `import_session` adds an account from
+a ready StringSession. Both reuse the telegram-layer validator and the
+single-account decrypt accessor introduced in #1143.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tests.agent_tools_helpers import _get_tool_handlers, _text
+
+
+def _make_account(acc_id=1, phone="+79001234567", is_active=True, is_primary=True):
+    a = MagicMock()
+    a.id = acc_id
+    a.phone = phone
+    a.is_active = is_active
+    a.flood_wait_until = None
+    a.is_primary = is_primary
+    return a
+
+
+# ---------------------------------------------------------------------------
+# export_session
+# ---------------------------------------------------------------------------
+
+
+class TestExportSessionTool:
+    @pytest.mark.anyio
+    async def test_missing_account_id_returns_error(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["export_session"]({})
+        assert "account_id" in _text(result)
+
+    @pytest.mark.anyio
+    async def test_no_confirm_returns_gate(self, mock_db):
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account(acc_id=1)])
+        mock_db.repos.accounts.get_decrypted_session = AsyncMock()
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["export_session"]({"account_id": 1})
+        assert "confirm=true" in _text(result)
+        # The gate must NOT leak the session string (decrypt never called).
+        mock_db.repos.accounts.get_decrypted_session.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_with_confirm_returns_session(self, mock_db):
+        acc = _make_account(acc_id=5, phone="+75555555555")
+        mock_db.get_accounts = AsyncMock(return_value=[acc])
+        mock_db.repos.accounts.get_decrypted_session = AsyncMock(return_value="THE_SESSION_STRING")
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["export_session"]({"account_id": 5, "confirm": True})
+        text = _text(result)
+        assert "THE_SESSION_STRING" in text
+        mock_db.repos.accounts.get_decrypted_session.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_unknown_account_returns_not_found(self, mock_db):
+        mock_db.get_accounts = AsyncMock(return_value=[])
+        mock_db.repos.accounts.get_decrypted_session = AsyncMock(return_value=None)
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["export_session"]({"account_id": 999, "confirm": True})
+        assert "не найден" in _text(result).lower() or "not found" in _text(result).lower()
+
+
+# ---------------------------------------------------------------------------
+# import_session
+# ---------------------------------------------------------------------------
+
+
+class TestImportSessionTool:
+    @pytest.mark.anyio
+    async def test_missing_args_returns_error(self, mock_db):
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["import_session"]({"phone": "+71112223344"})
+        assert "session_string" in _text(result)
+
+    @pytest.mark.anyio
+    async def test_invalid_session_rejected(self, mock_db):
+        mock_db.get_account_summaries = AsyncMock(return_value=[])
+        mock_db.add_account = AsyncMock()
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["import_session"](
+            {"phone": "+71112223344", "session_string": "garbage"}
+        )
+        assert "невалид" in _text(result).lower() or "invalid" in _text(result).lower()
+        mock_db.add_account.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_valid_session_adds_account(self, mock_db, monkeypatch):
+        # Patch the validator so the test does not depend on telethon internals.
+        monkeypatch.setattr("src.agent.tools.accounts.validate_session_string", lambda s: True)
+        mock_db.get_account_summaries = AsyncMock(return_value=[])
+        mock_db.add_account = AsyncMock(return_value=7)
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["import_session"](
+            {"phone": "+71112223344", "session_string": "valid-looking"}
+        )
+        assert "+71112223344" in _text(result)
+        mock_db.add_account.assert_awaited_once()
+
+    @pytest.mark.anyio
+    async def test_existing_phone_refused_without_force(self, mock_db, monkeypatch):
+        monkeypatch.setattr("src.agent.tools.accounts.validate_session_string", lambda s: True)
+        existing = _make_account(acc_id=1, phone="+71112223344")
+        mock_db.get_account_summaries = AsyncMock(return_value=[existing])
+        mock_db.add_account = AsyncMock()
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["import_session"](
+            {"phone": "+71112223344", "session_string": "valid-looking"}
+        )
+        assert "exist" in _text(result).lower() or "существует" in _text(result).lower()
+        mock_db.add_account.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# permission / registry contract
+# ---------------------------------------------------------------------------
+
+
+def test_session_tools_classified_write():
+    from src.agent.tools._categories import ToolCategory
+    from src.agent.tools.accounts import TOOL_GROUPS
+
+    flat = {name: meta for _, group in TOOL_GROUPS for name, meta in group.items()}
+    assert flat["export_session"].category == ToolCategory.WRITE
+    assert flat["import_session"].category == ToolCategory.WRITE


### PR DESCRIPTION
## Что и зачем

Sub эпика **#828** (SSO StringSession). Agent-tool слой — parity к CLI из #1143.

Два новых tool в `src/agent/tools/accounts.py`:

- **`export_session(account_id, confirm)`** — SENSITIVE/WRITE, гейт `confirm=true` (как `delete_account`). Возвращает расшифрованную StringSession через `db.repos.accounts.get_decrypted_session(...)` (прямой вызов репозитория, без facade-shim — соблюдён passthrough-гард). Секрет не логируется.
- **`import_session(phone, session_string, force)`** — валидация через telegram-слой `validate_session_string` (индиректный импорт; `agent.tools` не импортирует telethon напрямую — import-linter KEPT), отказ без `force` при существующем phone (data-loss guard), затем `db.add_account(...)` (шифрование at-rest).

Оба классифицированы **WRITE** в `TOOL_GROUPS`; добавлены в `docs/reference/agent-tools.md` — контракты registry==permissions и docs-cover зелёные.

## 🔴 Безопасность
- export требует confirm; session_string не логируется.
- import: guard против перезаписи рабочего аккаунта без force.

## Тесты
`tests/test_agent_tools_session_io_1144.py` — 9 тестов: confirm-гейт, export round-trip, неизвестный аккаунт, невалидный session, add, overwrite-guard, WRITE-классификация. + контракты smoke/permissions/deepagents-sync зелёные. ruff/import-linter чисты.

## ⚠️ Stacked PR
База — `feat/1143` (переиспользует `validate_session_string` + `get_decrypted_session`). Мержить **после** #1150 (#1143). После мержа #1143 base переключится на main.

Closes #1144

🤖 Generated with [Claude Code](https://claude.com/claude-code)