### PR TITLE
feat(cli): migrate Wave-2 simple groups argparse→Typer (#1122)

### DIFF
--- a/src/cli/commands/debug.py
+++ b/src/cli/commands/debug.py
@@ -1,3 +1,12 @@
+"""Shared async bodies for the ``debug`` CLI group (epic #959, Wave 2 — #1122).
+
+Migrated off the argparse dispatcher onto the Typer ``app`` (see
+``src/cli/typer_commands.py``). Each leaf sub-command is a plain ``async def
+*_impl`` here — no local ``asyncio.run`` (the Typer commands funnel through the
+single ``run_async`` bridge) and no ``argparse.Namespace`` (Typer passes the
+resolved flags as keyword arguments).
+"""
+
 from __future__ import annotations
 
 import argparse
@@ -10,41 +19,64 @@ from src.cli import runtime
 from src.cli.runtime import APP_LOG_PATH
 
 
+async def logs_impl(config_path: str, *, limit: int = 50) -> None:
+    """Print the last *limit* lines of the app log."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        if APP_LOG_PATH.exists():
+            with open(APP_LOG_PATH, encoding="utf-8", errors="replace") as f:
+                tail = deque(f, maxlen=limit)
+            for line in tail:
+                print(line, end="")
+        else:
+            print(f"No log file found at {APP_LOG_PATH}")
+            print("Tip: start the server first — logs are written to data/app.log.")
+    finally:
+        await db.close()
+
+
+async def memory_impl(config_path: str) -> None:
+    """Print process RSS, DB stats and DB file size."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        usage = resource.getrusage(resource.RUSAGE_SELF)
+        print(f"Max RSS: {usage.ru_maxrss / 1024:.1f} MB")
+
+        stats = await db.get_stats()
+        print("\nDB stats:")
+        for key, value in stats.items():
+            print(f"  {key}: {value}")
+
+        db_path = db._path if hasattr(db, "_path") else "unknown"
+        if db_path and db_path != ":memory:" and os.path.exists(db_path):
+            size_mb = os.path.getsize(db_path) / (1024 * 1024)
+            print(f"  DB file size: {size_mb:.1f} MB")
+    finally:
+        await db.close()
+
+
+async def timing_impl(config_path: str) -> None:
+    """Print operation timing stats (no persistent data collected yet)."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        print("Operation timing stats:")
+        print("  (no persistent timing data collected)")
+        print("  Tip: use 'test benchmark' for pytest serial vs parallel benchmarks")
+    finally:
+        await db.close()
+
+
 def run(args: argparse.Namespace) -> None:
-    async def _run() -> None:
-        _, db = await runtime.init_db(args.config)
-        try:
-            if args.debug_action == "logs":
-                limit = args.limit
-                if APP_LOG_PATH.exists():
-                    with open(APP_LOG_PATH, encoding="utf-8", errors="replace") as f:
-                        tail = deque(f, maxlen=limit)
-                    for line in tail:
-                        print(line, end="")
-                else:
-                    print(f"No log file found at {APP_LOG_PATH}")
-                    print("Tip: start the server first — logs are written to data/app.log.")
+    """Thin argparse adapter over the ``*_impl`` bodies (legacy dispatch path).
 
-            elif args.debug_action == "memory":
-                usage = resource.getrusage(resource.RUSAGE_SELF)
-                print(f"Max RSS: {usage.ru_maxrss / 1024:.1f} MB")
-
-                stats = await db.get_stats()
-                print("\nDB stats:")
-                for key, value in stats.items():
-                    print(f"  {key}: {value}")
-
-                db_path = db._path if hasattr(db, "_path") else "unknown"
-                if db_path and db_path != ":memory:" and os.path.exists(db_path):
-                    size_mb = os.path.getsize(db_path) / (1024 * 1024)
-                    print(f"  DB file size: {size_mb:.1f} MB")
-
-            elif args.debug_action == "timing":
-                print("Operation timing stats:")
-                print("  (no persistent timing data collected)")
-                print("  Tip: use 'test benchmark' for pytest serial vs parallel benchmarks")
-
-        finally:
-            await db.close()
-
-    asyncio.run(_run())
+    The production CLI routes ``debug`` through the Typer ``app`` (#1122); this
+    wrapper is kept so the argparse ``build_parser()`` leaf audit and the existing
+    command-level tests still exercise the shared bodies.
+    """
+    action = args.debug_action
+    if action == "logs":
+        asyncio.run(logs_impl(args.config, limit=args.limit))
+    elif action == "memory":
+        asyncio.run(memory_impl(args.config))
+    elif action == "timing":
+        asyncio.run(timing_impl(args.config))

--- a/src/cli/commands/export.py
+++ b/src/cli/commands/export.py
@@ -21,101 +21,135 @@ def _rfc822(dt: datetime | None) -> str:
     return format_datetime(dt)
 
 
-def run(args: argparse.Namespace) -> None:
-    async def _run() -> None:
-        _, db = await runtime.init_db(args.config)
-        try:
-            if args.export_action == "telegram":
-                await _run_telegram(db, args)
-                return
+async def export_impl(
+    config_path: str,
+    *,
+    fmt: str,
+    channel_id: int | None = None,
+    limit: int = 200,
+    output: str | None = None,
+) -> None:
+    """Export messages from the local DB as ``fmt`` (json/csv/rss)."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        capped_limit = max(1, min(limit, 10000))
 
-            channel_id = getattr(args, "channel_id", None)
-            limit = max(1, min(args.limit, 10000))
+        messages, _ = await db.search_messages(
+            channel_id=channel_id,
+            limit=capped_limit,
+        )
+        if not messages:
+            print("No messages found.", file=sys.stderr)
+            return
 
-            messages, _ = await db.search_messages(
-                channel_id=channel_id,
-                limit=limit,
-            )
-            if not messages:
-                print("No messages found.", file=sys.stderr)
-                return
+        if fmt == "json":
+            content = _export_json(messages)
+        elif fmt == "csv":
+            content = _export_csv(messages)
+        elif fmt == "rss":
+            content = _export_rss(messages)
+        else:
+            print(f"Unknown format: {fmt}", file=sys.stderr)
+            return
 
-            output_file = getattr(args, "output", None)
-            fmt = args.export_action
-
-            if fmt == "json":
-                content = _export_json(messages)
-            elif fmt == "csv":
-                content = _export_csv(messages)
-            elif fmt == "rss":
-                content = _export_rss(messages)
-            else:
-                print(f"Unknown format: {fmt}", file=sys.stderr)
-                return
-
-            if output_file:
-                with open(output_file, "w", encoding="utf-8") as f:
-                    f.write(content)
-                print(f"Exported {len(messages)} messages to {output_file}", file=sys.stderr)
-            else:
-                print(content, end="")
-        finally:
-            await db.close()
-
-    asyncio.run(_run())
+        if output:
+            with open(output, "w", encoding="utf-8") as f:
+                f.write(content)
+            print(f"Exported {len(messages)} messages to {output}", file=sys.stderr)
+        else:
+            print(content, end="")
+    finally:
+        await db.close()
 
 
-async def _run_telegram(db, args: argparse.Namespace) -> None:
+async def telegram_impl(
+    config_path: str,
+    *,
+    channel_id: int | None = None,
+    export_format: str = "json",
+    with_media: bool = False,
+    wait: bool = False,
+    max_file_size: int | None = None,
+    date_from: str | None = None,
+    date_to: str | None = None,
+    limit: int = 5000,
+    output: str | None = None,
+) -> None:
+    """Export a channel in Telegram-Desktop-compatible JSON/HTML tree form."""
     from src.services.export_service import run_offline_export
 
-    channel_id = getattr(args, "channel_id", None)
-    if not channel_id:
-        print("Error: --channel-id is required for telegram export.", file=sys.stderr)
-        return
+    _, db = await runtime.init_db(config_path)
+    try:
+        if not channel_id:
+            print("Error: --channel-id is required for telegram export.", file=sys.stderr)
+            return
 
-    if args.with_media:
-        # Media download needs the live worker (owns the ClientPool); enqueue an
-        # EXPORT task and optionally wait for it.
-        await _enqueue_media_export(db, args, int(channel_id))
-        return
+        if with_media:
+            # Media download needs the live worker (owns the ClientPool); enqueue an
+            # EXPORT task and optionally wait for it.
+            await _enqueue_media_export(
+                db,
+                channel_id=int(channel_id),
+                export_format=export_format,
+                max_file_size=max_file_size,
+                date_from=date_from,
+                date_to=date_to,
+                limit=limit,
+                output=output,
+                wait=wait,
+            )
+            return
 
-    summary = await run_offline_export(
-        db,
-        int(channel_id),
-        fmt=args.export_format,
-        date_from=args.date_from,
-        date_to=args.date_to,
-        limit=int(args.limit),
-        out_dir=args.output,
-    )
-    if summary is None:
-        print(f"No messages found for channel {channel_id}.", file=sys.stderr)
-        return
-    print(
-        f"Exported {summary.message_count} messages to {summary.out_dir} "
-        f"(files: {', '.join(summary.files)}; media skipped: {summary.media_skipped})",
-        file=sys.stderr,
-    )
-    if summary.truncated:
+        summary = await run_offline_export(
+            db,
+            int(channel_id),
+            fmt=export_format,
+            date_from=date_from,
+            date_to=date_to,
+            limit=int(limit),
+            out_dir=output,
+        )
+        if summary is None:
+            print(f"No messages found for channel {channel_id}.", file=sys.stderr)
+            return
         print(
-            f"Warning: channel has more than {args.limit} messages; exported the oldest "
-            f"{summary.message_count} (raise --limit to include more).",
+            f"Exported {summary.message_count} messages to {summary.out_dir} "
+            f"(files: {', '.join(summary.files)}; media skipped: {summary.media_skipped})",
             file=sys.stderr,
         )
+        if summary.truncated:
+            print(
+                f"Warning: channel has more than {limit} messages; exported the oldest "
+                f"{summary.message_count} (raise --limit to include more).",
+                file=sys.stderr,
+            )
+    finally:
+        await db.close()
 
 
-async def _enqueue_media_export(db, args: argparse.Namespace, channel_id: int) -> None:
+async def _enqueue_media_export(
+    db,
+    *,
+    channel_id: int,
+    export_format: str,
+    max_file_size: int | None,
+    date_from: str | None,
+    date_to: str | None,
+    limit: int,
+    output: str | None,
+    wait: bool,
+) -> None:
     from src.models import CollectionTaskType, ExportTaskPayload
 
     payload = ExportTaskPayload(
         channel_id=channel_id,
-        fmt=args.export_format,
+        fmt=export_format,
         with_media=True,
-        max_file_size_mb=args.max_file_size,
-        date_from=args.date_from,
-        date_to=args.date_to,
-        limit=int(args.limit),
-        out_dir=args.output,
+        max_file_size_mb=max_file_size,
+        date_from=date_from,
+        date_to=date_to,
+        limit=int(limit),
+        out_dir=output,
         requested_by="cli",
     )
     task_id = await db.repos.tasks.create_generic_task(
@@ -125,7 +159,7 @@ async def _enqueue_media_export(db, args: argparse.Namespace, channel_id: int) -
         f"Enqueued media export task #{task_id}; the worker will download media and build the tree.",
         file=sys.stderr,
     )
-    if args.wait:
+    if wait:
         await _poll_export_task(db, task_id)
 
 
@@ -214,3 +248,37 @@ def _export_rss(messages) -> str:
         + "\n".join(items)
         + "\n  </channel>\n</rss>"
     )
+
+
+def run(args: argparse.Namespace) -> None:
+    """Thin argparse adapter over the ``*_impl`` bodies (legacy dispatch path).
+
+    The production CLI routes ``export`` through the Typer ``app`` (#1122); this
+    wrapper keeps the argparse leaf audit and command-level tests working.
+    """
+    action = args.export_action
+    if action == "telegram":
+        asyncio.run(
+            telegram_impl(
+                args.config,
+                channel_id=getattr(args, "channel_id", None),
+                export_format=getattr(args, "export_format", "json"),
+                with_media=getattr(args, "with_media", False),
+                wait=getattr(args, "wait", False),
+                max_file_size=getattr(args, "max_file_size", None),
+                date_from=getattr(args, "date_from", None),
+                date_to=getattr(args, "date_to", None),
+                limit=getattr(args, "limit", 5000),
+                output=getattr(args, "output", None),
+            )
+        )
+    else:
+        asyncio.run(
+            export_impl(
+                args.config,
+                fmt=action,
+                channel_id=getattr(args, "channel_id", None),
+                limit=getattr(args, "limit", 200),
+                output=getattr(args, "output", None),
+            )
+        )

--- a/src/cli/commands/image.py
+++ b/src/cli/commands/image.py
@@ -1,4 +1,9 @@
-"""CLI commands for image generation."""
+"""Shared async bodies for the ``image`` CLI group (epic #959, Wave 2 — #1122).
+
+Migrated off the argparse dispatcher onto the Typer ``app`` (see
+``src/cli/typer_commands.py``). Each leaf sub-command is a plain ``async def
+*_impl`` here — no local ``asyncio.run`` and no ``argparse.Namespace``.
+"""
 
 from __future__ import annotations
 
@@ -38,67 +43,100 @@ def _generation_failure_text(svc: ImageGenerationService) -> str:
     return "Generation failed — check logs"
 
 
-def run(args: argparse.Namespace) -> None:
-    async def _run() -> None:
-        action = args.image_action
-        config, db = await runtime.init_db(args.config)
-        try:
-            await _run_action(action, args, db, config)
-        finally:
-            await db.close()
-
-    async def _run_action(action, args, db, config) -> None:
+async def generate_impl(config_path: str, *, prompt: str, model: str | None = None) -> None:
+    """Generate an image from *prompt* using *model* (or the default adapter)."""
+    config, db = await runtime.init_db(config_path)
+    try:
         svc = await _build_image_service(db, config)
-
-        if action == "generate":
-            if not await svc.is_available():
-                print("No image providers configured. Set REPLICATE_API_TOKEN or similar env var.")
-                return
-            model = args.model or None
-            prompt = args.prompt
-            print(f"Generating image: model={model or 'default'}, prompt={prompt!r}")
-            result = await svc.generate(model, prompt)
-            if result:
-                print(f"Result: {result}")
-            else:
-                print(_generation_failure_text(svc))
-
-        elif action == "models":
-            provider = args.provider
-            query = args.query or ""
-            refresh = getattr(args, "refresh", False)
-            models = await svc.search_models(provider, query, refresh=refresh)
-            if not models:
-                print(f"No models found for provider={provider} query={query!r}")
-                return
-            for m in models:
-                runs = f" ({m['run_count']:,} runs)" if m.get("run_count") else ""
-                print(f"  {m['model_string']}{runs}")
-                if m.get("description"):
-                    print(f"    {m['description']}")
-
-        elif action == "providers":
-            names = svc.adapter_names
-            if not names:
-                print("No providers configured. Set env vars: REPLICATE_API_TOKEN, TOGETHER_API_KEY, etc.")
-                return
-            for name in names:
-                print(f"  {name}")
-
-        elif action == "generated":
-            images = await db.repos.generated_images.list_recent(limit=args.limit)
-            if not images:
-                print("No generated images found.")
-                return
-            for img in images:
-                prompt = (img.prompt[:60] + "...") if len(img.prompt) > 60 else img.prompt
-                print(f"[{img.id}] {img.created_at} — {prompt}")
-                if img.local_path:
-                    print(f"    file=/{img.local_path}")
-                if img.model:
-                    print(f"    model={img.model}")
-
+        if not await svc.is_available():
+            print("No image providers configured. Set REPLICATE_API_TOKEN or similar env var.")
+            return
+        print(f"Generating image: model={model or 'default'}, prompt={prompt!r}")
+        result = await svc.generate(model, prompt)
+        if result:
+            print(f"Result: {result}")
         else:
-            print("Usage: image {generate|models|providers|generated}")
+            print(_generation_failure_text(svc))
+    finally:
+        await db.close()
 
-    asyncio.run(_run())
+
+async def models_impl(config_path: str, *, provider: str, query: str = "", refresh: bool = False) -> None:
+    """Search available models for *provider*."""
+    config, db = await runtime.init_db(config_path)
+    try:
+        svc = await _build_image_service(db, config)
+        models = await svc.search_models(provider, query or "", refresh=refresh)
+        if not models:
+            print(f"No models found for provider={provider} query={query!r}")
+            return
+        for m in models:
+            runs = f" ({m['run_count']:,} runs)" if m.get("run_count") else ""
+            print(f"  {m['model_string']}{runs}")
+            if m.get("description"):
+                print(f"    {m['description']}")
+    finally:
+        await db.close()
+
+
+async def providers_impl(config_path: str) -> None:
+    """List configured image providers."""
+    config, db = await runtime.init_db(config_path)
+    try:
+        svc = await _build_image_service(db, config)
+        names = svc.adapter_names
+        if not names:
+            print("No providers configured. Set env vars: REPLICATE_API_TOKEN, TOGETHER_API_KEY, etc.")
+            return
+        for name in names:
+            print(f"  {name}")
+    finally:
+        await db.close()
+
+
+async def generated_impl(config_path: str, *, limit: int = 20) -> None:
+    """List recently generated images."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        images = await db.repos.generated_images.list_recent(limit=limit)
+        if not images:
+            print("No generated images found.")
+            return
+        for img in images:
+            prompt = (img.prompt[:60] + "...") if len(img.prompt) > 60 else img.prompt
+            print(f"[{img.id}] {img.created_at} — {prompt}")
+            if img.local_path:
+                print(f"    file=/{img.local_path}")
+            if img.model:
+                print(f"    model={img.model}")
+    finally:
+        await db.close()
+
+
+def run(args: argparse.Namespace) -> None:
+    """Thin argparse adapter over the ``*_impl`` bodies (legacy dispatch path).
+
+    The production CLI routes ``image`` through the Typer ``app`` (#1122); this
+    wrapper keeps the argparse leaf audit and command-level tests working.
+    """
+    action = args.image_action
+    if action == "generate":
+        asyncio.run(generate_impl(args.config, prompt=args.prompt, model=getattr(args, "model", None)))
+    elif action == "models":
+        asyncio.run(
+            models_impl(
+                args.config,
+                provider=args.provider,
+                query=getattr(args, "query", ""),
+                refresh=getattr(args, "refresh", False),
+            )
+        )
+    elif action == "providers":
+        asyncio.run(providers_impl(args.config))
+    elif action == "generated":
+        asyncio.run(generated_impl(args.config, limit=getattr(args, "limit", 20)))
+    else:
+        # Unreachable via the real CLI (Typer/argparse reject unknown actions on
+        # parse); kept so the legacy adapter degrades to usage help like the
+        # original dispatcher did.
+        print("Usage: image {generate|models|providers|generated}")

--- a/src/cli/commands/notification.py
+++ b/src/cli/commands/notification.py
@@ -1,3 +1,14 @@
+"""Shared async bodies for the ``notification`` CLI group (epic #959, Wave 2 — #1122).
+
+Migrated off the argparse dispatcher onto the Typer ``app`` (see
+``src/cli/typer_commands.py``). Each leaf sub-command is a plain ``async def
+*_impl`` here — no local ``asyncio.run`` and no ``argparse.Namespace``.
+
+Every body builds the pool + services itself and tears the pool down on exit
+(notification commands touch BotFather via a connected account), mirroring the
+original ``run`` lifecycle.
+"""
+
 from __future__ import annotations
 
 import argparse
@@ -37,91 +48,147 @@ def _print_target_status(status) -> None:
         print(f"Diagnostic: {message}")
 
 
+async def _build(config_path: str):
+    """Build (config, db, pool, target_svc, svc) for a notification command."""
+    config, db = await runtime.init_db(config_path)
+    _, pool = await runtime.init_pool(config, db)
+    target_svc = NotificationTargetService(db, pool)
+    svc = NotificationService(
+        db,
+        target_svc,
+        config.notifications.bot_name_prefix,
+        config.notifications.bot_username_prefix,
+    )
+    return config, db, pool, target_svc, svc
+
+
+async def setup_impl(config_path: str) -> None:
+    """Create a personal notification bot via BotFather."""
+    _config, db, pool, _target_svc, svc = await _build(config_path)
+    try:
+        print("Creating notification bot via BotFather...")
+        bot = await svc.setup_bot()
+        print(f"Bot created: @{bot.bot_username}")
+        print("[!] Сохраните токен — он больше не будет показан:")
+        print(f"    Token: {bot.bot_token}")
+        print(f"Send /start to @{bot.bot_username} in Telegram to activate it.")
+    finally:
+        await pool.disconnect_all()
+        await db.close()
+
+
+async def status_impl(config_path: str) -> None:
+    """Show notification bot status."""
+    _config, db, pool, target_svc, svc = await _build(config_path)
+    try:
+        target_status = await _describe_target(target_svc)
+        if target_status is not None and getattr(target_status, "state", None) != "available":
+            _print_target_status(target_status)
+            return
+        bot = await svc.get_status()
+        if bot is None:
+            print("No notification bot configured.")
+        else:
+            print(f"Bot: @{bot.bot_username}")
+            print(f"Bot ID: {bot.bot_id}")
+            print(f"Created at: {bot.created_at}")
+    finally:
+        await pool.disconnect_all()
+        await db.close()
+
+
+async def delete_impl(config_path: str) -> None:
+    """Delete the notification bot via BotFather."""
+    _config, db, pool, _target_svc, svc = await _build(config_path)
+    try:
+        print("Deleting notification bot via BotFather...")
+        await svc.teardown_bot()
+        print("Notification bot deleted.")
+    finally:
+        await pool.disconnect_all()
+        await db.close()
+
+
+async def test_impl(config_path: str, *, message: str = "Тестовое уведомление") -> None:
+    """Send a test notification message."""
+    _config, db, pool, _target_svc, svc = await _build(config_path)
+    try:
+        await svc.send_notification(message)
+        print("Test notification sent.")
+    finally:
+        await pool.disconnect_all()
+        await db.close()
+
+
+async def set_account_impl(config_path: str, *, phone: str) -> None:
+    """Set the account used by the notification bot."""
+    _config, db, pool, target_svc, _svc = await _build(config_path)
+    try:
+        await target_svc.set_configured_phone(phone)
+        print(f"Notification bot account set to: {phone}")
+    finally:
+        await pool.disconnect_all()
+        await db.close()
+
+
+async def dry_run_impl(config_path: str) -> None:
+    """Preview notification matches without sending."""
+    from datetime import timezone
+
+    _config, db, pool, _target_svc, _svc = await _build(config_path)
+    try:
+        last_task = await db.repos.tasks.get_last_completed_collect_task()
+        since = None
+        if last_task and last_task.completed_at:
+            since = last_task.completed_at.astimezone(timezone.utc).strftime(
+                "%Y-%m-%d %H:%M:%S"
+            )
+        queries = await db.get_notification_queries(active_only=True)
+        filtered = []
+        for sq in queries:
+            val = await db.repos.settings.get_setting(
+                f"scheduler_job_disabled:sq_{sq.id}"
+            )
+            if val != "1":
+                filtered.append(sq)
+        queries = filtered
+        if not queries:
+            print("No active notification queries.")
+            return
+        # Match with the SAME engine production uses (regex/substring), not FTS, so the
+        # preview agrees with what would actually fire (#838/3). Counts are uncapped —
+        # dry_run_counts pages over the whole window so >5000 messages don't undercount.
+        from src.services.notification_matcher import dry_run_counts
+
+        counts = await dry_run_counts(db, queries, since)
+        total_matches = 0
+        for sq in queries:
+            total = counts.get(sq.id, 0)
+            name = sq.name or sq.query
+            print(f"  {name}: {total} matches")
+            total_matches += total
+        print(f"\nTotal: {total_matches} matches (since {since or 'N/A'})")
+    finally:
+        await pool.disconnect_all()
+        await db.close()
+
+
 def run(args: argparse.Namespace) -> None:
-    async def _run() -> None:
-        config, db = await runtime.init_db(args.config)
-        _, pool = await runtime.init_pool(config, db)
-        target_svc = NotificationTargetService(db, pool)
-        svc = NotificationService(
-            db,
-            target_svc,
-            config.notifications.bot_name_prefix,
-            config.notifications.bot_username_prefix,
-        )
-        try:
-            if args.notification_action == "setup":
-                print("Creating notification bot via BotFather...")
-                bot = await svc.setup_bot()
-                print(f"Bot created: @{bot.bot_username}")
-                print("[!] Сохраните токен — он больше не будет показан:")
-                print(f"    Token: {bot.bot_token}")
-                print(f"Send /start to @{bot.bot_username} in Telegram to activate it.")
+    """Thin argparse adapter over the ``*_impl`` bodies (legacy dispatch path).
 
-            elif args.notification_action == "status":
-                target_status = await _describe_target(target_svc)
-                if target_status is not None and getattr(target_status, "state", None) != "available":
-                    _print_target_status(target_status)
-                    return
-                bot = await svc.get_status()
-                if bot is None:
-                    print("No notification bot configured.")
-                else:
-                    print(f"Bot: @{bot.bot_username}")
-                    print(f"Bot ID: {bot.bot_id}")
-                    print(f"Created at: {bot.created_at}")
-
-            elif args.notification_action == "delete":
-                print("Deleting notification bot via BotFather...")
-                await svc.teardown_bot()
-                print("Notification bot deleted.")
-
-            elif args.notification_action == "test":
-                message = getattr(args, "message", "Тестовое уведомление")
-                await svc.send_notification(message)
-                print("Test notification sent.")
-
-            elif args.notification_action == "set-account":
-                phone = args.phone
-                await target_svc.set_configured_phone(phone)
-                print(f"Notification bot account set to: {phone}")
-                return
-
-            elif args.notification_action == "dry-run":
-                from datetime import timezone
-
-                last_task = await db.repos.tasks.get_last_completed_collect_task()
-                since = None
-                if last_task and last_task.completed_at:
-                    since = last_task.completed_at.astimezone(timezone.utc).strftime(
-                        "%Y-%m-%d %H:%M:%S"
-                    )
-                queries = await db.get_notification_queries(active_only=True)
-                filtered = []
-                for sq in queries:
-                    val = await db.repos.settings.get_setting(
-                        f"scheduler_job_disabled:sq_{sq.id}"
-                    )
-                    if val != "1":
-                        filtered.append(sq)
-                queries = filtered
-                if not queries:
-                    print("No active notification queries.")
-                    return
-                # Match with the SAME engine production uses (regex/substring), not FTS, so the
-                # preview agrees with what would actually fire (#838/3). Counts are uncapped —
-                # dry_run_counts pages over the whole window so >5000 messages don't undercount.
-                from src.services.notification_matcher import dry_run_counts
-
-                counts = await dry_run_counts(db, queries, since)
-                total_matches = 0
-                for sq in queries:
-                    total = counts.get(sq.id, 0)
-                    name = sq.name or sq.query
-                    print(f"  {name}: {total} matches")
-                    total_matches += total
-                print(f"\nTotal: {total_matches} matches (since {since or 'N/A'})")
-        finally:
-            await pool.disconnect_all()
-            await db.close()
-
-    asyncio.run(_run())
+    The production CLI routes ``notification`` through the Typer ``app`` (#1122);
+    this wrapper keeps the argparse leaf audit and command-level tests working.
+    """
+    action = args.notification_action
+    if action == "setup":
+        asyncio.run(setup_impl(args.config))
+    elif action == "status":
+        asyncio.run(status_impl(args.config))
+    elif action == "delete":
+        asyncio.run(delete_impl(args.config))
+    elif action == "test":
+        asyncio.run(test_impl(args.config, message=getattr(args, "message", "Тестовое уведомление")))
+    elif action == "set-account":
+        asyncio.run(set_account_impl(args.config, phone=args.phone))
+    elif action == "dry-run":
+        asyncio.run(dry_run_impl(args.config))

--- a/src/cli/commands/provider.py
+++ b/src/cli/commands/provider.py
@@ -1,3 +1,10 @@
+"""Shared async bodies for the ``provider`` CLI group (epic #959, Wave 2 — #1122).
+
+Migrated off the argparse dispatcher onto the Typer ``app`` (see
+``src/cli/typer_commands.py``). Each leaf sub-command is a plain ``async def
+*_impl`` here — no local ``asyncio.run`` and no ``argparse.Namespace``.
+"""
+
 from __future__ import annotations
 
 import argparse
@@ -8,147 +15,209 @@ from src.cli import runtime
 from src.services.agent_provider_service import ProviderConfigService
 
 
-def run(args: argparse.Namespace) -> None:
-    async def _run() -> None:
-        config, db = await runtime.init_db(args.config)
-        svc = ProviderConfigService(db, config)
+async def list_impl(config_path: str) -> None:
+    """List configured providers with their models and status."""
+    config, db = await runtime.init_db(config_path)
+    svc = ProviderConfigService(db, config)
+    try:
+        configs = await svc.load_provider_configs()
+        cache = await svc.load_model_cache()
+        if not configs:
+            print("No providers configured.")
+            print(f"Available providers: {', '.join(PROVIDER_SPECS.keys())}")
+            return
+        fmt = "{:<15} {:<8} {:<8} {:<25} {:<6} {:<30}"
+        print(fmt.format("Provider", "Enabled", "Priority", "Selected model", "Models", "Error"))
+        print("-" * 100)
+        for cfg in configs:
+            entry = cache.get(cfg.provider)
+            model_count = str(len(entry.models)) if entry else "—"
+            error = (cfg.last_validation_error or "")[:30]
+            print(fmt.format(
+                cfg.provider,
+                "Yes" if cfg.enabled else "No",
+                str(cfg.priority),
+                (cfg.selected_model or "—")[:25],
+                model_count,
+                error,
+            ))
+    finally:
+        await db.close()
+
+
+async def add_impl(config_path: str, *, name: str, api_key: str, base_url: str | None = None) -> None:
+    """Add or update a provider configuration."""
+    config, db = await runtime.init_db(config_path)
+    svc = ProviderConfigService(db, config)
+    try:
+        name = name.lower()
+        spec = provider_spec(name)
+        if spec is None:
+            print(f"Unknown provider: {name}")
+            print(f"Available: {', '.join(PROVIDER_SPECS.keys())}")
+            return
+        if not svc.writes_enabled:
+            print("ERROR: SESSION_ENCRYPTION_KEY is required to manage providers.")
+            return
+
+        configs = await svc.load_provider_configs()
+        existing = next((c for c in configs if c.provider == name), None)
+
+        secret_fields = {}
+        plain_fields = {}
+        for field in spec.secret_fields:
+            if field.name == "api_key":
+                secret_fields["api_key"] = api_key
+            elif existing:
+                secret_fields[field.name] = existing.secret_fields.get(field.name, "")
+        for field in spec.plain_fields:
+            if field.name == "base_url" and base_url:
+                plain_fields["base_url"] = base_url
+            elif existing:
+                plain_fields[field.name] = existing.plain_fields.get(field.name, "")
+
+        new_cfg = ProviderRuntimeConfig(
+            provider=name,
+            enabled=True,
+            priority=existing.priority if existing else 0,
+            selected_model=existing.selected_model if existing else "",
+            plain_fields=plain_fields,
+            secret_fields=secret_fields,
+        )
+
+        if existing:
+            configs = [new_cfg if c.provider == name else c for c in configs]
+        else:
+            configs.append(new_cfg)
+
+        await svc.save_provider_configs(configs)
+        verb = "Updated" if existing else "Added"
+        print(f"{verb} provider: {name}")
+    finally:
+        await db.close()
+
+
+async def delete_impl(config_path: str, *, name: str) -> None:
+    """Delete a provider configuration."""
+    config, db = await runtime.init_db(config_path)
+    svc = ProviderConfigService(db, config)
+    try:
+        name = name.lower()
+        if not svc.writes_enabled:
+            print("ERROR: SESSION_ENCRYPTION_KEY is required to manage providers.")
+            return
+        configs = await svc.load_provider_configs()
+        new_configs = [c for c in configs if c.provider != name]
+        if len(new_configs) == len(configs):
+            print(f"Provider '{name}' not found.")
+            return
+        await svc.save_provider_configs(new_configs)
+        print(f"Deleted provider: {name}")
+    finally:
+        await db.close()
+
+
+async def probe_impl(config_path: str, *, name: str) -> None:
+    """Test a provider connection by refreshing its model list."""
+    config, db = await runtime.init_db(config_path)
+    svc = ProviderConfigService(db, config)
+    try:
+        name = name.lower()
+        configs = await svc.load_provider_configs()
+        cfg = next((c for c in configs if c.provider == name), None)
+        if cfg is None:
+            print(f"Provider '{name}' not configured. Add it first.")
+            return
+        print(f"Probing {name}...")
         try:
-            if args.provider_action == "list":
-                configs = await svc.load_provider_configs()
-                cache = await svc.load_model_cache()
-                if not configs:
-                    print("No providers configured.")
-                    print(f"Available providers: {', '.join(PROVIDER_SPECS.keys())}")
-                    return
-                fmt = "{:<15} {:<8} {:<8} {:<25} {:<6} {:<30}"
-                print(fmt.format("Provider", "Enabled", "Priority", "Selected model", "Models", "Error"))
-                print("-" * 100)
-                for cfg in configs:
-                    entry = cache.get(cfg.provider)
-                    model_count = str(len(entry.models)) if entry else "—"
-                    error = (cfg.last_validation_error or "")[:30]
-                    print(fmt.format(
-                        cfg.provider,
-                        "Yes" if cfg.enabled else "No",
-                        str(cfg.priority),
-                        (cfg.selected_model or "—")[:25],
-                        model_count,
-                        error,
-                    ))
+            entry = await svc.refresh_models_for_provider(name, cfg)
+            if entry.error:
+                print(f"WARN: {entry.error}")
+            print(f"OK: {len(entry.models)} models available (source: {entry.source})")
+            if entry.models:
+                for m in entry.models[:10]:
+                    print(f"  {m}")
+                if len(entry.models) > 10:
+                    print(f"  ... and {len(entry.models) - 10} more")
+        except Exception as exc:
+            print(f"FAIL: {exc}")
+    finally:
+        await db.close()
 
-            elif args.provider_action == "add":
-                name = args.name.lower()
-                spec = provider_spec(name)
-                if spec is None:
-                    print(f"Unknown provider: {name}")
-                    print(f"Available: {', '.join(PROVIDER_SPECS.keys())}")
-                    return
-                if not svc.writes_enabled:
-                    print("ERROR: SESSION_ENCRYPTION_KEY is required to manage providers.")
-                    return
 
-                configs = await svc.load_provider_configs()
-                existing = next((c for c in configs if c.provider == name), None)
+async def refresh_impl(config_path: str, *, name: str | None = None) -> None:
+    """Refresh provider models for *name* (or all providers if omitted)."""
+    config, db = await runtime.init_db(config_path)
+    svc = ProviderConfigService(db, config)
+    try:
+        if name:
+            name = name.lower()
+            print(f"Refreshing models for {name}...")
+            try:
+                entry = await svc.refresh_models_for_provider(name)
+                print(f"OK: {len(entry.models)} models (source: {entry.source})")
+            except Exception as exc:
+                print(f"FAIL: {exc}")
+        else:
+            print("Refreshing all providers...")
+            results = await svc.refresh_all_models()
+            for prov, entry in results.items():
+                status = "OK" if not entry.error else f"WARN: {entry.error}"
+                print(f"  {prov}: {len(entry.models)} models — {status}")
+    finally:
+        await db.close()
 
-                secret_fields = {}
-                plain_fields = {}
-                for field in spec.secret_fields:
-                    if field.name == "api_key":
-                        secret_fields["api_key"] = args.api_key
-                    elif existing:
-                        secret_fields[field.name] = existing.secret_fields.get(field.name, "")
-                for field in spec.plain_fields:
-                    if field.name == "base_url" and args.base_url:
-                        plain_fields["base_url"] = args.base_url
-                    elif existing:
-                        plain_fields[field.name] = existing.plain_fields.get(field.name, "")
 
-                new_cfg = ProviderRuntimeConfig(
-                    provider=name,
-                    enabled=True,
-                    priority=existing.priority if existing else 0,
-                    selected_model=existing.selected_model if existing else "",
-                    plain_fields=plain_fields,
-                    secret_fields=secret_fields,
-                )
-
-                if existing:
-                    configs = [new_cfg if c.provider == name else c for c in configs]
+async def test_all_impl(config_path: str) -> None:
+    """Test all configured providers."""
+    config, db = await runtime.init_db(config_path)
+    svc = ProviderConfigService(db, config)
+    try:
+        configs = await svc.load_provider_configs()
+        if not configs:
+            print("No providers configured.")
+            return
+        print(f"Testing {len(configs)} provider(s)...\n")
+        for cfg in configs:
+            print(f"  {cfg.provider}...", end=" ", flush=True)
+            try:
+                entry = await svc.refresh_models_for_provider(cfg.provider, cfg)
+                if entry.error:
+                    print(f"WARN ({entry.error})")
                 else:
-                    configs.append(new_cfg)
+                    print(f"OK ({len(entry.models)} models)")
+            except Exception as exc:
+                print(f"FAIL ({exc})")
+    finally:
+        await db.close()
 
-                await svc.save_provider_configs(configs)
-                verb = "Updated" if existing else "Added"
-                print(f"{verb} provider: {name}")
 
-            elif args.provider_action == "delete":
-                name = args.name.lower()
-                if not svc.writes_enabled:
-                    print("ERROR: SESSION_ENCRYPTION_KEY is required to manage providers.")
-                    return
-                configs = await svc.load_provider_configs()
-                new_configs = [c for c in configs if c.provider != name]
-                if len(new_configs) == len(configs):
-                    print(f"Provider '{name}' not found.")
-                    return
-                await svc.save_provider_configs(new_configs)
-                print(f"Deleted provider: {name}")
+def run(args: argparse.Namespace) -> None:
+    """Thin argparse adapter over the ``*_impl`` bodies (legacy dispatch path).
 
-            elif args.provider_action == "probe":
-                name = args.name.lower()
-                configs = await svc.load_provider_configs()
-                cfg = next((c for c in configs if c.provider == name), None)
-                if cfg is None:
-                    print(f"Provider '{name}' not configured. Add it first.")
-                    return
-                print(f"Probing {name}...")
-                try:
-                    entry = await svc.refresh_models_for_provider(name, cfg)
-                    if entry.error:
-                        print(f"WARN: {entry.error}")
-                    print(f"OK: {len(entry.models)} models available (source: {entry.source})")
-                    if entry.models:
-                        for m in entry.models[:10]:
-                            print(f"  {m}")
-                        if len(entry.models) > 10:
-                            print(f"  ... and {len(entry.models) - 10} more")
-                except Exception as exc:
-                    print(f"FAIL: {exc}")
-
-            elif args.provider_action == "refresh":
-                name = args.name
-                if name:
-                    name = name.lower()
-                    print(f"Refreshing models for {name}...")
-                    try:
-                        entry = await svc.refresh_models_for_provider(name)
-                        print(f"OK: {len(entry.models)} models (source: {entry.source})")
-                    except Exception as exc:
-                        print(f"FAIL: {exc}")
-                else:
-                    print("Refreshing all providers...")
-                    results = await svc.refresh_all_models()
-                    for prov, entry in results.items():
-                        status = "OK" if not entry.error else f"WARN: {entry.error}"
-                        print(f"  {prov}: {len(entry.models)} models — {status}")
-
-            elif args.provider_action == "test-all":
-                configs = await svc.load_provider_configs()
-                if not configs:
-                    print("No providers configured.")
-                    return
-                print(f"Testing {len(configs)} provider(s)...\n")
-                for cfg in configs:
-                    print(f"  {cfg.provider}...", end=" ", flush=True)
-                    try:
-                        entry = await svc.refresh_models_for_provider(cfg.provider, cfg)
-                        if entry.error:
-                            print(f"WARN ({entry.error})")
-                        else:
-                            print(f"OK ({len(entry.models)} models)")
-                    except Exception as exc:
-                        print(f"FAIL ({exc})")
-        finally:
-            await db.close()
-
-    asyncio.run(_run())
+    The production CLI routes ``provider`` through the Typer ``app`` (#1122); this
+    wrapper keeps the argparse leaf audit and command-level tests working.
+    """
+    action = args.provider_action
+    if action == "list":
+        asyncio.run(list_impl(args.config))
+    elif action == "add":
+        asyncio.run(
+            add_impl(
+                args.config,
+                name=args.name,
+                # argparse enforces ``--api-key`` (required=True); the getattr keeps
+                # the thin adapter resilient to partial test Namespaces that exercise
+                # the early unknown-provider exit before api_key is read.
+                api_key=getattr(args, "api_key", ""),
+                base_url=getattr(args, "base_url", None),
+            )
+        )
+    elif action == "delete":
+        asyncio.run(delete_impl(args.config, name=args.name))
+    elif action == "probe":
+        asyncio.run(probe_impl(args.config, name=args.name))
+    elif action == "refresh":
+        asyncio.run(refresh_impl(args.config, name=getattr(args, "name", None)))
+    elif action == "test-all":
+        asyncio.run(test_all_impl(args.config))

--- a/src/cli/commands/translate.py
+++ b/src/cli/commands/translate.py
@@ -1,3 +1,10 @@
+"""Shared async bodies for the ``translate`` CLI group (epic #959, Wave 2 — #1122).
+
+Migrated off the argparse dispatcher onto the Typer ``app`` (see
+``src/cli/typer_commands.py``). Each leaf sub-command is a plain ``async def
+*_impl`` here — no local ``asyncio.run`` and no ``argparse.Namespace``.
+"""
+
 from __future__ import annotations
 
 import argparse
@@ -6,100 +13,137 @@ import asyncio
 from src.cli import runtime
 
 
+async def stats_impl(config_path: str) -> None:
+    """Show language distribution across collected messages."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        stats = await db.repos.messages.get_language_stats()
+        if not stats:
+            print("No language data. Run: python -m src.main translate detect")
+            return
+        fmt = "{:<10} {:>10}"
+        print(fmt.format("Language", "Messages"))
+        print("-" * 22)
+        total = 0
+        for lang, count in stats:
+            print(fmt.format(lang, count))
+            total += count
+        print("-" * 22)
+        print(fmt.format("Total", total))
+    finally:
+        await db.close()
+
+
+async def detect_impl(config_path: str, *, batch_size: int = 5000) -> None:
+    """Backfill language detection over untagged messages."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        total_updated = 0
+        while True:
+            updated = await db.repos.messages.backfill_language_detection(batch_size=batch_size)
+            total_updated += updated
+            if updated < batch_size:
+                break
+            print(f"  ... detected {total_updated} so far")
+        print(f"Language detection complete: {total_updated} messages updated.")
+    finally:
+        await db.close()
+
+
+async def run_impl(
+    config_path: str,
+    *,
+    target: str = "en",
+    source_filter: str = "",
+    limit: int = 100,
+) -> None:
+    """Run a translation batch toward *target* for untranslated messages."""
+    from src.services.provider_service import build_provider_service
+    from src.services.translation_service import TranslationService
+
+    _config, db = await runtime.init_db(config_path)
+    try:
+        source_langs = (
+            [s.strip() for s in source_filter.split(",") if s.strip()]
+            if source_filter else None
+        )
+
+        provider_name = await db.get_setting("translation_provider")
+        model = await db.get_setting("translation_model")
+
+        provider_service = await build_provider_service(db, _config)
+        svc = TranslationService(db, provider_service=provider_service)
+
+        msgs = await db.repos.messages.get_untranslated_messages(
+            target=target, source_langs=source_langs, limit=limit
+        )
+        if not msgs:
+            print("No messages to translate.")
+            return
+
+        print(f"Translating {len(msgs)} messages to {target}...")
+        results = await svc.translate_batch(msgs, target, provider_name=provider_name, model=model)
+        for msg_id, translated in results:
+            await db.repos.messages.update_translation(msg_id, target, translated)
+        print(f"Translated {len(results)}/{len(msgs)} messages.")
+    finally:
+        await db.close()
+
+
+async def message_impl(config_path: str, *, message_id: int, target: str = "en") -> None:
+    """Translate a single message by DB id toward *target*."""
+    from src.services.provider_service import build_provider_service
+    from src.services.translation_service import TranslationService
+
+    _config, db = await runtime.init_db(config_path)
+    try:
+        msg = await db.repos.messages.get_by_id(message_id)
+        if msg is None:
+            print(f"Message id={message_id} not found.")
+            return
+        text = msg.text or ""
+        if not text.strip():
+            print("Message has no text to translate.")
+            return
+
+        provider_name = await db.get_setting("translation_provider")
+        model = await db.get_setting("translation_model")
+        provider_service = await build_provider_service(db, _config)
+        svc = TranslationService(db, provider_service=provider_service)
+
+        results = await svc.translate_batch([msg], target, provider_name=provider_name, model=model)
+        if results:
+            _, translated = results[0]
+            await db.repos.messages.update_translation(message_id, target, translated)
+            print(f"Original:\n  {text[:500]}\n")
+            print(f"Translated ({target}):\n  {translated[:500]}")
+        else:
+            print("Translation failed.")
+    finally:
+        await db.close()
+
+
 def run(args: argparse.Namespace) -> None:
-    async def _run() -> None:
-        _config, db = await runtime.init_db(args.config)
-        try:
-            action = getattr(args, "translate_action", None) or "stats"
+    """Thin argparse adapter over the ``*_impl`` bodies (legacy dispatch path).
 
-            if action == "stats":
-                stats = await db.repos.messages.get_language_stats()
-                if not stats:
-                    print("No language data. Run: python -m src.main translate detect")
-                    return
-                fmt = "{:<10} {:>10}"
-                print(fmt.format("Language", "Messages"))
-                print("-" * 22)
-                total = 0
-                for lang, count in stats:
-                    print(fmt.format(lang, count))
-                    total += count
-                print("-" * 22)
-                print(fmt.format("Total", total))
-
-            elif action == "detect":
-                batch_size = getattr(args, "batch_size", 5000)
-                total_updated = 0
-                while True:
-                    updated = await db.repos.messages.backfill_language_detection(batch_size=batch_size)
-                    total_updated += updated
-                    if updated < batch_size:
-                        break
-                    print(f"  ... detected {total_updated} so far")
-                print(f"Language detection complete: {total_updated} messages updated.")
-
-            elif action == "run":
-                from src.services.provider_service import build_provider_service
-                from src.services.translation_service import TranslationService
-
-                target = getattr(args, "target", "en")
-                source_filter_raw = getattr(args, "source_filter", "")
-                limit = getattr(args, "limit", 100)
-                source_filter = (
-                    [s.strip() for s in source_filter_raw.split(",") if s.strip()]
-                    if source_filter_raw else None
-                )
-
-                provider_name = await db.get_setting("translation_provider")
-                model = await db.get_setting("translation_model")
-
-                provider_service = await build_provider_service(db, _config)
-                svc = TranslationService(db, provider_service=provider_service)
-
-                msgs = await db.repos.messages.get_untranslated_messages(
-                    target=target, source_langs=source_filter, limit=limit
-                )
-                if not msgs:
-                    print("No messages to translate.")
-                    return
-
-                print(f"Translating {len(msgs)} messages to {target}...")
-                results = await svc.translate_batch(msgs, target, provider_name=provider_name, model=model)
-                for msg_id, translated in results:
-                    await db.repos.messages.update_translation(msg_id, target, translated)
-                print(f"Translated {len(results)}/{len(msgs)} messages.")
-
-            elif action == "message":
-                from src.services.provider_service import build_provider_service
-                from src.services.translation_service import TranslationService
-
-                message_id = args.message_id
-                target = getattr(args, "target", "en")
-
-                msg = await db.repos.messages.get_by_id(message_id)
-                if msg is None:
-                    print(f"Message id={message_id} not found.")
-                    return
-                text = msg.text or ""
-                if not text.strip():
-                    print("Message has no text to translate.")
-                    return
-
-                provider_name = await db.get_setting("translation_provider")
-                model = await db.get_setting("translation_model")
-                provider_service = await build_provider_service(db, _config)
-                svc = TranslationService(db, provider_service=provider_service)
-
-                results = await svc.translate_batch([msg], target, provider_name=provider_name, model=model)
-                if results:
-                    _, translated = results[0]
-                    await db.repos.messages.update_translation(message_id, target, translated)
-                    print(f"Original:\n  {text[:500]}\n")
-                    print(f"Translated ({target}):\n  {translated[:500]}")
-                else:
-                    print("Translation failed.")
-
-        finally:
-            await db.close()
-
-    asyncio.run(_run())
+    The production CLI routes ``translate`` through the Typer ``app`` (#1122);
+    this wrapper keeps the argparse leaf audit and command-level tests working.
+    """
+    action = getattr(args, "translate_action", None) or "stats"
+    if action == "stats":
+        asyncio.run(stats_impl(args.config))
+    elif action == "detect":
+        asyncio.run(detect_impl(args.config, batch_size=getattr(args, "batch_size", 5000)))
+    elif action == "run":
+        asyncio.run(
+            run_impl(
+                args.config,
+                target=getattr(args, "target", "en"),
+                source_filter=getattr(args, "source_filter", ""),
+                limit=getattr(args, "limit", 100),
+            )
+        )
+    elif action == "message":
+        asyncio.run(
+            message_impl(args.config, message_id=args.message_id, target=getattr(args, "target", "en"))
+        )

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -7,13 +7,9 @@ from src.cli.commands import (
     account,
     channel,
     collect,
-    export,
-    image,
     mcp_server,
     messages,
-    notification,
     photo_loader,
-    provider,
     scheduler,
     search,
     search_query,
@@ -23,13 +19,11 @@ from src.cli.commands import (
 )
 from src.cli.commands import agent as agent_cmd
 from src.cli.commands import analytics as analytics_cmd
-from src.cli.commands import debug as debug_cmd
 from src.cli.commands import dialogs as dialogs_cmd
 from src.cli.commands import filter as filter_cmd
 from src.cli.commands import pipeline as pipeline_cmd
 from src.cli.commands import settings as settings_cmd
 from src.cli.commands import test as test_cmd
-from src.cli.commands import translate as translate_cmd
 from src.cli.dotenv import load_cli_dotenv
 from src.cli.parser import build_parser
 from src.cli.runtime import ensure_data_dirs, setup_logging
@@ -93,18 +87,12 @@ def main() -> None:
         "pipeline": pipeline_cmd.run,
         "account": account.run,
         "scheduler": scheduler.run,
-        "notification": notification.run,
         "photo-loader": photo_loader.run,
         "dialogs": dialogs_cmd.run,
         "test": test_cmd.run,
         "agent": agent_cmd.run,
         "analytics": analytics_cmd.run,
-        "image": image.run,
         "settings": settings_cmd.run,
-        "translate": translate_cmd.run,
-        "provider": provider.run,
-        "export": export.run,
-        "debug": debug_cmd.run,
     }
 
     handler = commands.get(args.command)
@@ -117,17 +105,12 @@ def main() -> None:
             "pipeline": "pipeline_action",
             "account": "account_action",
             "scheduler": "scheduler_action",
-            "notification": "notification_action",
             "photo-loader": "photo_loader_action",
             "dialogs": "dialogs_action",
             "test": "test_action",
             "agent": "agent_action",
             "analytics": "analytics_action",
-            "image": "image_action",
             "settings": "settings_action",
-            "provider": "provider_action",
-            "export": "export_action",
-            "debug": "debug_action",
         }
         if args.command in sub_attr and not getattr(args, sub_attr[args.command], None):
             parser.parse_args([args.command, "--help"])

--- a/src/cli/typer_commands.py
+++ b/src/cli/typer_commands.py
@@ -59,11 +59,17 @@ except ImportError:  # pragma: no cover - defensive fallback
     _NO_ARGS_HELP_EXCEPTIONS = (click.exceptions.NoArgsIsHelpError,)
 
 from src.cli.commands import collect as collect_cmd
+from src.cli.commands import debug as debug_cmd
+from src.cli.commands import export as export_cmd
+from src.cli.commands import image as image_cmd
 from src.cli.commands import mcp_server as mcp_server_cmd
 from src.cli.commands import messages as messages_cmd
+from src.cli.commands import notification as notification_cmd
+from src.cli.commands import provider as provider_cmd
 from src.cli.commands import search as search_cmd
 from src.cli.commands import serve as serve_cmd
 from src.cli.commands import server_control as server_control_cmd
+from src.cli.commands import translate as translate_cmd
 from src.cli.commands import worker as worker_cmd
 from src.cli.typer_app import app, apply_startup, run_async
 
@@ -99,8 +105,21 @@ class OutputFormat(str, Enum):
 #: handler; :func:`_argv_from_namespace` rebuilds the Typer argv from the parsed
 #: Namespace so the two entry points stay equivalent on the resolved flags.
 MIGRATED_COMMANDS: frozenset[str] = frozenset(
-    {"serve", "worker", "stop", "restart", "mcp-server", "collect", "search", "messages"}
+    {
+        # Wave 1 (#1121)
+        "serve", "worker", "stop", "restart", "mcp-server", "collect", "search", "messages",
+        # Wave 2 (#1122) — flat simple groups
+        "debug", "export", "translate", "image", "provider", "notification",
+    }
 )
+
+
+class ExportFormat(str, Enum):
+    """``export telegram --format`` choices — mirrors the argparse ``choices=[…]``."""
+
+    json = "json"
+    html = "html"
+    both = "both"
 
 
 # --------------------------------------------------------------------------- #
@@ -329,6 +348,364 @@ def messages_read(
 
 
 # --------------------------------------------------------------------------- #
+# debug → logs / memory / timing
+# --------------------------------------------------------------------------- #
+
+debug_app = typer.Typer(no_args_is_help=True, help="Diagnostic tools")
+app.add_typer(debug_app, name="debug")
+
+
+@debug_app.command("logs")
+def debug_logs(
+    ctx: typer.Context,
+    limit: int = typer.Option(50, "--limit", help="Number of log lines (default: 50)"),
+) -> None:
+    """Show recent log entries."""
+    apply_startup(ctx)
+    run_async(debug_cmd.logs_impl(ctx.obj.config, limit=limit))
+
+
+@debug_app.command("memory")
+def debug_memory(ctx: typer.Context) -> None:
+    """Show memory usage statistics."""
+    apply_startup(ctx)
+    run_async(debug_cmd.memory_impl(ctx.obj.config))
+
+
+@debug_app.command("timing")
+def debug_timing(ctx: typer.Context) -> None:
+    """Show operation timing stats."""
+    apply_startup(ctx)
+    run_async(debug_cmd.timing_impl(ctx.obj.config))
+
+
+# --------------------------------------------------------------------------- #
+# export → json / csv / rss / telegram
+# --------------------------------------------------------------------------- #
+
+export_app = typer.Typer(no_args_is_help=True, help="Export collected messages")
+app.add_typer(export_app, name="export")
+
+
+def _export_flat(
+    ctx: typer.Context,
+    fmt: str,
+    channel_id: int | None,
+    limit: int,
+    output: str | None,
+) -> None:
+    """Shared body for the flat json/csv/rss export sub-commands."""
+    apply_startup(ctx)
+    run_async(
+        export_cmd.export_impl(
+            ctx.obj.config,
+            fmt=fmt,
+            channel_id=channel_id,
+            limit=limit,
+            output=output,
+        )
+    )
+
+
+@export_app.command("json")
+def export_json(
+    ctx: typer.Context,
+    channel_id: int | None = typer.Option(None, "--channel-id", help="Filter by channel ID"),
+    limit: int = typer.Option(200, "--limit", help="Max messages (default: 200)"),
+    output: str | None = typer.Option(None, "--output", "-o", help="Output file (default: stdout)"),
+) -> None:
+    """Export as JSON."""
+    _export_flat(ctx, "json", channel_id, limit, output)
+
+
+@export_app.command("csv")
+def export_csv(
+    ctx: typer.Context,
+    channel_id: int | None = typer.Option(None, "--channel-id", help="Filter by channel ID"),
+    limit: int = typer.Option(200, "--limit", help="Max messages (default: 200)"),
+    output: str | None = typer.Option(None, "--output", "-o", help="Output file (default: stdout)"),
+) -> None:
+    """Export as CSV."""
+    _export_flat(ctx, "csv", channel_id, limit, output)
+
+
+@export_app.command("rss")
+def export_rss(
+    ctx: typer.Context,
+    channel_id: int | None = typer.Option(None, "--channel-id", help="Filter by channel ID"),
+    limit: int = typer.Option(200, "--limit", help="Max messages (default: 200)"),
+    output: str | None = typer.Option(None, "--output", "-o", help="Output file (default: stdout)"),
+) -> None:
+    """Export as RSS."""
+    _export_flat(ctx, "rss", channel_id, limit, output)
+
+
+@export_app.command("telegram")
+def export_telegram(
+    ctx: typer.Context,
+    channel_id: int | None = typer.Option(None, "--channel-id", help="Telegram channel ID to export (required)"),
+    export_format: ExportFormat = typer.Option(ExportFormat.json, "--format", help="Output format (default: json)"),
+    with_media: bool = typer.Option(
+        False, "--with-media", help="Download media artifacts (enqueues a worker task)"
+    ),
+    wait: bool = typer.Option(
+        False, "--wait", help="With --with-media: poll the enqueued task until it finishes"
+    ),
+    max_file_size: int | None = typer.Option(
+        None, "--max-file-size", help="Skip files larger than N MB (default: from settings or 3)"
+    ),
+    date_from: str | None = typer.Option(None, "--date-from", help="Start date YYYY-MM-DD"),
+    date_to: str | None = typer.Option(None, "--date-to", help="End date YYYY-MM-DD"),
+    limit: int = typer.Option(5000, "--limit", help="Max messages (default: 5000)"),
+    output: str | None = typer.Option(
+        None, "--output", "-o",
+        help="Output directory (default: data/exports/ChatExport_<date>_<channel>)",
+    ),
+) -> None:
+    """Export as Telegram-Desktop JSON/HTML."""
+    apply_startup(ctx)
+    run_async(
+        export_cmd.telegram_impl(
+            ctx.obj.config,
+            channel_id=channel_id,
+            export_format=export_format.value,
+            with_media=with_media,
+            wait=wait,
+            max_file_size=max_file_size,
+            date_from=date_from,
+            date_to=date_to,
+            limit=limit,
+            output=output,
+        )
+    )
+
+
+# --------------------------------------------------------------------------- #
+# translate → stats / detect / run / message
+# --------------------------------------------------------------------------- #
+
+translate_app = typer.Typer(no_args_is_help=True, help="Language detection and translation")
+app.add_typer(translate_app, name="translate")
+
+
+@translate_app.command("stats")
+def translate_stats(ctx: typer.Context) -> None:
+    """Show language distribution."""
+    apply_startup(ctx)
+    run_async(translate_cmd.stats_impl(ctx.obj.config))
+
+
+@translate_app.command("detect")
+def translate_detect(
+    ctx: typer.Context,
+    batch_size: int = typer.Option(5000, "--batch-size"),
+) -> None:
+    """Backfill language detection."""
+    apply_startup(ctx)
+    run_async(translate_cmd.detect_impl(ctx.obj.config, batch_size=batch_size))
+
+
+@translate_app.command("run")
+def translate_run(
+    ctx: typer.Context,
+    target: str = typer.Option("en", "--target", help="Target language code"),
+    source_filter: str = typer.Option("", "--source-filter", help="Comma-separated source languages"),
+    limit: int = typer.Option(100, "--limit", help="Max messages to translate"),
+) -> None:
+    """Run translation batch."""
+    apply_startup(ctx)
+    run_async(
+        translate_cmd.run_impl(
+            ctx.obj.config,
+            target=target,
+            source_filter=source_filter,
+            limit=limit,
+        )
+    )
+
+
+@translate_app.command("message")
+def translate_message(
+    ctx: typer.Context,
+    message_id: int = typer.Argument(..., help="Message DB id"),
+    target: str = typer.Option("en", "--target", help="Target language code"),
+) -> None:
+    """Translate a single message."""
+    apply_startup(ctx)
+    run_async(translate_cmd.message_impl(ctx.obj.config, message_id=message_id, target=target))
+
+
+# --------------------------------------------------------------------------- #
+# image → generate / models / providers / generated
+# --------------------------------------------------------------------------- #
+
+image_app = typer.Typer(no_args_is_help=True, help="Image generation")
+app.add_typer(image_app, name="image")
+
+
+@image_app.command("generate")
+def image_generate(
+    ctx: typer.Context,
+    prompt: str = typer.Argument(..., help="Text prompt for image generation"),
+    model: str | None = typer.Option(None, "--model", help="Model string (e.g. replicate:flux-schnell)"),
+) -> None:
+    """Generate an image from prompt."""
+    apply_startup(ctx)
+    run_async(image_cmd.generate_impl(ctx.obj.config, prompt=prompt, model=model))
+
+
+@image_app.command("models")
+def image_models(
+    ctx: typer.Context,
+    provider: str = typer.Option(..., "--provider", help="Provider name (replicate, together, openai)"),
+    query: str = typer.Option("", "--query", help="Search query"),
+    refresh: bool = typer.Option(
+        False, "--refresh", help="Fetch the live model list from the provider (OpenAI: /v1/models)"
+    ),
+) -> None:
+    """Search available models."""
+    apply_startup(ctx)
+    run_async(image_cmd.models_impl(ctx.obj.config, provider=provider, query=query, refresh=refresh))
+
+
+@image_app.command("providers")
+def image_providers(ctx: typer.Context) -> None:
+    """List configured image providers."""
+    apply_startup(ctx)
+    run_async(image_cmd.providers_impl(ctx.obj.config))
+
+
+@image_app.command("generated")
+def image_generated(
+    ctx: typer.Context,
+    limit: int = typer.Option(20, "--limit", help="Max images to show"),
+) -> None:
+    """List generated images."""
+    apply_startup(ctx)
+    run_async(image_cmd.generated_impl(ctx.obj.config, limit=limit))
+
+
+# --------------------------------------------------------------------------- #
+# provider → list / add / delete / probe / refresh / test-all
+# --------------------------------------------------------------------------- #
+
+provider_app = typer.Typer(no_args_is_help=True, help="LLM provider management")
+app.add_typer(provider_app, name="provider")
+
+
+@provider_app.command("list")
+def provider_list(ctx: typer.Context) -> None:
+    """List configured providers with models and status."""
+    apply_startup(ctx)
+    run_async(provider_cmd.list_impl(ctx.obj.config))
+
+
+@provider_app.command("add")
+def provider_add(
+    ctx: typer.Context,
+    name: str = typer.Argument(..., help="Provider name (e.g. openai, groq, anthropic)"),
+    api_key: str = typer.Option(..., "--api-key", help="API key"),
+    base_url: str | None = typer.Option(None, "--base-url", help="Custom base URL"),
+) -> None:
+    """Add or update a provider."""
+    apply_startup(ctx)
+    run_async(provider_cmd.add_impl(ctx.obj.config, name=name, api_key=api_key, base_url=base_url))
+
+
+@provider_app.command("delete")
+def provider_delete(
+    ctx: typer.Context,
+    name: str = typer.Argument(..., help="Provider name"),
+) -> None:
+    """Delete a provider."""
+    apply_startup(ctx)
+    run_async(provider_cmd.delete_impl(ctx.obj.config, name=name))
+
+
+@provider_app.command("probe")
+def provider_probe(
+    ctx: typer.Context,
+    name: str = typer.Argument(..., help="Provider name"),
+) -> None:
+    """Test provider connection."""
+    apply_startup(ctx)
+    run_async(provider_cmd.probe_impl(ctx.obj.config, name=name))
+
+
+@provider_app.command("refresh")
+def provider_refresh(
+    ctx: typer.Context,
+    name: str | None = typer.Argument(None, help="Provider name (default: all)"),
+) -> None:
+    """Refresh provider models."""
+    apply_startup(ctx)
+    run_async(provider_cmd.refresh_impl(ctx.obj.config, name=name))
+
+
+@provider_app.command("test-all")
+def provider_test_all(ctx: typer.Context) -> None:
+    """Test all configured providers."""
+    apply_startup(ctx)
+    run_async(provider_cmd.test_all_impl(ctx.obj.config))
+
+
+# --------------------------------------------------------------------------- #
+# notification → setup / status / delete / test / dry-run / set-account
+# --------------------------------------------------------------------------- #
+
+notification_app = typer.Typer(no_args_is_help=True, help="Personal notification bot management")
+app.add_typer(notification_app, name="notification")
+
+
+@notification_app.command("setup")
+def notification_setup(ctx: typer.Context) -> None:
+    """Create personal notification bot via BotFather."""
+    apply_startup(ctx)
+    run_async(notification_cmd.setup_impl(ctx.obj.config))
+
+
+@notification_app.command("status")
+def notification_status(ctx: typer.Context) -> None:
+    """Show notification bot status."""
+    apply_startup(ctx)
+    run_async(notification_cmd.status_impl(ctx.obj.config))
+
+
+@notification_app.command("delete")
+def notification_delete(ctx: typer.Context) -> None:
+    """Delete notification bot via BotFather."""
+    apply_startup(ctx)
+    run_async(notification_cmd.delete_impl(ctx.obj.config))
+
+
+@notification_app.command("test")
+def notification_test(
+    ctx: typer.Context,
+    message: str = typer.Option("Тестовое уведомление", "--message", help="Message text"),
+) -> None:
+    """Send a test notification message."""
+    apply_startup(ctx)
+    run_async(notification_cmd.test_impl(ctx.obj.config, message=message))
+
+
+@notification_app.command("dry-run")
+def notification_dry_run(ctx: typer.Context) -> None:
+    """Preview notification matches without sending."""
+    apply_startup(ctx)
+    run_async(notification_cmd.dry_run_impl(ctx.obj.config))
+
+
+@notification_app.command("set-account")
+def notification_set_account(
+    ctx: typer.Context,
+    phone: str = typer.Option(..., "--phone", help="Account phone number"),
+) -> None:
+    """Set account for notification bot."""
+    apply_startup(ctx)
+    run_async(notification_cmd.set_account_impl(ctx.obj.config, phone=phone))
+
+
+# --------------------------------------------------------------------------- #
 # argparse → Typer delegation
 # --------------------------------------------------------------------------- #
 
@@ -386,7 +763,154 @@ def _argv_from_namespace(args: argparse.Namespace) -> list[str]:
         argv.append("messages")
         if getattr(args, "messages_action", None) == "read":
             argv += _messages_read_argv(args)
+    elif command == "debug":
+        argv.append("debug")
+        argv += _debug_argv(args)
+    elif command == "export":
+        argv.append("export")
+        argv += _export_argv(args)
+    elif command == "translate":
+        argv.append("translate")
+        argv += _translate_argv(args)
+    elif command == "image":
+        argv.append("image")
+        argv += _image_argv(args)
+    elif command == "provider":
+        argv.append("provider")
+        argv += _provider_argv(args)
+    elif command == "notification":
+        argv.append("notification")
+        argv += _notification_argv(args)
     return argv
+
+
+def _debug_argv(args: argparse.Namespace) -> list[str]:
+    """argv tail for ``debug`` — the action plus its only flag (``logs --limit``)."""
+    action = getattr(args, "debug_action", None)
+    if action is None:
+        return []
+    tail = [action]
+    if action == "logs" and getattr(args, "limit", 50) != 50:
+        tail += ["--limit", str(args.limit)]
+    return tail
+
+
+def _export_argv(args: argparse.Namespace) -> list[str]:
+    """argv tail for ``export`` — the action plus its flags.
+
+    The flat json/csv/rss commands share one flag set; ``telegram`` has its own.
+    """
+    action = getattr(args, "export_action", None)
+    if action is None:
+        return []
+    tail = [action]
+    if action in ("json", "csv", "rss"):
+        if getattr(args, "channel_id", None) is not None:
+            tail += ["--channel-id", str(args.channel_id)]
+        if getattr(args, "limit", 200) != 200:
+            tail += ["--limit", str(args.limit)]
+        if getattr(args, "output", None):
+            tail += ["--output", args.output]
+    elif action == "telegram":
+        if getattr(args, "channel_id", None) is not None:
+            tail += ["--channel-id", str(args.channel_id)]
+        if getattr(args, "export_format", "json") != "json":
+            tail += ["--format", args.export_format]
+        if getattr(args, "with_media", False):
+            tail.append("--with-media")
+        if getattr(args, "wait", False):
+            tail.append("--wait")
+        if getattr(args, "max_file_size", None) is not None:
+            tail += ["--max-file-size", str(args.max_file_size)]
+        if getattr(args, "date_from", None):
+            tail += ["--date-from", args.date_from]
+        if getattr(args, "date_to", None):
+            tail += ["--date-to", args.date_to]
+        if getattr(args, "limit", 5000) != 5000:
+            tail += ["--limit", str(args.limit)]
+        if getattr(args, "output", None):
+            tail += ["--output", args.output]
+    return tail
+
+
+def _translate_argv(args: argparse.Namespace) -> list[str]:
+    """argv tail for ``translate`` — the action plus its flags / positional."""
+    action = getattr(args, "translate_action", None)
+    if action is None:
+        return []
+    tail = [action]
+    if action == "detect":
+        if getattr(args, "batch_size", 5000) != 5000:
+            tail += ["--batch-size", str(args.batch_size)]
+    elif action == "run":
+        if getattr(args, "target", "en") != "en":
+            tail += ["--target", args.target]
+        if getattr(args, "source_filter", ""):
+            tail += ["--source-filter", args.source_filter]
+        if getattr(args, "limit", 100) != 100:
+            tail += ["--limit", str(args.limit)]
+    elif action == "message":
+        if getattr(args, "target", "en") != "en":
+            tail += ["--target", args.target]
+        # Positional message_id after ``--`` (defensive, though it is always positive).
+        tail += ["--", str(args.message_id)]
+    return tail
+
+
+def _image_argv(args: argparse.Namespace) -> list[str]:
+    """argv tail for ``image`` — the action plus its flags / positional prompt."""
+    action = getattr(args, "image_action", None)
+    if action is None:
+        return []
+    tail = [action]
+    if action == "generate":
+        if getattr(args, "model", None):
+            tail += ["--model", args.model]
+        # Prompt is free text; emit after ``--`` so a leading ``-`` survives.
+        tail += ["--", args.prompt]
+    elif action == "models":
+        tail += ["--provider", args.provider]
+        if getattr(args, "query", ""):
+            tail += ["--query", args.query]
+        if getattr(args, "refresh", False):
+            tail.append("--refresh")
+    elif action == "generated":
+        if getattr(args, "limit", 20) != 20:
+            tail += ["--limit", str(args.limit)]
+    return tail
+
+
+def _provider_argv(args: argparse.Namespace) -> list[str]:
+    """argv tail for ``provider`` — the action plus its flags / positional name."""
+    action = getattr(args, "provider_action", None)
+    if action is None:
+        return []
+    tail = [action]
+    if action == "add":
+        tail += ["--api-key", args.api_key]
+        if getattr(args, "base_url", None):
+            tail += ["--base-url", args.base_url]
+        tail += ["--", args.name]
+    elif action in ("delete", "probe"):
+        tail += ["--", args.name]
+    elif action == "refresh":
+        if getattr(args, "name", None):
+            tail += ["--", args.name]
+    return tail
+
+
+def _notification_argv(args: argparse.Namespace) -> list[str]:
+    """argv tail for ``notification`` — the action plus its flags."""
+    action = getattr(args, "notification_action", None)
+    if action is None:
+        return []
+    tail = [action]
+    if action == "test":
+        if getattr(args, "message", "Тестовое уведомление") != "Тестовое уведомление":
+            tail += ["--message", args.message]
+    elif action == "set-account":
+        tail += ["--phone", args.phone]
+    return tail
 
 
 def _search_argv(args: argparse.Namespace) -> list[str]:

--- a/tests/test_cli_typer_wave2.py
+++ b/tests/test_cli_typer_wave2.py
@@ -1,0 +1,726 @@
+"""CliRunner tests for the Wave-2 Typer command groups (epic #959 — issue #1122).
+
+Wave 2 migrates the flat, depth-1 command groups off the argparse dispatcher onto
+the Typer ``app``:
+
+    debug · export · translate · image · provider · notification
+
+These tests drive the production ``app`` through ``typer.testing.CliRunner`` and
+assert each sub-command:
+
+* exposes the *same* flags / arguments / sub-command names the argparse parser did
+  (the hard invariant of the migration), and
+* delegates to the shared ``*_impl`` body with the flags mapped to exactly the
+  right keyword arguments.
+
+The shared bodies are stubbed (and ``run_async`` is patched to capture rather than
+execute the coroutine) so no real DB / Telegram / provider work happens — the
+wiring from CLI tokens to the body is what is under test. The final section drives
+the real prod path (``build_parser`` → ``dispatch_via_typer``) to guard the
+argparse→Typer round-trip end to end.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from src.cli.parser import build_parser
+from src.cli.typer_app import app
+from src.cli.typer_commands import dispatch_via_typer
+
+runner = CliRunner()
+
+
+def _delegate(argv: list[str]) -> None:
+    """Run the real prod path: argparse parse → argparse→Typer delegation."""
+    args = build_parser().parse_args(argv)
+    dispatch_via_typer(args)
+
+
+# --------------------------------------------------------------------------- #
+# debug → logs / memory / timing
+# --------------------------------------------------------------------------- #
+
+
+def test_debug_logs_defaults():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.debug_cmd.logs_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["debug", "logs"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", limit=50)
+
+
+def test_debug_logs_limit():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.debug_cmd.logs_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["debug", "logs", "--limit", "5"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", limit=5)
+
+
+def test_debug_memory_delegates():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.debug_cmd.memory_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["debug", "memory"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml")
+
+
+def test_debug_timing_delegates():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.debug_cmd.timing_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["debug", "timing"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml")
+
+
+def test_debug_bare_group_shows_help():
+    result = runner.invoke(app, ["debug"])
+    assert result.exit_code != 0  # no_args_is_help → non-zero
+    assert "logs" in result.output and "memory" in result.output
+
+
+# --------------------------------------------------------------------------- #
+# export → json / csv / rss / telegram
+# --------------------------------------------------------------------------- #
+
+
+def test_export_json_defaults():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.export_cmd.export_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["export", "json"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with(
+        "config.yaml", fmt="json", channel_id=None, limit=200, output=None
+    )
+
+
+def test_export_csv_flags():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.export_cmd.export_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(
+            app, ["export", "csv", "--channel-id", "42", "--limit", "10", "-o", "out.csv"]
+        )
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with(
+        "config.yaml", fmt="csv", channel_id=42, limit=10, output="out.csv"
+    )
+
+
+def test_export_rss_delegates_with_fmt():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.export_cmd.export_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["export", "rss"])
+    assert result.exit_code == 0
+    assert mock_impl.call_args.kwargs["fmt"] == "rss"
+
+
+def test_export_telegram_defaults():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.export_cmd.telegram_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["export", "telegram", "--channel-id", "100"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with(
+        "config.yaml",
+        channel_id=100,
+        export_format="json",
+        with_media=False,
+        wait=False,
+        max_file_size=None,
+        date_from=None,
+        date_to=None,
+        limit=5000,
+        output=None,
+    )
+
+
+def test_export_telegram_full_flags():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.export_cmd.telegram_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "export", "telegram", "--channel-id", "100",
+                "--format", "both", "--with-media", "--wait",
+                "--max-file-size", "5", "--date-from", "2025-01-01",
+                "--date-to", "2025-12-31", "--limit", "9", "--output", "/tmp/exp",
+            ],
+        )
+    assert result.exit_code == 0
+    kwargs = mock_impl.call_args.kwargs
+    assert kwargs["export_format"] == "both"
+    assert kwargs["with_media"] is True
+    assert kwargs["wait"] is True
+    assert kwargs["max_file_size"] == 5
+    assert kwargs["date_from"] == "2025-01-01"
+    assert kwargs["date_to"] == "2025-12-31"
+    assert kwargs["limit"] == 9
+    assert kwargs["output"] == "/tmp/exp"
+
+
+def test_export_telegram_rejects_unknown_format():
+    """--format keeps argparse's json/html/both choice set."""
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.export_cmd.telegram_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["export", "telegram", "--channel-id", "1", "--format", "bogus"])
+    assert result.exit_code == 2
+    mock_impl.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# translate → stats / detect / run / message
+# --------------------------------------------------------------------------- #
+
+
+def test_translate_stats_delegates():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.translate_cmd.stats_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["translate", "stats"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml")
+
+
+def test_translate_detect_defaults():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.translate_cmd.detect_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["translate", "detect"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", batch_size=5000)
+
+
+def test_translate_detect_batch_size():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.translate_cmd.detect_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["translate", "detect", "--batch-size", "100"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", batch_size=100)
+
+
+def test_translate_run_defaults():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.translate_cmd.run_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["translate", "run"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with(
+        "config.yaml", target="en", source_filter="", limit=100
+    )
+
+
+def test_translate_run_flags():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.translate_cmd.run_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(
+            app, ["translate", "run", "--target", "ru", "--source-filter", "en,de", "--limit", "5"]
+        )
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with(
+        "config.yaml", target="ru", source_filter="en,de", limit=5
+    )
+
+
+def test_translate_message_positional_and_target():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.translate_cmd.message_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["translate", "message", "777", "--target", "fr"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", message_id=777, target="fr")
+
+
+# --------------------------------------------------------------------------- #
+# image → generate / models / providers / generated
+# --------------------------------------------------------------------------- #
+
+
+def test_image_generate_prompt_only():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.image_cmd.generate_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["image", "generate", "a red cat"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", prompt="a red cat", model=None)
+
+
+def test_image_generate_with_model():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.image_cmd.generate_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["image", "generate", "sky", "--model", "replicate:flux-schnell"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", prompt="sky", model="replicate:flux-schnell")
+
+
+def test_image_models_requires_provider():
+    """--provider is required (argparse required=True parity)."""
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.image_cmd.models_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["image", "models"])
+    assert result.exit_code == 2
+    mock_impl.assert_not_called()
+
+
+def test_image_models_flags():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.image_cmd.models_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(
+            app, ["image", "models", "--provider", "openai", "--query", "dall", "--refresh"]
+        )
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with(
+        "config.yaml", provider="openai", query="dall", refresh=True
+    )
+
+
+def test_image_providers_delegates():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.image_cmd.providers_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["image", "providers"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml")
+
+
+def test_image_generated_defaults():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.image_cmd.generated_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["image", "generated"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", limit=20)
+
+
+def test_image_generated_limit():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.image_cmd.generated_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["image", "generated", "--limit", "3"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", limit=3)
+
+
+# --------------------------------------------------------------------------- #
+# provider → list / add / delete / probe / refresh / test-all
+# --------------------------------------------------------------------------- #
+
+
+def test_provider_list_delegates():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.provider_cmd.list_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["provider", "list"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml")
+
+
+def test_provider_add_requires_api_key():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.provider_cmd.add_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["provider", "add", "openai"])
+    assert result.exit_code == 2
+    mock_impl.assert_not_called()
+
+
+def test_provider_add_flags():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.provider_cmd.add_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(
+            app, ["provider", "add", "openai", "--api-key", "sk-xxx", "--base-url", "http://x"]
+        )
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with(
+        "config.yaml", name="openai", api_key="sk-xxx", base_url="http://x"
+    )
+
+
+def test_provider_delete_positional():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.provider_cmd.delete_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["provider", "delete", "groq"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", name="groq")
+
+
+def test_provider_probe_positional():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.provider_cmd.probe_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["provider", "probe", "cohere"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", name="cohere")
+
+
+def test_provider_refresh_no_name():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.provider_cmd.refresh_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["provider", "refresh"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", name=None)
+
+
+def test_provider_refresh_with_name():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.provider_cmd.refresh_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["provider", "refresh", "openai"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", name="openai")
+
+
+def test_provider_test_all_delegates():
+    """The ``test-all`` sub-command name (with the dash) is preserved."""
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.provider_cmd.test_all_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["provider", "test-all"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml")
+
+
+# --------------------------------------------------------------------------- #
+# notification → setup / status / delete / test / dry-run / set-account
+# --------------------------------------------------------------------------- #
+
+
+def test_notification_setup_delegates():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.notification_cmd.setup_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["notification", "setup"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml")
+
+
+def test_notification_status_delegates():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.notification_cmd.status_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["notification", "status"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml")
+
+
+def test_notification_delete_delegates():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.notification_cmd.delete_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["notification", "delete"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml")
+
+
+def test_notification_test_default_message():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.notification_cmd.test_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["notification", "test"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", message="Тестовое уведомление")
+
+
+def test_notification_test_custom_message():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.notification_cmd.test_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["notification", "test", "--message", "hi"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", message="hi")
+
+
+def test_notification_dry_run_delegates():
+    """The ``dry-run`` sub-command name (with the dash) is preserved."""
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.notification_cmd.dry_run_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["notification", "dry-run"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml")
+
+
+def test_notification_set_account_requires_phone():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.notification_cmd.set_account_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["notification", "set-account"])
+    assert result.exit_code == 2
+    mock_impl.assert_not_called()
+
+
+def test_notification_set_account_phone():
+    """The ``set-account`` sub-command name (with the dash) is preserved."""
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.notification_cmd.set_account_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["notification", "set-account", "--phone", "+15550001111"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", phone="+15550001111")
+
+
+# --------------------------------------------------------------------------- #
+# Global --config threads through the migrated groups
+# --------------------------------------------------------------------------- #
+
+
+def test_global_config_threads_into_group():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.debug_cmd.timing_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["--config", "prod.yaml", "debug", "timing"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("prod.yaml")
+
+
+# --------------------------------------------------------------------------- #
+# argparse → Typer delegation round-trip (the real prod path)
+#
+# `main()` parses with argparse, then `dispatch_via_typer` rebuilds the Typer
+# argv. These guard the "names / flags / behaviour unchanged" invariant end to
+# end, including awkward positionals (negative channel ids, dash-leading prompts).
+# --------------------------------------------------------------------------- #
+
+
+def test_delegation_debug_logs_roundtrip():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.debug_cmd.logs_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        _delegate(["debug", "logs", "--limit", "7"])
+    mock_impl.assert_called_once_with("config.yaml", limit=7)
+
+
+def test_delegation_export_csv_negative_channel_id():
+    """Regression: a negative channel id survives argparse→Typer delegation."""
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.export_cmd.export_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        _delegate(["export", "csv", "--channel-id", "-100123", "--limit", "5"])
+    mock_impl.assert_called_once_with(
+        "config.yaml", fmt="csv", channel_id=-100123, limit=5, output=None
+    )
+
+
+def test_delegation_export_telegram_roundtrip():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.export_cmd.telegram_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        _delegate(["export", "telegram", "--channel-id", "-100500", "--format", "html", "--with-media"])
+    kwargs = mock_impl.call_args.kwargs
+    assert kwargs["channel_id"] == -100500
+    assert kwargs["export_format"] == "html"
+    assert kwargs["with_media"] is True
+
+
+def test_delegation_translate_message_roundtrip():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.translate_cmd.message_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        _delegate(["translate", "message", "42", "--target", "ru"])
+    mock_impl.assert_called_once_with("config.yaml", message_id=42, target="ru")
+
+
+def test_delegation_image_generate_dash_prompt():
+    """Regression: a prompt starting with '-' survives delegation as the prompt."""
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.image_cmd.generate_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        _delegate(["image", "generate", "-weird prompt", "--model", "openai:dall-e-3"])
+    kwargs = mock_impl.call_args.kwargs
+    assert kwargs["prompt"] == "-weird prompt"
+    assert kwargs["model"] == "openai:dall-e-3"
+
+
+def test_delegation_provider_add_roundtrip():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.provider_cmd.add_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        _delegate(["provider", "add", "openai", "--api-key", "sk-1", "--base-url", "http://h"])
+    mock_impl.assert_called_once_with(
+        "config.yaml", name="openai", api_key="sk-1", base_url="http://h"
+    )
+
+
+def test_delegation_provider_test_all_roundtrip():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.provider_cmd.test_all_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        _delegate(["provider", "test-all"])
+    mock_impl.assert_called_once_with("config.yaml")
+
+
+def test_delegation_notification_set_account_roundtrip():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.notification_cmd.set_account_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        _delegate(["notification", "set-account", "--phone", "+15550001111"])
+    mock_impl.assert_called_once_with("config.yaml", phone="+15550001111")
+
+
+def test_delegation_notification_dry_run_roundtrip():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.notification_cmd.dry_run_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        _delegate(["notification", "dry-run"])
+    mock_impl.assert_called_once_with("config.yaml")
+
+
+def test_delegation_honours_global_config():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.provider_cmd.list_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        _delegate(["--config", "prod.yaml", "provider", "list"])
+    mock_impl.assert_called_once_with("prod.yaml")
+
+
+# --------------------------------------------------------------------------- #
+# Bare-group help parity: a group with no sub-command prints help, exits 0.
+# argparse's old `sub_attr` fallback printed `<group> --help` and exited 0; the
+# Typer path (no_args_is_help groups raise NoArgsIsHelpError, caught by
+# dispatch_via_typer) must match.
+# --------------------------------------------------------------------------- #
+
+
+def test_provider_without_subcommand_shows_help_and_exits_zero():
+    import pytest
+
+    args = build_parser().parse_args(["provider"])
+    with pytest.raises(SystemExit) as exc_info:
+        dispatch_via_typer(args)
+    assert exc_info.value.code == 0
+
+
+def test_image_without_subcommand_clean_via_full_cli(capsys):
+    """End-to-end: `python -m src.main image` prints help, exits 0, no traceback."""
+    import pytest
+
+    from src.cli.main import main
+
+    with patch("sys.argv", ["main.py", "image"]):
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+    assert exc_info.value.code == 0
+    out = capsys.readouterr()
+    combined = out.out + out.err
+    assert "NoArgsIsHelpError" not in combined
+    assert "Traceback" not in combined
+    assert "generate" in combined  # the help lists the sub-commands


### PR DESCRIPTION
## Что

Часть эпика #959 (argparse→Typer). **Волна 2 — простые группы команд** (depth=1, плоские сабкоманды). Мигрирует 6 групп с argparse-диспетчера на Typer `app`, продолжая гибрид Волны 1 (#1121):

    debug · export · translate · image · provider · notification

## Почему

Type-hints становятся схемой флагов (нет `add_argument`); диспетчер `args.{X}_action` растворяется в отдельные декорированные функции; async-тела идут через единый `run_async` bridge (нет локального `asyncio.run`).

## Как

- **6 sub-`Typer()`** подключены к корню под теми же именами; каждая сабкоманда — декорированная функция с **неизменными** именами/флагами (`export telegram`, `image generate`, `provider test-all`, `notification dry-run`, `notification set-account`, …).
- Тела в `commands/{group}.py` → `async def *_impl(...)`. `main()` роутит группы через `dispatch_via_typer` (добавлены в `MIGRATED_COMMANDS` + per-group `_*_argv` реконструкция argv с `--`-сепаратором для negative-id/dash-leading позиционных).
- **TDD:** 53 новых CliRunner-теста в `test_cli_typer_wave2.py` — маппинг флаг→kwarg, choice-set (`export --format`), required-опции (`image --provider`, `provider --api-key`, `notification --phone`), bare-group help-parity, argparse→Typer round-trip (negative channel id, dash-prompt).

## Инварианты — сохранены

- ✅ Имена сабкоманд/флагов/кортежи real-tg манифеста **неизменны**. `pytest -k "manifest or parity or real_telegram_policy or cli_main"` — 98 зелёных.
- ✅ `register()` в `parser_domains/{6}.py` **сохранены** + тонкий `run(args)`-адаптер над `*_impl` оставлен (см. развилку ниже). Существующие command-level тесты зелёные без правок.
- ✅ CLI↔Web↔Agent parity сверена по `docs/reference/parity.md` для всех 6 групп — расхождений нет (имена не менялись → parity сохраняется автоматически). `test_cli_agent_parity.py` зелёный. `parity.md` менять не требуется.

## ⚠️ Развилка vs тело issue

Issue п.3/п.4 предписывает «убрать `register()` из `parser_domains/` и опустошить их». **Я этого НЕ сделал намеренно**, повторяя решение Волны 1: тест-сторож `test_real_telegram_policy.py::_cli_leaf_commands()` строит live-CLI манифест из `build_parser()` (argparse), а **не** из Typer. Опустошение `register()` выкинуло бы мигрированные команды из manifest-свипа и сломало сторож. Финальная волна (#1125) убирает argparse-путь целиком — тогда `parser_domains/` уйдут вместе с ним. Тонкий `run(args)`-адаптер над `*_impl` сохранён по той же причине (leaf-audit + обратная совместимость тестов).

## Проверки (локально)

- `ruff check src/ tests/ conftest.py` — чисто.
- mypy: на затронутых файлах 1 ошибка `export.py` (`fmt`-Literal) — она **наследие baseline** (на `main` их было 3; число уменьшено, новых не добавлено).
- Полный релевантный набор: Wave-0/1/2 Typer-сьюты + 6 групповых тест-файлов + сторожа (manifest/parity/policy/cli_main) — зелёные (parallel + aiosqlite_serial). Широкий `-k cli` свип: 1676 parallel + 725 serial зелёных, без warnings.

Closes #1122

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WatmFaDVtxqjnAZ4DESfE6