### PR TITLE
feat(web): POST export-session REST endpoint for SSO

### DIFF
--- a/src/database/repositories/accounts.py
+++ b/src/database/repositories/accounts.py
@@ -363,6 +363,35 @@ class AccountsRepository:
         raw_session = str(row["session_string"] or "")
         return self._decrypt_session_for_live_use(raw_session, str(row["phone"]))
 
+    async def get_session_export(
+        self, *, account_id: int | None = None, phone: str | None = None
+    ) -> tuple[str, str] | None:
+        """Return ``(phone, decrypted_session)`` from a SINGLE row, or ``None`` if absent.
+
+        Unlike resolving identity and decrypting in two separate awaits, this binds
+        the phone and the session to the SAME row read, so a concurrent delete+reinsert
+        between the two steps can't pair a fresh session with a stale phone (SQLite
+        reuses rowids) — a session-export consistency hazard (#1145 review). Exactly
+        one of ``account_id`` / ``phone`` must be given. Decrypt failure on the target
+        still raises :class:`AccountSessionDecryptError`.
+        """
+        if (account_id is None) == (phone is None):
+            raise ValueError("provide exactly one of account_id / phone")
+        if account_id is not None:
+            cur = await self._db.execute(
+                "SELECT phone, session_string FROM accounts WHERE id = ?", (account_id,)
+            )
+        else:
+            cur = await self._db.execute(
+                "SELECT phone, session_string FROM accounts WHERE phone = ?", (phone,)
+            )
+        row = await cur.fetchone()
+        if row is None:
+            return None
+        row_phone = str(row["phone"])
+        raw_session = str(row["session_string"] or "")
+        return row_phone, self._decrypt_session_for_live_use(raw_session, row_phone)
+
     async def get_live_usable_accounts(self, active_only: bool = False) -> list[Account]:
         """Return accounts whose sessions can be decrypted for live Telegram use."""
         sql = "SELECT * FROM accounts"

--- a/src/web/routes/accounts.py
+++ b/src/web/routes/accounts.py
@@ -186,24 +186,23 @@ async def export_session(request: Request, account_id: int):
     Returns 404 ``{"error": "account_not_found"}`` for an unknown id.
     """
     db = deps.get_db(request)
-    # Resolve identity via summaries (no decrypt) so a broken sibling session
-    # can't abort the lookup (#1143); decrypt only the chosen account.
-    summaries = await db.get_account_summaries(active_only=False)
-    acc = next((a for a in summaries if a.id == account_id), None)
-    if acc is None:
-        return JSONResponse({"error": "account_not_found"}, status_code=404)
-
+    # Read phone + session from a SINGLE row so a concurrent delete+reinsert can't
+    # pair a fresh session with a stale phone (SQLite reuses rowids) — #1145 review.
+    # A broken sibling session still can't abort this (only the target row is read).
     try:
-        session_string = await db.repos.accounts.get_decrypted_session(account_id=account_id)
+        export = await db.repos.accounts.get_session_export(account_id=account_id)
     except AccountSessionDecryptError as exc:
-        # status carries only the failure kind (phone+status), never the secret.
+        # status carries only the failure kind, never the secret.
         return JSONResponse(
             {"error": "session_decrypt_failed", "status": exc.status}, status_code=409
         )
+    if export is None:
+        return JSONResponse({"error": "account_not_found"}, status_code=404)
+    phone, session_string = export
     if not session_string:
         return JSONResponse({"error": "no_session"}, status_code=409)
 
     # Audit the export WITHOUT the value (account_id + actor only) — session_string
     # is a secret and must never be logged.
     logger.info("account.export_session account_id=%s by=web", account_id)
-    return JSONResponse({"phone": acc.phone, "session_string": session_string})
+    return JSONResponse({"phone": phone, "session_string": session_string})

--- a/src/web/routes/accounts.py
+++ b/src/web/routes/accounts.py
@@ -1,5 +1,6 @@
 """Account management routes — split from settings.py for clarity."""
 
+import logging
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Request
@@ -7,9 +8,12 @@ from fastapi.responses import JSONResponse, RedirectResponse
 
 from src.agent.runtime_context import AgentRuntimeContext
 from src.agent.tools.accounts import get_live_account_info_text
+from src.database.repositories.accounts import AccountSessionDecryptError
 from src.web import deps
 from src.web.schemas.accounts import AccountInfoResponse, FloodStatusItem
 from src.web.schemas.common import ErrorResponse
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -164,3 +168,42 @@ async def flood_clear(request: Request, account_id: int):
         return RedirectResponse(url="/settings?error=account_not_found", status_code=303)
     await db.update_account_flood(acc.phone, None)
     return RedirectResponse(url="/settings?msg=flood_cleared", status_code=303)
+
+
+@router.post(
+    "/{account_id}/export-session",
+    tags=["accounts"],
+    summary="Export the decrypted StringSession for SSO",
+    responses={404: {"model": ErrorResponse, "description": "Account not found"}},
+)
+async def export_session(request: Request, account_id: int):
+    """Return the decrypted plaintext StringSession for SSO (parity with CLI/agent, #828).
+
+    POST (not GET) so the secret never lands in a URL/access log. Guarded by the
+    panel's existing WEB_PASS auth (BasicAuthMiddleware → 401 for API clients
+    without credentials). The session string grants FULL account access — it is
+    returned in the JSON body ONLY on this explicit request and is NEVER logged.
+    Returns 404 ``{"error": "account_not_found"}`` for an unknown id.
+    """
+    db = deps.get_db(request)
+    # Resolve identity via summaries (no decrypt) so a broken sibling session
+    # can't abort the lookup (#1143); decrypt only the chosen account.
+    summaries = await db.get_account_summaries(active_only=False)
+    acc = next((a for a in summaries if a.id == account_id), None)
+    if acc is None:
+        return JSONResponse({"error": "account_not_found"}, status_code=404)
+
+    try:
+        session_string = await db.repos.accounts.get_decrypted_session(account_id=account_id)
+    except AccountSessionDecryptError as exc:
+        # status carries only the failure kind (phone+status), never the secret.
+        return JSONResponse(
+            {"error": "session_decrypt_failed", "status": exc.status}, status_code=409
+        )
+    if not session_string:
+        return JSONResponse({"error": "no_session"}, status_code=409)
+
+    # Audit the export WITHOUT the value (account_id + actor only) — session_string
+    # is a secret and must never be logged.
+    logger.info("account.export_session account_id=%s by=web", account_id)
+    return JSONResponse({"phone": acc.phone, "session_string": session_string})

--- a/tests/routes/test_export_session_1145.py
+++ b/tests/routes/test_export_session_1145.py
@@ -97,32 +97,61 @@ async def test_export_session_roundtrip_with_encryption(tmp_path):
 
 
 @pytest.mark.anyio
-async def test_get_session_export_binds_phone_and_session_to_one_row(tmp_path):
-    """Regression for the #1145 review HIGH: phone and session must come from the
-    SAME row, never a stale phone paired with a fresh session after delete+reinsert.
+async def test_old_two_read_pattern_would_mix_phone_and_session(tmp_path):
+    """Proves the #1145 HIGH was real: the OLD two-await pattern (identity from one
+    read, session from a second) pairs a STALE phone with a FRESH session when a
+    delete+reinsert lands between the two reads on a reused rowid.
 
-    The endpoint previously read identity (summaries) and the session in two
-    separate awaits; if a row is deleted and a different account reinserted onto
-    the reused id between them, the response would mix the old phone with the new
-    session. `get_session_export` reads both from one row, so the pairing is
-    always consistent — or None if the row is gone.
+    This reconstructs the pre-fix route logic locally and forces the race BETWEEN
+    the two reads. It must observe the mix — establishing the hazard the fixed
+    code (next test) prevents. If this ever stops mixing, the race model is wrong
+    and the guard below would prove nothing.
     """
-    db = Database(str(tmp_path / "consistency.db"))
+    db = Database(str(tmp_path / "old.db"))
+    await db.initialize()
+    try:
+        # Step 1 of the OLD pattern: read identity (summaries) for the FIRST account.
+        first_id = await db.add_account(Account(phone="+15551110001", session_string="sess_one"))
+        summaries = await db.get_account_summaries(active_only=False)
+        stale_phone = next(s.phone for s in summaries if s.id == first_id)
+
+        # The race lands BETWEEN the two reads: row deleted, a DIFFERENT account
+        # reinserted onto the reused id.
+        await db.delete_account(first_id)
+        reused_id = await db.add_account(Account(phone="+15552220002", session_string="sess_two"))
+        assert reused_id == first_id  # rowid genuinely reused
+
+        # Step 2 of the OLD pattern: decrypt by id only → gets the NEW session.
+        fresh_session = await db.repos.accounts.get_decrypted_session(account_id=first_id)
+
+        # The old route returned stale_phone + fresh_session → a poisoned pairing.
+        assert (stale_phone, fresh_session) == ("+15551110001", "sess_two")
+        assert stale_phone != "+15552220002"  # phone does NOT own the live session
+    finally:
+        await db.close()
+
+
+@pytest.mark.anyio
+async def test_get_session_export_never_mixes_across_reused_rowid(tmp_path):
+    """The fix: `get_session_export` reads phone AND session from ONE row, so under
+    the same delete+reinsert race it returns a CONSISTENT pair (or None) — never the
+    stale_phone+fresh_session mix the sibling test above demonstrates for the old code.
+    """
+    db = Database(str(tmp_path / "fixed.db"))
     await db.initialize()
     try:
         first_id = await db.add_account(Account(phone="+15551110001", session_string="sess_one"))
-
-        # Simulate the hazard: delete the row, reinsert a DIFFERENT account.
         await db.delete_account(first_id)
         reused_id = await db.add_account(Account(phone="+15552220002", session_string="sess_two"))
+        assert reused_id == first_id  # same rowid the export targets
 
         export = await db.repos.accounts.get_session_export(account_id=reused_id)
         assert export is not None
         phone, session = export
-        # phone and session are from the SAME (current) row — never mixed.
+        # Both fields come from the SAME current row — the stale phone is impossible.
         assert (phone, session) == ("+15552220002", "sess_two")
 
-        # A genuinely absent id yields None (→ 404 at the route), not a stale pairing.
+        # A genuinely absent id yields None (→ 404 at the route), never a stale pairing.
         assert await db.repos.accounts.get_session_export(account_id=999999) is None
     finally:
         await db.close()

--- a/tests/routes/test_export_session_1145.py
+++ b/tests/routes/test_export_session_1145.py
@@ -155,3 +155,87 @@ async def test_get_session_export_never_mixes_across_reused_rowid(tmp_path):
         assert await db.repos.accounts.get_session_export(account_id=999999) is None
     finally:
         await db.close()
+
+
+@pytest.mark.anyio
+async def test_export_route_never_mixes_when_race_lands_mid_request(route_client, base_app):
+    """Regression guard for the #1145 HIGH at the LIVE ROUTE surface.
+
+    The sibling tests above either reconstruct the old pattern by hand at the DB
+    level (never touching the route) or stage the delete+reinsert *before* the
+    accessor runs — so a regressed two-read route would still pass them. This
+    test instead exercises the REAL endpoint over HTTP and injects the race
+    *between* identity-resolution and session-fetch, at the dependency boundary
+    the old route used for the second read (`get_decrypted_session`).
+
+    The pre-fix route did: phone from `get_account_summaries`, then session from
+    a separate `get_decrypted_session` await. We monkeypatch that session-fetch
+    boundary so that just before it runs, the targeted row is deleted and a
+    DIFFERENT account is reinserted onto the SAME reused rowid. A two-read route
+    would then return stale_phone + fresh_session (the poisoned pairing). The
+    fixed route never calls `get_decrypted_session` (it reads both fields from
+    one row via `get_session_export`), so the injected race cannot split the
+    pair: the response is always a consistent (phone, session) couple or 404 —
+    never the mix. Revert the prod accessor to two reads and THIS test must fail.
+
+    Scope: this guards the specific two-read regression (identity then a separate
+    `get_decrypted_session`). The DB cross-check at the end also asserts the more
+    general invariant — the returned phone must currently own the returned session
+    — so a differently-shaped split would still trip that assertion at the route.
+    """
+    app, db, pool = base_app
+    accounts_repo = db.repos.accounts
+
+    # Seed a target row, capture its rowid, then free it so the reinsert below
+    # lands on the SAME id the request will resolve.
+    first_id = await db.add_account(Account(phone="+15551110001", session_string="sess_one"))
+    await db.delete_account(first_id)
+    reused_id = await db.add_account(Account(phone="+15552220002", session_string="sess_two"))
+    assert reused_id == first_id  # rowid genuinely reused — the hazard's premise
+
+    # Reset to the FIRST account so the request starts by resolving its identity,
+    # then have the race swap the row to the SECOND account mid-request.
+    await db.delete_account(reused_id)
+    target_id = await db.add_account(Account(phone="+15551110001", session_string="sess_one"))
+    assert target_id == first_id
+
+    real_get_decrypted_session = accounts_repo.get_decrypted_session
+    race_fired = {"count": 0}
+
+    async def racing_get_decrypted_session(*args, **kwargs):
+        # The OLD route reaches here AFTER reading the stale phone from summaries.
+        # Land the delete+reinsert now, onto the reused rowid, so the session this
+        # returns belongs to a DIFFERENT account than the phone already resolved.
+        if race_fired["count"] == 0:
+            race_fired["count"] += 1
+            await db.delete_account(target_id)
+            swapped_id = await db.add_account(
+                Account(phone="+15552220002", session_string="sess_two")
+            )
+            assert swapped_id == target_id  # still the reused rowid
+        return await real_get_decrypted_session(*args, **kwargs)
+
+    accounts_repo.get_decrypted_session = racing_get_decrypted_session
+    try:
+        resp = await route_client.post(f"/settings/{target_id}/export-session")
+    finally:
+        accounts_repo.get_decrypted_session = real_get_decrypted_session
+
+    # Consistency invariant: the response is NEVER a stale_phone + fresh_session
+    # mix. The fixed route returns the single current row's pair; a regressed
+    # two-read route would return ("+15551110001", "sess_two") — caught here.
+    if resp.status_code == 200:
+        body = resp.json()
+        assert (body["phone"], body["session_string"]) != (
+            "+15551110001",
+            "sess_two",
+        ), "two-read regression: stale phone paired with a fresh session"
+        # Whatever pair is returned, it must be internally consistent: this phone
+        # must currently own this session in the DB.
+        export = await accounts_repo.get_session_export(phone=body["phone"])
+        assert export is not None
+        assert export[1] == body["session_string"]
+    else:
+        # Or the row was absent at read time → 404, never a poisoned pairing.
+        assert resp.status_code == 404
+        assert resp.json()["error"] == "account_not_found"

--- a/tests/routes/test_export_session_1145.py
+++ b/tests/routes/test_export_session_1145.py
@@ -89,8 +89,40 @@ async def test_export_session_roundtrip_with_encryption(tmp_path):
         assert row is not None
         assert str(row["session_string"]).startswith("enc:v2:")
 
-        # the exact accessor the endpoint uses returns plaintext
-        decrypted = await db.repos.accounts.get_decrypted_session(account_id=acc.id)
-        assert decrypted == "plain_sess_xyz"
+        # the exact accessor the endpoint uses returns (phone, plaintext)
+        export = await db.repos.accounts.get_session_export(account_id=acc.id)
+        assert export == ("+15550009999", "plain_sess_xyz")
+    finally:
+        await db.close()
+
+
+@pytest.mark.anyio
+async def test_get_session_export_binds_phone_and_session_to_one_row(tmp_path):
+    """Regression for the #1145 review HIGH: phone and session must come from the
+    SAME row, never a stale phone paired with a fresh session after delete+reinsert.
+
+    The endpoint previously read identity (summaries) and the session in two
+    separate awaits; if a row is deleted and a different account reinserted onto
+    the reused id between them, the response would mix the old phone with the new
+    session. `get_session_export` reads both from one row, so the pairing is
+    always consistent — or None if the row is gone.
+    """
+    db = Database(str(tmp_path / "consistency.db"))
+    await db.initialize()
+    try:
+        first_id = await db.add_account(Account(phone="+15551110001", session_string="sess_one"))
+
+        # Simulate the hazard: delete the row, reinsert a DIFFERENT account.
+        await db.delete_account(first_id)
+        reused_id = await db.add_account(Account(phone="+15552220002", session_string="sess_two"))
+
+        export = await db.repos.accounts.get_session_export(account_id=reused_id)
+        assert export is not None
+        phone, session = export
+        # phone and session are from the SAME (current) row — never mixed.
+        assert (phone, session) == ("+15552220002", "sess_two")
+
+        # A genuinely absent id yields None (→ 404 at the route), not a stale pairing.
+        assert await db.repos.accounts.get_session_export(account_id=999999) is None
     finally:
         await db.close()

--- a/tests/routes/test_export_session_1145.py
+++ b/tests/routes/test_export_session_1145.py
@@ -1,0 +1,96 @@
+"""Route tests for SSO session export (#1145, epic #828).
+
+`POST /settings/{account_id}/export-session` returns the decrypted plaintext
+StringSession behind the panel's existing WEB_PASS auth. POST (not GET) keeps the
+secret out of URLs/logs; the value is never logged.
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from src.database import Database
+from src.models import Account
+
+
+@pytest.mark.anyio
+async def test_export_session_returns_decrypted_string(route_client, base_app):
+    app, db, pool = base_app
+    accounts = await db.get_account_summaries(active_only=False)
+    acc = accounts[0]  # +1234567890 seeded with session_string="test_session"
+
+    resp = await route_client.post(f"/settings/{acc.id}/export-session")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["phone"] == acc.phone
+    assert body["session_string"] == "test_session"
+
+
+@pytest.mark.anyio
+async def test_export_session_unknown_id_returns_404(route_client, base_app):
+    resp = await route_client.post("/settings/99999/export-session")
+    assert resp.status_code == 404
+    assert resp.json()["error"] == "account_not_found"
+
+
+@pytest.mark.anyio
+async def test_export_session_is_post_not_get(route_client, base_app):
+    # GET must not expose the secret (would land in URLs/logs).
+    app, db, pool = base_app
+    acc = (await db.get_account_summaries(active_only=False))[0]
+    resp = await route_client.get(f"/settings/{acc.id}/export-session")
+    assert resp.status_code == 405  # method not allowed
+
+
+@pytest.mark.anyio
+async def test_export_session_requires_auth(base_app):
+    """Without WEB_PASS auth the endpoint returns 401 (never the secret)."""
+    app, db, pool = base_app
+    acc = (await db.get_account_summaries(active_only=False))[0]
+    transport = ASGITransport(app=app)
+    async with AsyncClient(
+        transport=transport,
+        base_url="http://test",
+        follow_redirects=False,
+        headers={"Accept": "application/json", "Origin": "http://test"},
+    ) as c:
+        resp = await c.post(f"/settings/{acc.id}/export-session")
+    assert resp.status_code == 401
+    assert "test_session" not in resp.text
+
+
+@pytest.mark.anyio
+async def test_export_session_not_logged(route_client, base_app, caplog):
+    app, db, pool = base_app
+    acc = (await db.get_account_summaries(active_only=False))[0]
+    with caplog.at_level(logging.DEBUG):
+        resp = await route_client.post(f"/settings/{acc.id}/export-session")
+    assert resp.status_code == 200
+    # The secret must never appear in any log record.
+    assert "test_session" not in caplog.text
+
+
+@pytest.mark.anyio
+async def test_export_session_roundtrip_with_encryption(tmp_path):
+    """With SESSION_ENCRYPTION_KEY: stored enc:v2:*, the accessor the endpoint
+    calls returns the decrypted plaintext (the route is exercised over HTTP by the
+    plaintext tests above; here we verify the encryption layer the endpoint relies on)."""
+    db = Database(str(tmp_path / "enc.db"), session_encryption_secret="route-secret")
+    await db.initialize()
+    try:
+        await db.add_account(Account(phone="+15550009999", session_string="plain_sess_xyz"))
+        acc = (await db.get_account_summaries(active_only=False))[0]
+
+        # stored encrypted at rest
+        cur = await db.execute("SELECT session_string FROM accounts WHERE id = ?", (acc.id,))
+        row = await cur.fetchone()
+        assert row is not None
+        assert str(row["session_string"]).startswith("enc:v2:")
+
+        # the exact accessor the endpoint uses returns plaintext
+        decrypted = await db.repos.accounts.get_decrypted_session(account_id=acc.id)
+        assert decrypted == "plain_sess_xyz"
+    finally:
+        await db.close()


### PR DESCRIPTION
## Что и зачем

Core-sub эпика **#828** (SSO StringSession). REST/web-поверхность экспорта — CLI (#1143, смержен) и agent-tool (#1144, PR #1153) уже покрывают остальные слои.

**`POST /settings/{account_id}/export-session`** → `{"phone", "session_string"}` (расшифрованный plaintext).

## 🔴 Безопасность
- **POST, не GET** — session = секрет, не должен попадать в URL/access-log.
- За существующей **WEB_PASS**-авторизацией: `BasicAuthMiddleware` возвращает **401** для API-клиента без credentials (тест-гард `test_export_session_requires_auth`).
- Резолв identity через summaries (без расшифровки всей БД) → расшифровка ТОЛЬКО целевого через `db.repos.accounts.get_decrypted_session()` (битый сиблинг не рушит экспорт, #1143).
- **Audit**: `logger.info` пишет `account_id` + actor, **без значения session** (caplog-гард `test_export_session_not_logged`).
- 404 `{"error": "account_not_found"}`; 409 при decrypt-failure (только status) / пустой сессии.

## Путь
Под accounts-router (`/settings` prefix — проектная конвенция для account-эндпоинтов; в проекте нет `/api/accounts`, все account-роуты под `/settings`). Это parity-выбор по конвенции.

## Тесты (TDD)
`tests/routes/test_export_session_1145.py` — 6: 200+round-trip, 404, **401 без auth**, GET→405, секрет не в логах, encrypted-at-rest+расшифровка. + 284 смежных route/web теста зелёные. ruff/import-linter/mypy чисты.

Closes #1145

🤖 Generated with [Claude Code](https://claude.com/claude-code)