### PR TITLE
feat(cli): Wave-1 argparse→Typer — serve/worker/stop/restart/mcp-server/collect/search/messages (#1121)

### DIFF
--- a/src/cli/commands/collect.py
+++ b/src/cli/commands/collect.py
@@ -41,103 +41,121 @@ def print_resolve_backoff_warning(pool) -> None:
     )
 
 
-def run(args: argparse.Namespace) -> None:
-    async def _run() -> None:
-        collect_action = getattr(args, "collect_action", None)
+async def collect_impl(
+    config_path: str, *, channel_id: int | None = None, full: bool = False
+) -> None:
+    """Run one-shot collection: a single ``--channel-id`` or enqueue all channels.
 
-        if collect_action == "sample":
-            await _run_sample(args)
+    Shared async body for both CLI entry points — the argparse ``run`` wrapper
+    below and the Typer ``collect`` command (``src/cli/typer_commands.py``).
+    Driven through the single async-bridge ``run_async`` by its callers, so
+    there is no local ``asyncio.run`` in the migrated path.
+    """
+    config, db = await runtime.init_db(config_path)
+    _, pool = await runtime.init_pool(config, db)
+    try:
+        if not pool.clients:
+            logging.error("No connected accounts. Run 'serve' and add accounts via web UI.")
             return
 
-        config, db = await runtime.init_db(args.config)
-        _, pool = await runtime.init_pool(config, db)
-        try:
-            if not pool.clients:
-                logging.error("No connected accounts. Run 'serve' and add accounts via web UI.")
+        collector = Collector(pool, db, config.scheduler)
+
+        if channel_id:
+            channels = await db.get_channels()
+            channel = next((ch for ch in channels if ch.channel_id == channel_id), None)
+            if not channel:
+                print(f"Channel {channel_id} not found in DB")
                 return
-
-            collector = Collector(pool, db, config.scheduler)
-
-            if args.channel_id:
-                channels = await db.get_channels()
-                channel = next((ch for ch in channels if ch.channel_id == args.channel_id), None)
-                if not channel:
-                    print(f"Channel {args.channel_id} not found in DB")
-                    return
-                if channel.is_filtered:
-                    print(f"Channel {args.channel_id} is filtered and excluded from collection")
-                    return
-                try:
-                    count = await collector.collect_single_channel(
-                        channel,
-                        full=bool(getattr(args, "full", False)),
-                    )
-                except UsernameResolveFloodWaitDeferredError as exc:
-                    retry_at = exc.next_available_at.astimezone().isoformat()
-                    print(f"Username resolve Flood Wait active until {retry_at}; try again later.")
-                    return
-                except UsernameResolveRateLimitedError as exc:
-                    retry_at = exc.run_after_with_buffer().astimezone().isoformat()
-                    print(
-                        "resolve_username rate-limited "
-                        f"on {exc.phone}; deferred until {retry_at}."
-                    )
-                    return
-                except AllCollectionClientsFloodedError as exc:
-                    retry_at = exc.next_available_at.astimezone().isoformat()
-                    print(
-                        f"All accounts are flood-waited until {retry_at} "
-                        f"(retry in {exc.retry_after_sec}s); try again later."
-                    )
-                    return
-                print(f"Collected {count} messages from channel {args.channel_id}")
-            else:
-                channel_bundle = ChannelBundle.from_database(db)
-                collection_service = CollectionService(
-                    channel_bundle, collector, collection_queue=None
-                )
-                task_enqueuer = TaskEnqueuer(db, collection_service)
-                result = await task_enqueuer.enqueue_all_channels(
-                    resolve_backoff_remaining_sec=pool.get_resolve_username_backoff_remaining_sec(),
-                )
+            if channel.is_filtered:
+                print(f"Channel {channel_id} is filtered and excluded from collection")
+                return
+            try:
+                count = await collector.collect_single_channel(channel, full=full)
+            except UsernameResolveFloodWaitDeferredError as exc:
+                retry_at = exc.next_available_at.astimezone().isoformat()
+                print(f"Username resolve Flood Wait active until {retry_at}; try again later.")
+                return
+            except UsernameResolveRateLimitedError as exc:
+                retry_at = exc.run_after_with_buffer().astimezone().isoformat()
                 print(
-                    f"Enqueued {result.queued_count} channels "
-                    f"(skipped {result.skipped_existing_count}, "
-                    f"total {result.total_candidates}). "
-                    f"Run 'serve' to execute tasks."
+                    "resolve_username rate-limited "
+                    f"on {exc.phone}; deferred until {retry_at}."
                 )
-                print_resolve_backoff_warning(pool)
-        finally:
-            await pool.disconnect_all()
-            await db.close()
-
-    async def _run_sample(args: argparse.Namespace) -> None:
-        config, db = await runtime.init_db(args.config)
-        _, pool = await runtime.init_pool(config, db)
-        try:
-            if not pool.clients:
-                logging.error("No connected accounts. Run 'serve' and add accounts via web UI.")
                 return
-
-            channel_id = args.channel_id
-            limit = getattr(args, "limit", 10)
-            collector = Collector(pool, db, config.scheduler)
-
-            print(f"Sampling last {limit} messages from channel {channel_id}...\n")
-            previews = await collector.sample_channel(channel_id, limit=limit)
-
-            if not previews:
-                print("No messages found.")
+            except AllCollectionClientsFloodedError as exc:
+                retry_at = exc.next_available_at.astimezone().isoformat()
+                print(
+                    f"All accounts are flood-waited until {retry_at} "
+                    f"(retry in {exc.retry_after_sec}s); try again later."
+                )
                 return
+            print(f"Collected {count} messages from channel {channel_id}")
+        else:
+            channel_bundle = ChannelBundle.from_database(db)
+            collection_service = CollectionService(
+                channel_bundle, collector, collection_queue=None
+            )
+            task_enqueuer = TaskEnqueuer(db, collection_service)
+            result = await task_enqueuer.enqueue_all_channels(
+                resolve_backoff_remaining_sec=pool.get_resolve_username_backoff_remaining_sec(),
+            )
+            print(
+                f"Enqueued {result.queued_count} channels "
+                f"(skipped {result.skipped_existing_count}, "
+                f"total {result.total_candidates}). "
+                f"Run 'serve' to execute tasks."
+            )
+            print_resolve_backoff_warning(pool)
+    finally:
+        await pool.disconnect_all()
+        await db.close()
 
-            for msg in previews:
-                date_str = msg["date"].strftime("%Y-%m-%d %H:%M") if msg["date"] else "no date"
-                media = msg["media_type"] or "-"
-                text = msg["text_preview"] or ""
-                preview = repr(text) if text else "(no text)"
-                print(f"#{msg['message_id']:<8} {date_str}  {media:<12} {preview}")
-        finally:
-            await pool.disconnect_all()
-            await db.close()
 
-    asyncio.run(_run())
+async def collect_sample_impl(config_path: str, *, channel_id: int, limit: int = 10) -> None:
+    """Preview the last *limit* messages of a channel without saving to DB.
+
+    Shared async body for the ``collect sample`` sub-command (both CLI entry
+    points). Driven through ``run_async`` by its callers.
+    """
+    config, db = await runtime.init_db(config_path)
+    _, pool = await runtime.init_pool(config, db)
+    try:
+        if not pool.clients:
+            logging.error("No connected accounts. Run 'serve' and add accounts via web UI.")
+            return
+
+        collector = Collector(pool, db, config.scheduler)
+
+        print(f"Sampling last {limit} messages from channel {channel_id}...\n")
+        previews = await collector.sample_channel(channel_id, limit=limit)
+
+        if not previews:
+            print("No messages found.")
+            return
+
+        for msg in previews:
+            date_str = msg["date"].strftime("%Y-%m-%d %H:%M") if msg["date"] else "no date"
+            media = msg["media_type"] or "-"
+            text = msg["text_preview"] or ""
+            preview = repr(text) if text else "(no text)"
+            print(f"#{msg['message_id']:<8} {date_str}  {media:<12} {preview}")
+    finally:
+        await pool.disconnect_all()
+        await db.close()
+
+
+def run(args: argparse.Namespace) -> None:
+    if getattr(args, "collect_action", None) == "sample":
+        asyncio.run(
+            collect_sample_impl(
+                args.config, channel_id=args.channel_id, limit=getattr(args, "limit", 10)
+            )
+        )
+        return
+    asyncio.run(
+        collect_impl(
+            args.config,
+            channel_id=getattr(args, "channel_id", None),
+            full=bool(getattr(args, "full", False)),
+        )
+    )

--- a/src/cli/commands/mcp_server.py
+++ b/src/cli/commands/mcp_server.py
@@ -17,11 +17,11 @@ to stderr so the protocol stream stays clean.
 from __future__ import annotations
 
 import argparse
-import asyncio
 import logging
 import sys
 
 from src.cli.runtime import init_db, init_pool
+from src.cli.typer_app import run_async
 
 logger = logging.getLogger(__name__)
 
@@ -67,10 +67,22 @@ async def _serve(config_path: str, *, with_pool: bool) -> None:
         await db.close()
 
 
-def run(args: argparse.Namespace) -> None:
+def serve_mcp(config_path: str, *, no_pool: bool = False) -> None:
+    """Run the stdio MCP server until interrupted.
+
+    Shared body for both CLI entry points — the argparse ``run`` wrapper below
+    and the Typer ``mcp-server`` command (``src/cli/typer_commands.py``). Routes
+    logging off stdout (the JSON-RPC channel) first, then drives the long-lived
+    ``_serve`` coroutine through the single async-bridge ``run_async`` (replacing
+    the former local ``asyncio.run``). ``KeyboardInterrupt`` exits quietly.
+    """
     _route_logging_to_stderr()
-    with_pool = not getattr(args, "no_pool", False)
+    with_pool = not no_pool
     try:
-        asyncio.run(_serve(args.config, with_pool=with_pool))
+        run_async(_serve(config_path, with_pool=with_pool))
     except KeyboardInterrupt:
         pass
+
+
+def run(args: argparse.Namespace) -> None:
+    serve_mcp(args.config, no_pool=getattr(args, "no_pool", False))

--- a/src/cli/commands/messages.py
+++ b/src/cli/commands/messages.py
@@ -93,126 +93,165 @@ def _print_live_messages(collected: list, reaction_users_by_message_id: dict[int
         print()
 
 
-def run(args: argparse.Namespace) -> None:
-    async def _run() -> None:
-        config, db = await runtime.init_db(args.config)
-        pool = None
-        try:
-            if args.messages_action == "read":
-                identifier = args.identifier
-                include_reaction_users = bool(getattr(args, "include_reaction_users", False))
-                reaction_users_limit = normalize_reaction_users_limit(getattr(args, "reaction_users_limit", None))
+async def messages_read_impl(
+    config_path: str,
+    *,
+    identifier: str,
+    limit: int = 50,
+    live: bool = False,
+    phone: str | None = None,
+    query: str = "",
+    date_from: str | None = None,
+    date_to: str | None = None,
+    topic_id: int | None = None,
+    offset_id: int | None = None,
+    include_reaction_users: bool = False,
+    reaction_users_limit: int | None = None,
+    output_format: str = "text",
+) -> None:
+    """Read messages from a channel/dialog — live Telegram (``--live``) or the DB.
 
-                if args.live:
-                    # Live mode: read from Telegram
-                    _, pool = await runtime.init_pool(config, db)
-                    if not pool.clients:
-                        print("No connected accounts.")
-                        return
-                    accounts = sorted(pool.clients.keys())
-                    phone = args.phone or accounts[0]
-                    if phone not in pool.clients:
-                        print(f"Account {phone} not connected.")
-                        return
-                    result = await pool.get_native_client_by_phone(phone)
-                    if result is None:
-                        print(f"Client for {phone} unavailable (flood-wait or not connected).")
-                        return
-                    client, _ = result
-                    try:
-                        # Try numeric ID first; a freshly created chat may not be in
-                        # the cold entity cache yet, so warm dialogs once and retry
-                        # via the centralized resolver.
-                        try:
-                            entity_id = int(identifier)
-                        except ValueError:
-                            entity_id = None
-                        resolve_target = entity_id if entity_id is not None else identifier
-                        entity = await pool.resolve_entity_with_warm(
-                            client, phone, resolve_target, operation="cli_messages_read_resolve"
-                        )
-                        kwargs = {"limit": args.limit}
-                        if args.offset_id:
-                            kwargs["offset_id"] = args.offset_id
-                        if args.topic_id:
-                            kwargs["reply_to"] = args.topic_id
-                        collected: list = []
+    Shared async body for both CLI entry points — the argparse ``run`` wrapper
+    below and the Typer ``messages read`` command (``src/cli/typer_commands.py``).
+    Driven through the single async-bridge ``run_async`` by its callers, so
+    there is no local ``asyncio.run`` in the migrated path.
+    """
+    config, db = await runtime.init_db(config_path)
+    pool = None
+    try:
+        include_reaction_users = bool(include_reaction_users)
+        reaction_users_limit = normalize_reaction_users_limit(reaction_users_limit)
 
-                        async def _read_messages() -> None:
-                            async for msg in client.iter_messages(entity, **kwargs):
-                                collected.append(msg)
+        if live:
+            # Live mode: read from Telegram
+            _, pool = await runtime.init_pool(config, db)
+            if not pool.clients:
+                print("No connected accounts.")
+                return
+            accounts = sorted(pool.clients.keys())
+            phone = phone or accounts[0]
+            if phone not in pool.clients:
+                print(f"Account {phone} not connected.")
+                return
+            result = await pool.get_native_client_by_phone(phone)
+            if result is None:
+                print(f"Client for {phone} unavailable (flood-wait or not connected).")
+                return
+            client, _ = result
+            try:
+                # Try numeric ID first; a freshly created chat may not be in
+                # the cold entity cache yet, so warm dialogs once and retry
+                # via the centralized resolver.
+                try:
+                    entity_id = int(identifier)
+                except ValueError:
+                    entity_id = None
+                resolve_target = entity_id if entity_id is not None else identifier
+                entity = await pool.resolve_entity_with_warm(
+                    client, phone, resolve_target, operation="cli_messages_read_resolve"
+                )
+                kwargs = {"limit": limit}
+                if offset_id:
+                    kwargs["offset_id"] = offset_id
+                if topic_id:
+                    kwargs["reply_to"] = topic_id
+                collected: list = []
 
-                        try:
-                            await run_with_flood_wait(
-                                _read_messages(),
-                                operation="cli_messages_read",
-                                phone=phone,
-                                pool=pool,
-                            )
-                        except HandledFloodWaitError as exc:
-                            print(f"Flood wait: {exc.info.detail}")
-                            return
-                        if not collected:
-                            print("No messages found.")
-                            return
-                        reaction_users_by_message_id: dict[int, str] = {}
-                        if include_reaction_users:
-                            async def _read_reaction_users() -> None:
-                                for msg in collected:
-                                    if not format_message_reactions(msg):
-                                        continue
-                                    result = await fetch_message_reaction_users(
-                                        client,
-                                        entity,
-                                        msg.id,
-                                        limit=reaction_users_limit,
-                                    )
-                                    formatted = format_reaction_users_result(result)
-                                    if formatted:
-                                        reaction_users_by_message_id[msg.id] = formatted
+                async def _read_messages() -> None:
+                    async for msg in client.iter_messages(entity, **kwargs):
+                        collected.append(msg)
 
-                            try:
-                                await run_with_flood_wait(
-                                    _read_reaction_users(),
-                                    operation="cli_messages_reaction_users",
-                                    phone=phone,
-                                    pool=pool,
-                                )
-                            except HandledFloodWaitError as exc:
-                                print(f"Flood wait: {exc.info.detail}")
-                                return
-                        _print_live_messages(collected, reaction_users_by_message_id)
-                    except Exception as exc:
-                        print(f"Error reading messages: {exc}")
-                else:
-                    if include_reaction_users:
-                        print("--include-reaction-users works only with --live.")
-                        return
-                    # DB mode: read collected messages
-                    channels = await db.get_channels()
-                    ch = resolve_channel(channels, identifier)
-                    if not ch:
-                        print(
-                            f"Channel '{identifier}' not found in DB. "
-                            "Use --live to read directly from Telegram."
-                        )
-                        return
-                    page = await db.search_messages(
-                        query=args.query,
-                        channel_id=ch.channel_id,
-                        date_from=args.date_from,
-                        date_to=args.date_to,
-                        limit=args.limit,
-                        topic_id=args.topic_id,
+                try:
+                    await run_with_flood_wait(
+                        _read_messages(),
+                        operation="cli_messages_read",
+                        phone=phone,
+                        pool=pool,
                     )
-                    messages = page.messages
-                    if not messages:
-                        print("No messages found.")
-                        return
-                    _print_messages(messages, args.output_format, page.total, has_more=page.has_more)
-        finally:
-            if pool:
-                await pool.disconnect_all()
-            await db.close()
+                except HandledFloodWaitError as exc:
+                    print(f"Flood wait: {exc.info.detail}")
+                    return
+                if not collected:
+                    print("No messages found.")
+                    return
+                reaction_users_by_message_id: dict[int, str] = {}
+                if include_reaction_users:
+                    async def _read_reaction_users() -> None:
+                        for msg in collected:
+                            if not format_message_reactions(msg):
+                                continue
+                            result = await fetch_message_reaction_users(
+                                client,
+                                entity,
+                                msg.id,
+                                limit=reaction_users_limit,
+                            )
+                            formatted = format_reaction_users_result(result)
+                            if formatted:
+                                reaction_users_by_message_id[msg.id] = formatted
 
-    asyncio.run(_run())
+                    try:
+                        await run_with_flood_wait(
+                            _read_reaction_users(),
+                            operation="cli_messages_reaction_users",
+                            phone=phone,
+                            pool=pool,
+                        )
+                    except HandledFloodWaitError as exc:
+                        print(f"Flood wait: {exc.info.detail}")
+                        return
+                _print_live_messages(collected, reaction_users_by_message_id)
+            except Exception as exc:
+                print(f"Error reading messages: {exc}")
+        else:
+            if include_reaction_users:
+                print("--include-reaction-users works only with --live.")
+                return
+            # DB mode: read collected messages
+            channels = await db.get_channels()
+            ch = resolve_channel(channels, identifier)
+            if not ch:
+                print(
+                    f"Channel '{identifier}' not found in DB. "
+                    "Use --live to read directly from Telegram."
+                )
+                return
+            page = await db.search_messages(
+                query=query,
+                channel_id=ch.channel_id,
+                date_from=date_from,
+                date_to=date_to,
+                limit=limit,
+                topic_id=topic_id,
+            )
+            messages = page.messages
+            if not messages:
+                print("No messages found.")
+                return
+            _print_messages(messages, output_format, page.total, has_more=page.has_more)
+    finally:
+        if pool:
+            await pool.disconnect_all()
+        await db.close()
+
+
+def run(args: argparse.Namespace) -> None:
+    if getattr(args, "messages_action", None) != "read":
+        return
+    asyncio.run(
+        messages_read_impl(
+            args.config,
+            identifier=args.identifier,
+            limit=getattr(args, "limit", 50),
+            live=getattr(args, "live", False),
+            phone=getattr(args, "phone", None),
+            query=getattr(args, "query", ""),
+            date_from=getattr(args, "date_from", None),
+            date_to=getattr(args, "date_to", None),
+            topic_id=getattr(args, "topic_id", None),
+            offset_id=getattr(args, "offset_id", None),
+            include_reaction_users=getattr(args, "include_reaction_users", False),
+            reaction_users_limit=getattr(args, "reaction_users_limit", None),
+            output_format=getattr(args, "output_format", "text"),
+        )
+    )

--- a/src/cli/commands/search.py
+++ b/src/cli/commands/search.py
@@ -9,88 +9,122 @@ from src.search.engine import SearchEngine
 from src.services.embedding_service import EmbeddingService
 
 
-def run(args: argparse.Namespace) -> None:
-    async def _run() -> None:
-        config, db = await runtime.init_db(args.config)
+async def search_impl(
+    config_path: str,
+    *,
+    query: str = "",
+    limit: int = 20,
+    mode: str = "local",
+    channel_id: int | None = None,
+    min_length: int | None = None,
+    max_length: int | None = None,
+    fts: bool = False,
+    include_filtered: bool = False,
+    index_now: bool = False,
+    reset_index: bool = False,
+    purge_cache: bool = False,
+) -> None:
+    """Search messages across the configured *mode*, or run an index/purge side task.
 
-        if getattr(args, "purge_cache", False):
-            try:
-                if not args.query:
-                    logging.error("--purge-cache requires a query (the Premium search text to purge).")
-                    return
-                deleted = await db.repos.messages.delete_premium_search_results(args.query)
-                print(f"Purged {deleted} cached message(s) from Premium search for '{args.query}'.")
-            finally:
-                await db.close()
+    Shared async body for both CLI entry points — the argparse ``run`` wrapper
+    below and the Typer ``search`` command (``src/cli/typer_commands.py``).
+    Driven through the single async-bridge ``run_async`` by its callers, so
+    there is no local ``asyncio.run`` in the migrated path.
+    """
+    config, db = await runtime.init_db(config_path)
+
+    if purge_cache:
+        try:
+            if not query:
+                logging.error("--purge-cache requires a query (the Premium search text to purge).")
+                return
+            deleted = await db.repos.messages.delete_premium_search_results(query)
+            print(f"Purged {deleted} cached message(s) from Premium search for '{query}'.")
+        finally:
+            await db.close()
+        return
+
+    pool = None
+    if mode in ("telegram", "my_chats", "channel"):
+        _, pool = await runtime.init_pool(config, db)
+        if not pool.clients:
+            logging.error("No connected accounts. Run 'serve' and add accounts via web UI.")
+            await db.close()
             return
 
-        pool = None
-        if args.mode in ("telegram", "my_chats", "channel"):
-            _, pool = await runtime.init_pool(config, db)
-            if not pool.clients:
-                logging.error("No connected accounts. Run 'serve' and add accounts via web UI.")
-                await db.close()
-                return
+    try:
+        if index_now:
+            if reset_index:
+                await db.repos.messages.reset_embeddings_index()
+            indexed = await EmbeddingService(db, config).index_pending_messages()
+            print(f"Indexed {indexed} messages for semantic search.")
+            return
 
-        try:
-            if getattr(args, "index_now", False):
-                if getattr(args, "reset_index", False):
-                    await db.repos.messages.reset_embeddings_index()
-                indexed = await EmbeddingService(db, config).index_pending_messages()
-                print(f"Indexed {indexed} messages for semantic search.")
-                return
+        if not query:
+            logging.error("Search query is required unless --index-now is used.")
+            return
 
-            if not args.query:
-                logging.error("Search query is required unless --index-now is used.")
-                return
+        engine = SearchEngine(db, pool, config=config)
 
-            engine = SearchEngine(db, pool, config=config)
-            include_filtered = getattr(args, "all", False)
+        if mode == "telegram":
+            result = await engine.search_telegram(query, limit=limit)
+        elif mode == "my_chats":
+            result = await engine.search_my_chats(query, limit=limit)
+        elif mode == "channel":
+            result = await engine.search_in_channel(channel_id, query, limit=limit)
+        elif mode == "semantic":
+            result = await engine.search_semantic(
+                query,
+                limit=limit,
+                min_length=min_length,
+                max_length=max_length,
+                include_filtered=include_filtered,
+            )
+        elif mode == "hybrid":
+            result = await engine.search_hybrid(
+                query,
+                limit=limit,
+                min_length=min_length,
+                max_length=max_length,
+                is_fts=fts,
+                include_filtered=include_filtered,
+            )
+        else:
+            result = await engine.search_local(
+                query,
+                limit=limit,
+                min_length=min_length,
+                max_length=max_length,
+                is_fts=fts,
+                include_filtered=include_filtered,
+            )
 
-            if args.mode == "telegram":
-                result = await engine.search_telegram(args.query, limit=args.limit)
-            elif args.mode == "my_chats":
-                result = await engine.search_my_chats(args.query, limit=args.limit)
-            elif args.mode == "channel":
-                result = await engine.search_in_channel(
-                    args.channel_id, args.query, limit=args.limit
-                )
-            elif args.mode == "semantic":
-                result = await engine.search_semantic(
-                    args.query,
-                    limit=args.limit,
-                    min_length=args.min_length,
-                    max_length=args.max_length,
-                    include_filtered=include_filtered,
-                )
-            elif args.mode == "hybrid":
-                result = await engine.search_hybrid(
-                    args.query,
-                    limit=args.limit,
-                    min_length=args.min_length,
-                    max_length=args.max_length,
-                    is_fts=args.fts,
-                    include_filtered=include_filtered,
-                )
-            else:
-                result = await engine.search_local(
-                    args.query,
-                    limit=args.limit,
-                    min_length=args.min_length,
-                    max_length=args.max_length,
-                    is_fts=args.fts,
-                    include_filtered=include_filtered,
-                )
+        total_display = f"{result.total}+" if result.has_more else str(result.total)
+        print(f"Found {total_display} results for '{result.query}':\n")
+        for msg in result.messages:
+            text_preview = (msg.text or "")[:200]
+            print(f"[{msg.date}] Channel {msg.channel_id}: {text_preview}")
+            print("---")
+    finally:
+        if pool:
+            await pool.disconnect_all()
+        await db.close()
 
-            total_display = f"{result.total}+" if result.has_more else str(result.total)
-            print(f"Found {total_display} results for '{result.query}':\n")
-            for msg in result.messages:
-                text_preview = (msg.text or "")[:200]
-                print(f"[{msg.date}] Channel {msg.channel_id}: {text_preview}")
-                print("---")
-        finally:
-            if pool:
-                await pool.disconnect_all()
-            await db.close()
 
-    asyncio.run(_run())
+def run(args: argparse.Namespace) -> None:
+    asyncio.run(
+        search_impl(
+            args.config,
+            query=getattr(args, "query", "") or "",
+            limit=getattr(args, "limit", 20),
+            mode=getattr(args, "mode", "local"),
+            channel_id=getattr(args, "channel_id", None),
+            min_length=getattr(args, "min_length", None),
+            max_length=getattr(args, "max_length", None),
+            fts=getattr(args, "fts", False),
+            include_filtered=getattr(args, "all", False),
+            index_now=getattr(args, "index_now", False),
+            reset_index=getattr(args, "reset_index", False),
+            purge_cache=getattr(args, "purge_cache", False),
+        )
+    )

--- a/src/cli/commands/serve.py
+++ b/src/cli/commands/serve.py
@@ -15,10 +15,18 @@ from src.config import load_config
 from src.web.app import create_app
 
 
-def run(args: argparse.Namespace) -> None:
-    config = load_config(args.config)
-    if args.web_pass:
-        config.web.password = args.web_pass
+def serve_web(config_path: str, *, web_pass: str | None = None, no_worker: bool = False) -> None:
+    """Start the web server (and, by default, the embedded Telegram worker).
+
+    Shared body for both CLI entry points — the argparse ``run`` wrapper below
+    and the Typer ``serve`` command (``src/cli/typer_commands.py``). ``uvicorn``
+    owns the event loop, so this stays a plain ``def`` (no async-bridge). Exits
+    via ``sys.exit(1)`` when no web password is configured or another managed
+    server is already running, matching the pre-migration behaviour.
+    """
+    config = load_config(config_path)
+    if web_pass:
+        config.web.password = web_pass
     if not config.web.password:
         logging.error("WEB_PASS must be set for web panel authentication")
         sys.exit(1)
@@ -28,7 +36,7 @@ def run(args: argparse.Namespace) -> None:
     # unless this flag is set. By default `serve` owns the worker too;
     # `--no-worker` is for split deployments where `python -m src.main worker`
     # runs in its own process / container.
-    app.state.embed_worker = not getattr(args, "no_worker", False)
+    app.state.embed_worker = not no_worker
     pid_path = pid_file_path(config)
     try:
         register_current_process(pid_path)
@@ -42,3 +50,11 @@ def run(args: argparse.Namespace) -> None:
         pass
     finally:
         unregister_current_process(pid_path)
+
+
+def run(args: argparse.Namespace) -> None:
+    serve_web(
+        args.config,
+        web_pass=getattr(args, "web_pass", None),
+        no_worker=getattr(args, "no_worker", False),
+    )

--- a/src/cli/commands/server_control.py
+++ b/src/cli/commands/server_control.py
@@ -7,14 +7,25 @@ from src.cli.commands import serve
 from src.cli.process_control import ProcessControlError, StopResult, pid_file_path, stop_server
 from src.config import load_config
 
+_GRACEFUL_STOP_NOTICE = (
+    "Останавливаю сервер gracefully. Если сейчас идёт сбор канала, "
+    "подожду завершения активной задачи; остальные останутся pending в БД."
+)
+_GRACEFUL_RESTART_NOTICE = (
+    "Перезапускаю сервер gracefully. Если сейчас идёт сбор канала, "
+    "подожду завершения активной задачи; остальные останутся pending в БД."
+)
 
-def run_stop(args: argparse.Namespace) -> None:
-    config = load_config(args.config)
+
+def _stop_managed_server(config_path: str, notice: str) -> None:
+    """Stop the managed server, printing *notice* first; exit(1) on failure.
+
+    Shared by ``stop_web`` and ``restart_web`` — both gracefully terminate the
+    running server and exit non-zero if it is unmanaged or never stops.
+    """
+    config = load_config(config_path)
     try:
-        print(
-            "Останавливаю сервер gracefully. Если сейчас идёт сбор канала, "
-            "подожду завершения активной задачи; остальные останутся pending в БД."
-        )
+        print(notice)
         outcome = stop_server(pid_file_path(config))
     except ProcessControlError as exc:
         print(str(exc))
@@ -22,20 +33,22 @@ def run_stop(args: argparse.Namespace) -> None:
     print(outcome.message)
     if outcome.result in (StopResult.UNMANAGED, StopResult.TIMEOUT):
         sys.exit(1)
+
+
+def stop_web(config_path: str) -> None:
+    """Stop the web server started by this app (graceful)."""
+    _stop_managed_server(config_path, _GRACEFUL_STOP_NOTICE)
+
+
+def restart_web(config_path: str, *, web_pass: str | None = None) -> None:
+    """Restart the web server: stop gracefully, then start a fresh ``serve``."""
+    _stop_managed_server(config_path, _GRACEFUL_RESTART_NOTICE)
+    serve.serve_web(config_path, web_pass=web_pass)
+
+
+def run_stop(args: argparse.Namespace) -> None:
+    stop_web(args.config)
 
 
 def run_restart(args: argparse.Namespace) -> None:
-    config = load_config(args.config)
-    try:
-        print(
-            "Перезапускаю сервер gracefully. Если сейчас идёт сбор канала, "
-            "подожду завершения активной задачи; остальные останутся pending в БД."
-        )
-        outcome = stop_server(pid_file_path(config))
-    except ProcessControlError as exc:
-        print(str(exc))
-        sys.exit(1)
-    print(outcome.message)
-    if outcome.result in (StopResult.UNMANAGED, StopResult.TIMEOUT):
-        sys.exit(1)
-    serve.run(args)
+    restart_web(args.config, web_pass=getattr(args, "web_pass", None))

--- a/src/cli/commands/worker.py
+++ b/src/cli/commands/worker.py
@@ -6,6 +6,17 @@ from src.config import load_config
 from src.runtime.worker import run_worker
 
 
-def run(args: argparse.Namespace) -> None:
-    config = load_config(args.config)
+def serve_worker(config_path: str) -> None:
+    """Start the standalone Telegram worker runtime.
+
+    Shared body for both CLI entry points: the argparse ``run`` wrapper below
+    and the Typer ``worker`` command (``src/cli/typer_commands.py``) call this
+    with the resolved ``--config`` path. ``run_worker`` owns its own event loop,
+    so this stays a plain ``def`` (no async-bridge needed).
+    """
+    config = load_config(config_path)
     run_worker(config)
+
+
+def run(args: argparse.Namespace) -> None:
+    serve_worker(args.config)

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -33,6 +33,7 @@ from src.cli.commands import translate as translate_cmd
 from src.cli.dotenv import load_cli_dotenv
 from src.cli.parser import build_parser
 from src.cli.runtime import ensure_data_dirs, setup_logging
+from src.cli.typer_commands import MIGRATED_COMMANDS, dispatch_via_typer
 
 
 # Migration note (epic #959, Wave 0 — issue #1120): the Typer scaffold lives in
@@ -50,6 +51,19 @@ from src.cli.runtime import ensure_data_dirs, setup_logging
 def main() -> None:
     parser = build_parser()
     args = parser.parse_args()
+
+    # Wave 1 (epic #959, issue #1121): the super-simple commands now live as
+    # Typer commands on ``src/cli/typer_app.py::app``. Route them through the
+    # Typer app *before* the argparse-path startup side effects below: the Typer
+    # commands run those exact side effects themselves via ``apply_startup`` (the
+    # 1:1 port), so doing them here too would double-fire logging setup / dotenv.
+    # Every other command keeps the argparse ``commands.X.run`` path (and the
+    # side effects below) until its own wave lands. The argparse ``register()``
+    # declarations stay so ``build_parser()`` remains the leaf-coverage source of
+    # truth (test_real_telegram_policy manifest sweep).
+    if args.command in MIGRATED_COMMANDS:
+        dispatch_via_typer(args)
+        return
 
     # Export the resolved config path so subprocess-spawning backends inherit it.
     # CodexSdkBackend spawns `python -m src.main --config <path> mcp-server`; it

--- a/src/cli/typer_commands.py
+++ b/src/cli/typer_commands.py
@@ -1,0 +1,490 @@
+"""Typer leaf commands migrated from argparse (epic #959, Wave 1 — issue #1121).
+
+Wave 1 moves the *super-simple* commands (no nested groups, or a single trivial
+sub-command) off the hand-rolled argparse dispatcher and onto the Typer ``app``
+from the Wave-0 scaffold (``src/cli/typer_app.py``):
+
+    serve · worker · stop · restart · mcp-server · collect (+ ``collect sample``)
+    · search · messages read
+
+Design (the hybrid chosen for Wave 1):
+
+* **Type-hints are the schema.** Each command declares the *same* flags /
+  arguments the argparse parser did (identical names, defaults and behaviour),
+  expressed as Typer ``Option`` / ``Argument`` parameters. No ``add_argument``.
+* **One async bridge.** Async command bodies funnel through ``run_async`` (one
+  ``asyncio.run`` per process); the local ``asyncio.run(_run())`` blocks that
+  used to live in ``commands/*.py`` are gone — the shared bodies in those
+  modules are now plain ``async def`` ``*_impl`` functions called from here.
+* **argparse stays as the leaf-coverage source of truth.** The
+  ``register()`` declarations in ``parser_domains/*.py`` are intentionally kept:
+  ``test_real_telegram_policy.py`` derives the live-CLI manifest from
+  ``build_parser()``, so removing them would drop migrated commands from the
+  manifest sweep. ``src/cli/main.py`` routes these commands through the Typer
+  ``app`` (``dispatch_via_typer``) while every other command keeps the argparse
+  path, so the production CLI executes the migrated Typer bodies.
+
+The Final wave (#1125) removes the argparse path entirely.
+"""
+
+from __future__ import annotations
+
+import argparse
+from enum import Enum
+from typing import cast
+
+import click
+import typer
+
+# Typer vendors its *own* copy of Click under ``typer._click``, so the exception
+# a Typer sub-group raises (``NoArgsIsHelpError`` / ``ClickException``) is NOT the
+# same class as the one in the top-level ``click`` package — an ``except
+# click.exceptions.ClickException`` would silently miss it. ``dispatch_via_typer``
+# must catch both. The vendored module is private; fall back gracefully to the
+# public ``click`` types if a future Typer drops it, so the import can never
+# crash the CLI.
+try:  # pragma: no cover - exercised indirectly via dispatch_via_typer tests
+    from typer._click import exceptions as _typer_click_exc
+
+    _CLICK_EXCEPTIONS: tuple[type[BaseException], ...] = (
+        click.exceptions.ClickException,
+        _typer_click_exc.ClickException,
+    )
+    _NO_ARGS_HELP_EXCEPTIONS: tuple[type[BaseException], ...] = (
+        click.exceptions.NoArgsIsHelpError,
+        _typer_click_exc.NoArgsIsHelpError,
+    )
+except ImportError:  # pragma: no cover - defensive fallback
+    _CLICK_EXCEPTIONS = (click.exceptions.ClickException,)
+    _NO_ARGS_HELP_EXCEPTIONS = (click.exceptions.NoArgsIsHelpError,)
+
+from src.cli.commands import collect as collect_cmd
+from src.cli.commands import mcp_server as mcp_server_cmd
+from src.cli.commands import messages as messages_cmd
+from src.cli.commands import search as search_cmd
+from src.cli.commands import serve as serve_cmd
+from src.cli.commands import server_control as server_control_cmd
+from src.cli.commands import worker as worker_cmd
+from src.cli.typer_app import app, apply_startup, run_async
+
+
+class SearchMode(str, Enum):
+    """``search --mode`` choices — mirrors the argparse ``choices=[…]`` set.
+
+    Subclassing ``str`` keeps the value a plain string for the command bodies
+    (which compare against ``"local"`` / ``"telegram"`` / … literals) while
+    giving Typer the closed choice set argparse enforced, so an unknown ``--mode``
+    is rejected on the Typer path too (not silently treated as ``local``).
+    """
+
+    local = "local"
+    semantic = "semantic"
+    hybrid = "hybrid"
+    telegram = "telegram"
+    my_chats = "my_chats"
+    channel = "channel"
+
+
+class OutputFormat(str, Enum):
+    """``messages read --format`` choices — mirrors the argparse ``choices=[…]``."""
+
+    text = "text"
+    json = "json"
+    csv = "csv"
+
+
+#: Argparse ``args.command`` names (dash form for ``mcp-server``) that Wave 1
+#: migrated to Typer. ``src/cli/main.py`` routes these through the Typer ``app``
+#: via :func:`dispatch_via_typer` instead of the argparse ``commands.X.run``
+#: handler; :func:`_argv_from_namespace` rebuilds the Typer argv from the parsed
+#: Namespace so the two entry points stay equivalent on the resolved flags.
+MIGRATED_COMMANDS: frozenset[str] = frozenset(
+    {"serve", "worker", "stop", "restart", "mcp-server", "collect", "search", "messages"}
+)
+
+
+# --------------------------------------------------------------------------- #
+# serve / worker
+# --------------------------------------------------------------------------- #
+
+
+@app.command()
+def serve(
+    ctx: typer.Context,
+    web_pass: str | None = typer.Option(None, "--web-pass", help="Web panel password (overrides config)"),
+    no_worker: bool = typer.Option(
+        False,
+        "--no-worker",
+        help=(
+            "Do not spawn the embedded Telegram worker inside this process. "
+            "Use this when you run `python -m src.main worker` in a separate "
+            "process / container (Docker, k8s). Without this flag the serve "
+            "command runs both the web app and the worker in one process — "
+            "clicking 'Collect' in the UI immediately triggers collection."
+        ),
+    ),
+) -> None:
+    """Start web server."""
+    apply_startup(ctx)
+    serve_cmd.serve_web(ctx.obj.config, web_pass=web_pass, no_worker=no_worker)
+
+
+@app.command()
+def worker(ctx: typer.Context) -> None:
+    """Start Telegram worker runtime."""
+    apply_startup(ctx)
+    worker_cmd.serve_worker(ctx.obj.config)
+
+
+# --------------------------------------------------------------------------- #
+# stop / restart
+# --------------------------------------------------------------------------- #
+
+
+@app.command()
+def stop(ctx: typer.Context) -> None:
+    """Stop web server started by this app."""
+    apply_startup(ctx)
+    server_control_cmd.stop_web(ctx.obj.config)
+
+
+@app.command()
+def restart(
+    ctx: typer.Context,
+    web_pass: str | None = typer.Option(None, "--web-pass", help="Web panel password (overrides config)"),
+) -> None:
+    """Restart web server."""
+    apply_startup(ctx)
+    server_control_cmd.restart_web(ctx.obj.config, web_pass=web_pass)
+
+
+# --------------------------------------------------------------------------- #
+# mcp-server
+# --------------------------------------------------------------------------- #
+
+
+@app.command("mcp-server")
+def mcp_server(
+    ctx: typer.Context,
+    no_pool: bool = typer.Option(
+        False,
+        "--no-pool",
+        help="Skip Telegram client pool init; pool-dependent tools return an error message",
+    ),
+) -> None:
+    """Expose the agent tool registry as a stdio MCP server (for external agents like Codex)."""
+    apply_startup(ctx)
+    mcp_server_cmd.serve_mcp(ctx.obj.config, no_pool=no_pool)
+
+
+# --------------------------------------------------------------------------- #
+# collect (+ collect sample)
+# --------------------------------------------------------------------------- #
+
+collect_app = typer.Typer(no_args_is_help=False, help="Run one-shot collection")
+app.add_typer(collect_app, name="collect")
+
+
+@collect_app.callback(invoke_without_command=True)
+def collect(
+    ctx: typer.Context,
+    channel_id: int | None = typer.Option(
+        None,
+        "--channel-id",
+        help="Collect single channel by channel_id (incremental by default)",
+    ),
+    full: bool = typer.Option(
+        False,
+        "--full",
+        help="For --channel-id, explicitly backfill the full channel history",
+    ),
+) -> None:
+    """Run one-shot collection (no sub-command = collect all / single channel)."""
+    # The ``sample`` sub-command has its own body; only run the top-level
+    # collection when no sub-command was invoked.
+    if ctx.invoked_subcommand is not None:
+        return
+    apply_startup(ctx)
+    run_async(collect_cmd.collect_impl(ctx.obj.config, channel_id=channel_id, full=full))
+
+
+@collect_app.command("sample")
+def collect_sample(
+    ctx: typer.Context,
+    channel_id: int = typer.Argument(..., help="Channel ID (numeric)"),
+    limit: int = typer.Option(10, "--limit", help="Number of messages to preview (default: 10)"),
+) -> None:
+    """Preview last N messages without saving to DB."""
+    apply_startup(ctx)
+    run_async(collect_cmd.collect_sample_impl(ctx.obj.config, channel_id=channel_id, limit=limit))
+
+
+# --------------------------------------------------------------------------- #
+# search
+# --------------------------------------------------------------------------- #
+
+
+@app.command()
+def search(
+    ctx: typer.Context,
+    query: str = typer.Argument("", help="Search query"),
+    limit: int = typer.Option(20, "--limit", help="Max results"),
+    mode: SearchMode = typer.Option(
+        SearchMode.local,
+        "--mode",
+        help="Search mode: local, semantic, hybrid, telegram, my_chats, channel",
+    ),
+    channel_id: int | None = typer.Option(None, "--channel-id", help="Channel ID for --mode=channel"),
+    min_length: int | None = typer.Option(None, "--min-length", help="Min message length"),
+    max_length: int | None = typer.Option(None, "--max-length", help="Max message length"),
+    fts: bool = typer.Option(False, "--fts", help="Use FTS5 boolean syntax"),
+    all_channels: bool = typer.Option(
+        False, "--all", help="Search all channels including filtered ones"
+    ),
+    index_now: bool = typer.Option(
+        False, "--index-now", help="Run semantic embeddings indexing/backfill before exiting"
+    ),
+    reset_index: bool = typer.Option(
+        False, "--reset-index", help="Drop semantic vector index before --index-now"
+    ),
+    purge_cache: bool = typer.Option(
+        False,
+        "--purge-cache",
+        help="Delete messages cached by a previous Premium global search for <query> and exit",
+    ),
+) -> None:
+    """Search messages."""
+    apply_startup(ctx)
+    run_async(
+        search_cmd.search_impl(
+            ctx.obj.config,
+            query=query,
+            limit=limit,
+            mode=mode.value,
+            channel_id=channel_id,
+            min_length=min_length,
+            max_length=max_length,
+            fts=fts,
+            include_filtered=all_channels,
+            index_now=index_now,
+            reset_index=reset_index,
+            purge_cache=purge_cache,
+        )
+    )
+
+
+# --------------------------------------------------------------------------- #
+# messages read
+# --------------------------------------------------------------------------- #
+
+messages_app = typer.Typer(no_args_is_help=True, help="Read messages from DB or live Telegram")
+app.add_typer(messages_app, name="messages")
+
+
+@messages_app.command("read")
+def messages_read(
+    ctx: typer.Context,
+    identifier: str = typer.Argument(..., help="Channel pk, channel_id, @username, or dialog ID"),
+    limit: int = typer.Option(50, "--limit", help="Max messages (default: 50)"),
+    live: bool = typer.Option(False, "--live", help="Read from Telegram instead of DB"),
+    phone: str | None = typer.Option(None, "--phone", help="Account phone (for --live)"),
+    query: str = typer.Option("", "--query", help="Text filter (DB only)"),
+    date_from: str | None = typer.Option(None, "--date-from", help="Start date YYYY-MM-DD (DB only)"),
+    date_to: str | None = typer.Option(None, "--date-to", help="End date YYYY-MM-DD (DB only)"),
+    topic_id: int | None = typer.Option(None, "--topic-id", help="Forum topic ID"),
+    offset_id: int | None = typer.Option(
+        None, "--offset-id", help="Read messages before this message ID (--live)"
+    ),
+    include_reaction_users: bool = typer.Option(
+        False, "--include-reaction-users", help="Show users who reacted (live mode only)"
+    ),
+    reaction_users_limit: int = typer.Option(
+        20,
+        "--reaction-users-limit",
+        help="Max reaction users per message for --include-reaction-users (default: 20)",
+    ),
+    output_format: OutputFormat = typer.Option(
+        OutputFormat.text, "--format", help="Output format (default: text)"
+    ),
+) -> None:
+    """Read messages from a channel/dialog."""
+    apply_startup(ctx)
+    run_async(
+        messages_cmd.messages_read_impl(
+            ctx.obj.config,
+            identifier=identifier,
+            limit=limit,
+            live=live,
+            phone=phone,
+            query=query,
+            date_from=date_from,
+            date_to=date_to,
+            topic_id=topic_id,
+            offset_id=offset_id,
+            include_reaction_users=include_reaction_users,
+            reaction_users_limit=reaction_users_limit,
+            output_format=output_format.value,
+        )
+    )
+
+
+# --------------------------------------------------------------------------- #
+# argparse → Typer delegation
+# --------------------------------------------------------------------------- #
+
+
+def _argv_from_namespace(args: argparse.Namespace) -> list[str]:
+    """Reconstruct the Typer argv for a migrated command from parsed argparse args.
+
+    ``src/cli/main.py`` has already parsed the process argv with the argparse
+    parser; we rebuild the minimal token list Typer needs so the Typer command
+    body runs with exactly the resolved flags. The global ``--config`` is passed
+    as a root option so ``main_callback`` records it on ``ctx.obj`` (matching the
+    argparse global). Only flags that differ from their defaults are emitted, so
+    store_true flags stay absent unless set.
+    """
+    command = args.command
+    argv: list[str] = ["--config", args.config]
+
+    if command == "serve":
+        argv.append("serve")
+        if getattr(args, "web_pass", None):
+            argv += ["--web-pass", args.web_pass]
+        if getattr(args, "no_worker", False):
+            argv.append("--no-worker")
+    elif command == "worker":
+        argv.append("worker")
+    elif command == "stop":
+        argv.append("stop")
+    elif command == "restart":
+        argv.append("restart")
+        if getattr(args, "web_pass", None):
+            argv += ["--web-pass", args.web_pass]
+    elif command == "mcp-server":
+        argv.append("mcp-server")
+        if getattr(args, "no_pool", False):
+            argv.append("--no-pool")
+    elif command == "collect":
+        argv.append("collect")
+        if getattr(args, "collect_action", None) == "sample":
+            argv.append("sample")
+            # Options before ``--``; the positional channel_id after it, so a
+            # negative id (e.g. ``-100123``) is never mistaken for an option —
+            # argparse accepts negative-number positionals, Click does not.
+            if getattr(args, "limit", 10) != 10:
+                argv += ["--limit", str(args.limit)]
+            argv += ["--", str(args.channel_id)]
+        else:
+            if getattr(args, "channel_id", None) is not None:
+                argv += ["--channel-id", str(args.channel_id)]
+            if getattr(args, "full", False):
+                argv.append("--full")
+    elif command == "search":
+        argv.append("search")
+        argv += _search_argv(args)
+    elif command == "messages":
+        argv.append("messages")
+        if getattr(args, "messages_action", None) == "read":
+            argv += _messages_read_argv(args)
+    return argv
+
+
+def _search_argv(args: argparse.Namespace) -> list[str]:
+    """argv tail for ``search`` — non-default flags, then ``--`` + positional query.
+
+    The query is emitted after a ``--`` separator so a query starting with ``-``
+    (which argparse accepts as the positional) is not parsed as an option by
+    Click. Always emit ``--`` so an empty query stays an explicit empty argument.
+    """
+    tail: list[str] = []
+    if getattr(args, "limit", 20) != 20:
+        tail += ["--limit", str(args.limit)]
+    if getattr(args, "mode", "local") != "local":
+        tail += ["--mode", args.mode]
+    if getattr(args, "channel_id", None) is not None:
+        tail += ["--channel-id", str(args.channel_id)]
+    if getattr(args, "min_length", None) is not None:
+        tail += ["--min-length", str(args.min_length)]
+    if getattr(args, "max_length", None) is not None:
+        tail += ["--max-length", str(args.max_length)]
+    if getattr(args, "fts", False):
+        tail.append("--fts")
+    if getattr(args, "all", False):
+        tail.append("--all")
+    if getattr(args, "index_now", False):
+        tail.append("--index-now")
+    if getattr(args, "reset_index", False):
+        tail.append("--reset-index")
+    if getattr(args, "purge_cache", False):
+        tail.append("--purge-cache")
+    tail += ["--", getattr(args, "query", "") or ""]
+    return tail
+
+
+def _messages_read_argv(args: argparse.Namespace) -> list[str]:
+    """argv tail for ``messages read`` — flags, then ``--`` + positional identifier.
+
+    The identifier follows a ``--`` separator so a negative channel id passed as
+    the identifier survives Click's option parsing (see the collect-sample note).
+    """
+    tail: list[str] = ["read"]
+    if getattr(args, "limit", 50) != 50:
+        tail += ["--limit", str(args.limit)]
+    if getattr(args, "live", False):
+        tail.append("--live")
+    if getattr(args, "phone", None):
+        tail += ["--phone", args.phone]
+    if getattr(args, "query", ""):
+        tail += ["--query", args.query]
+    if getattr(args, "date_from", None):
+        tail += ["--date-from", args.date_from]
+    if getattr(args, "date_to", None):
+        tail += ["--date-to", args.date_to]
+    if getattr(args, "topic_id", None) is not None:
+        tail += ["--topic-id", str(args.topic_id)]
+    if getattr(args, "offset_id", None) is not None:
+        tail += ["--offset-id", str(args.offset_id)]
+    if getattr(args, "include_reaction_users", False):
+        tail.append("--include-reaction-users")
+    if getattr(args, "reaction_users_limit", 20) != 20:
+        tail += ["--reaction-users-limit", str(args.reaction_users_limit)]
+    if getattr(args, "output_format", "text") != "text":
+        tail += ["--format", args.output_format]
+    tail += ["--", args.identifier]
+    return tail
+
+
+def dispatch_via_typer(args: argparse.Namespace) -> None:
+    """Execute a migrated command through the Typer ``app``.
+
+    Called by ``src/cli/main.py`` for commands in :data:`MIGRATED_COMMANDS`.
+    Runs the Typer app in non-standalone mode so a command's own ``SystemExit`` /
+    a Typer ``Exit`` propagate exactly as they did under argparse (the argparse
+    dispatcher never swallowed them either).
+
+    Non-standalone mode also makes Click *re-raise* ``ClickException`` instead of
+    rendering it, so we handle those here to preserve the argparse behaviour:
+
+    * A bare command group with ``no_args_is_help`` (``messages`` with no ``read``
+      sub-command) raises :class:`click.exceptions.NoArgsIsHelpError`. Argparse's
+      old ``sub_attr`` fallback printed that group's ``--help`` and exited **0**;
+      we reproduce that — render the help, exit 0 — so the user sees usage, not a
+      ``NoArgsIsHelpError`` traceback with exit 1.
+    * Any other usage error (unknown option, bad value) renders normally and
+      exits with its own (non-zero) code, matching argparse's exit-2 on misuse.
+    """
+    argv = _argv_from_namespace(args)
+    try:
+        app(args=argv, standalone_mode=False)
+    except _NO_ARGS_HELP_EXCEPTIONS as exc:
+        # Bare group → show help and exit cleanly (argparse parity: exit 0).
+        # Must precede the generic ClickException arm — NoArgsIsHelpError is a
+        # subclass of it but argparse exited 0 here, not 2.
+        # ``exc`` is a (vendored or stdlib) ClickException; both share the
+        # ``.show()`` / ``.exit_code`` interface — cast for the type checker.
+        cast("click.ClickException", exc).show()
+        raise SystemExit(0) from None
+    except _CLICK_EXCEPTIONS as exc:
+        click_exc = cast("click.ClickException", exc)
+        click_exc.show()
+        raise SystemExit(click_exc.exit_code) from None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -963,13 +963,15 @@ class TestCLIServerControl:
                 "Server stopped (PID 123).",
             ),
         ):
-            with patch("src.cli.commands.server_control.serve.run") as mock_serve_run:
+            with patch("src.cli.commands.server_control.serve.serve_web") as mock_serve_web:
                 args = _ns(command="restart", web_pass="secret")
                 run_restart(args)
 
         out = capsys.readouterr().out
         assert "Server stopped" in out
-        mock_serve_run.assert_called_once_with(args)
+        # restart starts a fresh serve via the shared serve_web body, threading
+        # the --web-pass override through (no Namespace hand-off).
+        mock_serve_web.assert_called_once_with("config.yaml", web_pass="secret")
 
     def test_restart_command_starts_serve_when_not_running(self, capsys):
         from src.cli.commands.server_control import run_restart
@@ -982,13 +984,13 @@ class TestCLIServerControl:
                 "Server is not running (no PID file: data/tg_search.pid).",
             ),
         ):
-            with patch("src.cli.commands.server_control.serve.run") as mock_serve_run:
+            with patch("src.cli.commands.server_control.serve.serve_web") as mock_serve_web:
                 args = _ns(command="restart", web_pass=None)
                 run_restart(args)
 
         out = capsys.readouterr().out
         assert "not running" in out
-        mock_serve_run.assert_called_once_with(args)
+        mock_serve_web.assert_called_once_with("config.yaml", web_pass=None)
 
     def test_restart_command_exits_for_timeout(self):
         from src.cli.commands.server_control import run_restart

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -319,17 +319,23 @@ class TestMainDispatch:
     @patch("src.cli.main.ensure_data_dirs")
     @patch("src.cli.main.build_parser")
     def test_main_dispatches_to_handler(self, mock_build, mock_dirs, mock_log, mock_dotenv):
-        """main() calls the correct handler for a known command."""
+        """main() calls the correct argparse handler for a not-yet-migrated command.
+
+        ``channel`` still routes through the argparse ``commands.X.run`` path
+        (only Wave 1's super-simple commands moved to Typer), so this asserts the
+        legacy dispatch + the argparse-path startup side effects still fire.
+        """
         parser = MagicMock()
         args = MagicMock()
-        args.command = "stop"
+        args.command = "channel"
+        args.channel_action = "list"
         args.config = "custom-config.yaml"
         parser.parse_args.return_value = args
         mock_build.return_value = parser
 
         mock_handler = MagicMock()
-        with patch("src.cli.main.server_control") as mock_mod:
-            mock_mod.run_stop = mock_handler
+        with patch("src.cli.main.channel") as mock_mod:
+            mock_mod.run = mock_handler
             main()
 
         mock_handler.assert_called_once_with(args)
@@ -386,24 +392,34 @@ class TestMainDispatch:
     @patch("src.cli.main.ensure_data_dirs")
     @patch("src.cli.main.build_parser")
     def test_main_serve_dispatch(self, mock_build, mock_dirs, mock_log, mock_dotenv):
-        """main() dispatches 'serve' command."""
+        """main() routes the migrated 'serve' command through the Typer app.
+
+        Wave 1 moved ``serve`` to Typer, so ``main()`` delegates via
+        ``dispatch_via_typer`` instead of calling ``commands.serve.run`` — and it
+        does so *before* the argparse-path startup side effects (those run inside
+        the Typer command's ``apply_startup`` to avoid double-firing).
+        """
         parser = MagicMock()
         args = MagicMock()
         args.command = "serve"
         parser.parse_args.return_value = args
         mock_build.return_value = parser
 
-        with patch("src.cli.main.serve") as mock_mod:
-            mock_mod.run = MagicMock()
+        with patch("src.cli.main.dispatch_via_typer") as mock_dispatch:
             main()
-            mock_mod.run.assert_called_once_with(args)
+
+        mock_dispatch.assert_called_once_with(args)
+        # The argparse-path side effects are NOT run here for a migrated command.
+        mock_log.assert_not_called()
+        mock_dotenv.assert_not_called()
+        mock_dirs.assert_not_called()
 
     @patch("src.cli.main.load_cli_dotenv")
     @patch("src.cli.main.setup_logging")
     @patch("src.cli.main.ensure_data_dirs")
     @patch("src.cli.main.build_parser")
     def test_main_collect_dispatch(self, mock_build, mock_dirs, mock_log, mock_dotenv):
-        """main() dispatches 'collect' command."""
+        """main() routes the migrated 'collect' command through the Typer app."""
         parser = MagicMock()
         args = MagicMock()
         args.command = "collect"
@@ -412,10 +428,10 @@ class TestMainDispatch:
         parser.parse_args.return_value = args
         mock_build.return_value = parser
 
-        with patch("src.cli.main.collect") as mock_mod:
-            mock_mod.run = MagicMock()
+        with patch("src.cli.main.dispatch_via_typer") as mock_dispatch:
             main()
-            mock_mod.run.assert_called_once_with(args)
+
+        mock_dispatch.assert_called_once_with(args)
 
     @patch("src.cli.main.load_cli_dotenv")
     @patch("src.cli.main.setup_logging")

--- a/tests/test_cli_serve_commands.py
+++ b/tests/test_cli_serve_commands.py
@@ -160,8 +160,10 @@ def test_restart_success(capsys):
     with patch("src.cli.commands.server_control.load_config", return_value=cfg), \
          patch("src.cli.commands.server_control.stop_server", return_value=outcome), \
          patch("src.cli.commands.server_control.pid_file_path", return_value="/tmp/test.pid"), \
-         patch("src.cli.commands.serve.run") as mock_serve:
+         patch("src.cli.commands.serve.serve_web") as mock_serve:
         run_restart(_args())
     out = capsys.readouterr().out
     assert "подожду завершения активной задачи" in out
+    # restart stops the running server, then starts a fresh `serve` via the
+    # shared serve_web body (no more Namespace hand-off).
     mock_serve.assert_called_once()

--- a/tests/test_cli_typer_wave1.py
+++ b/tests/test_cli_typer_wave1.py
@@ -1,0 +1,500 @@
+"""CliRunner tests for the Wave-1 Typer commands (epic #959 — issue #1121).
+
+Wave 1 migrates the super-simple commands off the argparse dispatcher onto the
+Typer ``app``: serve · worker · stop · restart · mcp-server · collect
+(+ ``collect sample``) · search · messages read.
+
+These tests drive the production ``app`` through ``typer.testing.CliRunner`` and
+assert each command:
+
+* exposes the *same* flags / arguments the argparse parser did (identical names,
+  defaults, behaviour — the hard invariant of the migration), and
+* delegates to the shared command body (``serve_web`` / ``*_impl``) with the
+  flags mapped to exactly the right keyword arguments.
+
+The shared bodies are stubbed (and ``run_async`` is patched to capture rather
+than execute the coroutine) so no real DB / Telegram / uvicorn work happens —
+the wiring from CLI tokens to the body is what is under test.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from src.cli.parser import build_parser
+from src.cli.typer_app import app
+from src.cli.typer_commands import dispatch_via_typer
+
+runner = CliRunner()
+
+
+def _delegate(argv: list[str]) -> None:
+    """Run the real prod path: argparse parse → argparse→Typer delegation.
+
+    Mirrors ``src/cli/main.py``: the process argv is parsed by ``build_parser``,
+    then a migrated command is executed by ``dispatch_via_typer`` (which rebuilds
+    the Typer argv from the Namespace). This is the round-trip that must preserve
+    every flag / positional, including the awkward ones (negative ids, queries
+    that start with ``-``).
+    """
+    args = build_parser().parse_args(argv)
+    dispatch_via_typer(args)
+
+
+# --------------------------------------------------------------------------- #
+# serve / worker (synchronous bodies — no async-bridge)
+# --------------------------------------------------------------------------- #
+
+
+def test_serve_delegates_with_defaults():
+    with patch("src.cli.typer_commands.serve_cmd.serve_web") as mock_serve:
+        result = runner.invoke(app, ["serve"])
+    assert result.exit_code == 0
+    mock_serve.assert_called_once_with("config.yaml", web_pass=None, no_worker=False)
+
+
+def test_serve_threads_web_pass_and_no_worker():
+    with patch("src.cli.typer_commands.serve_cmd.serve_web") as mock_serve:
+        result = runner.invoke(app, ["serve", "--web-pass", "s3cret", "--no-worker"])
+    assert result.exit_code == 0
+    mock_serve.assert_called_once_with("config.yaml", web_pass="s3cret", no_worker=True)
+
+
+def test_serve_honours_global_config_option():
+    with patch("src.cli.typer_commands.serve_cmd.serve_web") as mock_serve:
+        result = runner.invoke(app, ["--config", "prod.yaml", "serve"])
+    assert result.exit_code == 0
+    mock_serve.assert_called_once_with("prod.yaml", web_pass=None, no_worker=False)
+
+
+def test_worker_delegates():
+    with patch("src.cli.typer_commands.worker_cmd.serve_worker") as mock_worker:
+        result = runner.invoke(app, ["worker"])
+    assert result.exit_code == 0
+    mock_worker.assert_called_once_with("config.yaml")
+
+
+# --------------------------------------------------------------------------- #
+# stop / restart
+# --------------------------------------------------------------------------- #
+
+
+def test_stop_delegates():
+    with patch("src.cli.typer_commands.server_control_cmd.stop_web") as mock_stop:
+        result = runner.invoke(app, ["stop"])
+    assert result.exit_code == 0
+    mock_stop.assert_called_once_with("config.yaml")
+
+
+def test_restart_threads_web_pass():
+    with patch("src.cli.typer_commands.server_control_cmd.restart_web") as mock_restart:
+        result = runner.invoke(app, ["restart", "--web-pass", "pw"])
+    assert result.exit_code == 0
+    mock_restart.assert_called_once_with("config.yaml", web_pass="pw")
+
+
+def test_restart_defaults_web_pass_to_none():
+    with patch("src.cli.typer_commands.server_control_cmd.restart_web") as mock_restart:
+        result = runner.invoke(app, ["restart"])
+    assert result.exit_code == 0
+    mock_restart.assert_called_once_with("config.yaml", web_pass=None)
+
+
+# --------------------------------------------------------------------------- #
+# mcp-server
+# --------------------------------------------------------------------------- #
+
+
+def test_mcp_server_defaults_pool_on():
+    with patch("src.cli.typer_commands.mcp_server_cmd.serve_mcp") as mock_mcp:
+        result = runner.invoke(app, ["mcp-server"])
+    assert result.exit_code == 0
+    mock_mcp.assert_called_once_with("config.yaml", no_pool=False)
+
+
+def test_mcp_server_no_pool_flag():
+    with patch("src.cli.typer_commands.mcp_server_cmd.serve_mcp") as mock_mcp:
+        result = runner.invoke(app, ["mcp-server", "--no-pool"])
+    assert result.exit_code == 0
+    mock_mcp.assert_called_once_with("config.yaml", no_pool=True)
+
+
+# --------------------------------------------------------------------------- #
+# collect (+ collect sample) — async bodies via run_async
+# --------------------------------------------------------------------------- #
+
+
+def test_collect_all_channels_defaults():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.collect_cmd.collect_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async") as mock_run_async,
+    ):
+        result = runner.invoke(app, ["collect"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", channel_id=None, full=False)
+    mock_run_async.assert_called_once()
+
+
+def test_collect_single_channel_full():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.collect_cmd.collect_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["collect", "--channel-id", "12345", "--full"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", channel_id=12345, full=True)
+
+
+def test_collect_sample_positional_and_limit():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.collect_cmd.collect_sample_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        # Negative channel ids must be passed after ``--`` (Click, unlike
+        # argparse, treats a leading ``-`` as an option). The argparse→Typer
+        # delegation emits exactly this form; see test_collect_sample_negative_id.
+        result = runner.invoke(app, ["collect", "sample", "--limit", "5", "--", "-100123"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", channel_id=-100123, limit=5)
+
+
+def test_collect_sample_defaults_limit_to_ten():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.collect_cmd.collect_sample_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["collect", "sample", "777"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", channel_id=777, limit=10)
+
+
+# --------------------------------------------------------------------------- #
+# search
+# --------------------------------------------------------------------------- #
+
+
+def test_search_defaults():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.search_cmd.search_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["search", "hello world"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with(
+        "config.yaml",
+        query="hello world",
+        limit=20,
+        mode="local",
+        channel_id=None,
+        min_length=None,
+        max_length=None,
+        fts=False,
+        include_filtered=False,
+        index_now=False,
+        reset_index=False,
+        purge_cache=False,
+    )
+
+
+def test_search_limit_and_mode():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.search_cmd.search_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["search", "q", "--limit", "5", "--mode", "semantic"])
+    assert result.exit_code == 0
+    kwargs = mock_impl.call_args.kwargs
+    assert kwargs["query"] == "q"
+    assert kwargs["limit"] == 5
+    assert kwargs["mode"] == "semantic"
+
+
+def test_search_all_maps_to_include_filtered():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.search_cmd.search_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["search", "q", "--all", "--fts"])
+    assert result.exit_code == 0
+    kwargs = mock_impl.call_args.kwargs
+    assert kwargs["include_filtered"] is True
+    assert kwargs["fts"] is True
+
+
+def test_search_channel_mode_threads_channel_id():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.search_cmd.search_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["search", "q", "--mode", "channel", "--channel-id", "42"])
+    assert result.exit_code == 0
+    kwargs = mock_impl.call_args.kwargs
+    assert kwargs["mode"] == "channel"
+    assert kwargs["channel_id"] == 42
+
+
+def test_search_rejects_unknown_mode():
+    """--mode keeps argparse's closed choice set: an unknown value is rejected.
+
+    The Typer signature uses a str-Enum mirroring argparse ``choices``, so a bad
+    mode errors (exit 2) before the body runs — it is not silently treated as
+    ``local``.
+    """
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.search_cmd.search_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["search", "q", "--mode", "bogus"])
+    assert result.exit_code == 2
+    mock_impl.assert_not_called()
+
+
+def test_search_mode_value_is_plain_str():
+    """The Enum subclasses ``str`` so the body still receives a plain string."""
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.search_cmd.search_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["search", "q", "--mode", "semantic"])
+    assert result.exit_code == 0
+    assert mock_impl.call_args.kwargs["mode"] == "semantic"
+    assert type(mock_impl.call_args.kwargs["mode"]) is str
+
+
+def test_messages_read_rejects_unknown_format():
+    """--format keeps argparse's text/json/csv choice set (rejects others)."""
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.messages_cmd.messages_read_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["messages", "read", "100", "--format", "bogus"])
+    assert result.exit_code == 2
+    mock_impl.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# messages read
+# --------------------------------------------------------------------------- #
+
+
+def test_messages_read_defaults():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.messages_cmd.messages_read_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["messages", "read", "100"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with(
+        "config.yaml",
+        identifier="100",
+        limit=50,
+        live=False,
+        phone=None,
+        query="",
+        date_from=None,
+        date_to=None,
+        topic_id=None,
+        offset_id=None,
+        include_reaction_users=False,
+        reaction_users_limit=20,
+        output_format="text",
+    )
+
+
+def test_messages_read_format_json():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.messages_cmd.messages_read_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["messages", "read", "@chan", "--format", "json"])
+    assert result.exit_code == 0
+    assert mock_impl.call_args.kwargs["output_format"] == "json"
+
+
+def test_messages_read_live_flags():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.messages_cmd.messages_read_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "messages", "read", "100",
+                "--live", "--phone", "+15550001111",
+                "--offset-id", "900", "--topic-id", "7",
+            ],
+        )
+    assert result.exit_code == 0
+    kwargs = mock_impl.call_args.kwargs
+    assert kwargs["live"] is True
+    assert kwargs["phone"] == "+15550001111"
+    assert kwargs["offset_id"] == 900
+    assert kwargs["topic_id"] == 7
+
+
+def test_messages_read_date_filters_db_mode():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.messages_cmd.messages_read_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "messages", "read", "100",
+                "--query", "hello",
+                "--date-from", "2025-01-01", "--date-to", "2025-12-31",
+            ],
+        )
+    assert result.exit_code == 0
+    kwargs = mock_impl.call_args.kwargs
+    assert kwargs["query"] == "hello"
+    assert kwargs["date_from"] == "2025-01-01"
+    assert kwargs["date_to"] == "2025-12-31"
+
+
+# --------------------------------------------------------------------------- #
+# argparse → Typer delegation round-trip (the real prod path)
+#
+# These guard the invariant "names / flags / behaviour are unchanged" end to
+# end: `main()` parses with argparse, then `dispatch_via_typer` rebuilds the
+# Typer argv. Awkward positionals (negative ids, dash-leading queries) that
+# argparse accepts but Click would mis-read as options must survive the trip.
+# --------------------------------------------------------------------------- #
+
+
+def test_delegation_serve_flags_roundtrip():
+    with patch("src.cli.typer_commands.serve_cmd.serve_web") as mock_serve:
+        _delegate(["serve", "--web-pass", "pw", "--no-worker"])
+    mock_serve.assert_called_once_with("config.yaml", web_pass="pw", no_worker=True)
+
+
+def test_delegation_collect_single_channel_roundtrip():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.collect_cmd.collect_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        _delegate(["collect", "--channel-id", "12345", "--full"])
+    mock_impl.assert_called_once_with("config.yaml", channel_id=12345, full=True)
+
+
+def test_delegation_collect_sample_negative_id():
+    """Regression: a negative channel id must survive argparse→Typer delegation."""
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.collect_cmd.collect_sample_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        _delegate(["collect", "sample", "-100123", "--limit", "5"])
+    mock_impl.assert_called_once_with("config.yaml", channel_id=-100123, limit=5)
+
+
+def test_delegation_search_dash_query():
+    """Regression: a query starting with '-' must survive delegation as the query."""
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.search_cmd.search_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        _delegate(["search", "-100500", "--mode", "semantic"])
+    kwargs = mock_impl.call_args.kwargs
+    assert kwargs["query"] == "-100500"
+    assert kwargs["mode"] == "semantic"
+
+
+def test_delegation_search_channel_mode_negative_channel_id():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.search_cmd.search_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        _delegate(["search", "q", "--mode", "channel", "--channel-id", "-100500"])
+    kwargs = mock_impl.call_args.kwargs
+    assert kwargs["channel_id"] == -100500
+
+
+def test_delegation_messages_read_negative_identifier():
+    """Regression: a negative-id identifier must survive argparse→Typer delegation."""
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.messages_cmd.messages_read_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        _delegate(["messages", "read", "-100500", "--format", "json", "--limit", "10"])
+    kwargs = mock_impl.call_args.kwargs
+    assert kwargs["identifier"] == "-100500"
+    assert kwargs["output_format"] == "json"
+    assert kwargs["limit"] == 10
+
+
+def test_delegation_mcp_server_no_pool():
+    with patch("src.cli.typer_commands.mcp_server_cmd.serve_mcp") as mock_mcp:
+        _delegate(["mcp-server", "--no-pool"])
+    mock_mcp.assert_called_once_with("config.yaml", no_pool=True)
+
+
+def test_delegation_honours_global_config():
+    with patch("src.cli.typer_commands.worker_cmd.serve_worker") as mock_worker:
+        _delegate(["--config", "prod.yaml", "worker"])
+    mock_worker.assert_called_once_with("prod.yaml")
+
+
+# --------------------------------------------------------------------------- #
+# Bare-group help parity (regression for the messages-no-subcommand blocker)
+#
+# argparse's old `sub_attr` fallback printed `messages --help` and exited 0 for
+# a bare `messages` (no `read`). The Typer path must match: render help, exit 0,
+# and crucially NOT leak a `NoArgsIsHelpError` traceback. Because Typer vendors
+# its own Click, the exception is `typer._click.exceptions.NoArgsIsHelpError`
+# (not the stdlib `click` one), so `dispatch_via_typer` must catch both.
+# --------------------------------------------------------------------------- #
+
+
+def test_messages_without_subcommand_shows_help_and_exits_zero():
+    import pytest
+
+    args = build_parser().parse_args(["messages"])
+    # No body should run — only help. dispatch_via_typer raises SystemExit(0).
+    with (
+        patch("src.cli.typer_commands.messages_cmd.messages_read_impl") as mock_impl,
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            dispatch_via_typer(args)
+    assert exc_info.value.code == 0
+    mock_impl.assert_not_called()
+
+
+def test_messages_without_subcommand_clean_via_full_cli(capsys):
+    """End-to-end: `python -m src.main messages` prints help, exits 0, no traceback."""
+    import pytest
+
+    from src.cli.main import main
+
+    with patch("sys.argv", ["main.py", "messages"]):
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+    # Exit 0 (argparse parity) and the help — not a NoArgsIsHelpError traceback.
+    assert exc_info.value.code == 0
+    out = capsys.readouterr()
+    combined = out.out + out.err
+    assert "NoArgsIsHelpError" not in combined
+    assert "Traceback" not in combined
+    assert "read" in combined  # the help lists the `read` sub-command


### PR DESCRIPTION
## Что

Часть эпика #959 (argparse→Typer). **Волна 1** мигрирует 8 супер-простых команд на Typer-каркас Волны 0 (`typer_app.py`):

`serve` · `worker` · `stop` · `restart` · `mcp-server` · `collect` (+ `collect sample`) · `search` · `messages read`

Тело каждой команды переехало в Typer-сигнатуру, чьи type-hints объявляют **ровно те же** флаги/аргументы (имена, дефолты, поведение неизменны). Async-тела funnel через единый async-bridge (`run_async`); локальные `asyncio.run(_run())` в `commands/*.py` убраны и заменены общими `async def *_impl`.

## Почему гибрид (register() сохранён)

Issue ставит целью «убрать register() из parser_domains». Но `test_real_telegram_policy.py` строит leaf-манифест **из `build_parser()`** и требует `stale_manifest == []` / `missing == []`. Удаление register() выкинуло бы мигрированные команды из sweep и сломало инвариант `pytest -k "manifest or real_telegram_policy"` зелёный — он **жёстче** цели «убрать register()».

Поэтому argparse-декларации остаются источником истины для leaf-audit, а `main()` делегирует мигрированные команды в Typer `app` через `dispatch_via_typer` (реконструирует Typer-argv из распарсенного Namespace), запуская startup-side-effects единожды через `apply_startup`. Финальная волна (#1125) уберёт argparse-путь. Развилка зафиксирована комментарием в issue #1121.

## Сохранённый паритет (argparse→Typer round-trip)

- Отрицательные channel_id / query с ведущим `-` переживают делегирование через `--` separator (Click, в отличие от argparse, трактует ведущий `-` как опцию).
- `messages` без `read` печатает help и выходит **0** без `NoArgsIsHelpError`-трейсбека — `dispatch_via_typer` ловит `ClickException` (и Typer-вендоренный, и stdlib), повторяя старый argparse-fallback `messages --help`.
- `--mode` / `--format` сохраняют закрытый набор choices через str-Enum.
- TG_CONFIG_PATH-экспорт (для mcp-server subprocess), exit-коды и cleanup ресурсов — без изменений.

## Тесты

- Новый `tests/test_cli_typer_wave1.py` — CliRunner + полный delegation round-trip; **мутационно верифицированные** регресс-гарды на negative-id и bare-group-help.
- Адаптированы `test_cli_main` / `test_cli_serve_commands` / `test_cli` (dispatch + restart) под новый контракт.

## Инварианты ✅

- Все имена/флаги сохранены: `serve --web-pass --no-worker`, `mcp-server --no-pool`, `collect --channel-id --full`, `collect sample`, `search --limit --mode`, `messages read --format text|json|csv`.
- Манифест real-tg: кортежи имён неизменны; leaf-audit зелёный.
- `pytest -k "manifest or parity or real_telegram_policy or cli_main"` — зелёный.
- CLI/Web parity сохранён.

## Проверки

- `ruff check src/ tests/` — clean
- `mypy` — 0 новых ошибок в изменённых файлах
- `lint-imports` — контракт KEPT (CLI не импортирует telethon напрямую)
- Целевой набор + smoke + serial messages/cli — зелёные

## Ревью

Прогнан dual adversarial-ревью (Codex ∥ Claude). Codex — чисто по всем 6 пунктам. Claude поймал 1 BLOCKER (`messages` без read → трейсбек + exit 1) и 3 MINOR (mode/format choices, misleading test name, redundant condition) — **все исправлены** в этом PR, с regression-тестами.

Closes #1121

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUmxVr3iHtGgnkRu4RCvhr