### PR TITLE
feat(cli): migrate Wave-3 medium groups argparse→Typer (#1123)

### DIFF
--- a/src/cli/commands/account.py
+++ b/src/cli/commands/account.py
@@ -1,3 +1,15 @@
+"""Shared async bodies for the ``account`` CLI group (epic #959, Wave 3 — #1123).
+
+Migrated off the argparse dispatcher onto the Typer ``app`` (see
+``src/cli/typer_commands.py``). Each leaf sub-command is a plain ``async def
+*_impl`` here — no local ``asyncio.run`` and no ``argparse.Namespace``. A thin
+``run(args)`` adapter is kept for the argparse leaf audit and existing tests.
+
+The auth flow (send-code / verify-code) and the SSO export/import paths (#828)
+keep their exact behaviour — only the argparse→Typer wiring changed. The session
+string grants full account access and is NEVER logged.
+"""
+
 from __future__ import annotations
 
 import argparse
@@ -36,9 +48,9 @@ async def _load_resolve_backoffs(db, *, now: datetime) -> dict[str, datetime]:
     return parse_resolve_backoff_setting(raw, now=now)
 
 
-async def _resolve_credentials(args: argparse.Namespace, config, db) -> tuple[int, str]:
-    api_id = getattr(args, "api_id", None) or config.telegram.api_id
-    api_hash = getattr(args, "api_hash", None) or config.telegram.api_hash
+async def _resolve_credentials(config, db, *, api_id: int | None, api_hash: str | None) -> tuple[int, str]:
+    api_id = api_id or config.telegram.api_id
+    api_hash = api_hash or config.telegram.api_hash
     if api_id == 0 or not api_hash:
         stored_id = await db.get_setting("tg_api_id")
         stored_hash = await db.get_setting("tg_api_hash")
@@ -58,6 +70,10 @@ async def _run_export_session(args: argparse.Namespace, db: Database) -> None:
     ONLY on this explicit request and is NEVER logged. Selects by ``--id`` or ``--phone``
     (exactly one). Decrypts only the chosen account, so a broken sibling session can't
     abort the lookup — this is the recovery path operators reach for.
+
+    Operates on a caller-supplied ``db`` so the #1143 unit tests can drive it with an
+    in-memory database; :func:`export_session_impl` is the Typer entry point that opens
+    a DB first. Business logic is unchanged from the pre-Typer version (#1123).
     """
     account_id = getattr(args, "id", None)
     phone = getattr(args, "phone", None)
@@ -100,6 +116,9 @@ async def _run_import(args: argparse.Namespace, db: Database) -> None:
     Validates the session via the telegram layer (CLI must not import telethon directly),
     then takes the normal ``add_account`` path — the repository encrypts at rest as usual.
     The raw session string is never echoed back or logged.
+
+    Operates on a caller-supplied ``db`` (see :func:`_run_export_session`); the Typer
+    entry point is :func:`import_impl`. Business logic unchanged from pre-Typer (#1123).
     """
     phone = getattr(args, "phone", None)
     session_string = _read_session_arg(args)
@@ -146,258 +165,408 @@ def _read_session_arg(args: argparse.Namespace) -> str | None:
     return value.strip() if value else None
 
 
-def run(args: argparse.Namespace) -> None:
-    async def _run() -> None:
-        config, db = await runtime.init_db(args.config)
-        pool = None
+async def export_session_impl(
+    config_path: str, *, account_id: int | None = None, phone: str | None = None, as_json: bool = False
+) -> None:
+    """Typer entry point for SSO export — opens a DB then delegates to the core (#828)."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        ns = argparse.Namespace(id=account_id, phone=phone, json=as_json)
+        await _run_export_session(ns, db)
+    finally:
+        await db.close()
+
+
+async def import_impl(
+    config_path: str,
+    *,
+    phone: str | None,
+    session_string: str | None = None,
+    session_string_stdin: bool = False,
+    force: bool = False,
+) -> None:
+    """Typer entry point for SSO import — opens a DB then delegates to the core (#828)."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        ns = argparse.Namespace(
+            phone=phone,
+            session_string=session_string,
+            session_string_stdin=session_string_stdin,
+            force=force,
+        )
+        await _run_import(ns, db)
+    finally:
+        await db.close()
+
+
+async def send_code_impl(
+    config_path: str, *, phone: str, api_id: int | None = None, api_hash: str | None = None
+) -> None:
+    """Send a Telegram auth code to *phone* and stash the pending-auth state."""
+    config, db = await runtime.init_db(config_path)
+    try:
+        api_id, api_hash = await _resolve_credentials(config, db, api_id=api_id, api_hash=api_hash)
+        if api_id == 0 or not api_hash:
+            print("ERROR: API credentials not configured.")
+            print("Provide --api-id and --api-hash, or set them in config/DB.")
+            return
+
+        auth = TelegramAuth(api_id, api_hash)
         try:
-            if args.account_action == "add":
-                args.account_action = "verify-code" if getattr(args, "code", None) else "send-code"
+            info = await auth.send_code(phone)
+        except Exception as exc:
+            await auth.cleanup()
+            print(f"Error sending auth code: {exc}")
+            return
 
-            if args.account_action == "export-session":
-                await _run_export_session(args, db)
-                return
+        await db.set_setting(_pending_key(phone), json.dumps(info))
+        await auth.cleanup()
+        code_type = info.get("code_type", "Telegram")
+        print(f"Code sent to {phone} via {code_type}.")
+        print(f"Run: account verify-code --phone {phone} --code CODE")
+    finally:
+        await db.close()
 
-            if args.account_action == "import":
-                await _run_import(args, db)
-                return
 
-            if args.account_action == "send-code":
-                phone = args.phone
-                api_id, api_hash = await _resolve_credentials(args, config, db)
-                if api_id == 0 or not api_hash:
-                    print("ERROR: API credentials not configured.")
-                    print("Provide --api-id and --api-hash, or set them in config/DB.")
-                    return
+async def verify_code_impl(
+    config_path: str,
+    *,
+    phone: str,
+    code: str,
+    password: str | None = None,
+    api_id: int | None = None,
+    api_hash: str | None = None,
+) -> None:
+    """Verify a Telegram auth code and persist the freshly authenticated account."""
+    config, db = await runtime.init_db(config_path)
+    pool = None
+    try:
+        password_2fa = password or None
 
-                auth = TelegramAuth(api_id, api_hash)
+        pending_raw = await db.get_setting(_pending_key(phone))
+        if not pending_raw:
+            print(f"ERROR: No pending auth for {phone}. Run 'account send-code' first.")
+            return
+        pending = json.loads(pending_raw)
+        phone_code_hash = pending["phone_code_hash"]
+
+        api_id, api_hash = await _resolve_credentials(config, db, api_id=api_id, api_hash=api_hash)
+        if api_id == 0 or not api_hash:
+            print("ERROR: API credentials not configured.")
+            return
+
+        auth = TelegramAuth(api_id, api_hash)
+        try:
+            session_string = await auth.sign_in_fresh(
+                phone, code, phone_code_hash,
+                session_str=pending.get("session_str", ""),
+                password_2fa=password_2fa,
+                code_consumed=pending.get("code_consumed", False),
+            )
+        except ValueError as exc:
+            if "2FA" in str(exc) or "password" in str(exc).lower():
+                pending["code_consumed"] = True
+                await db.set_setting(_pending_key(phone), json.dumps(pending))
+                print(f"2FA required. Re-run with --code {code} --password YOUR_2FA_PASSWORD")
+            else:
+                print(f"Auth failed: {exc}")
+            return
+        except Exception as exc:
+            print(f"Auth failed: {exc}")
+            return
+
+        existing = await db.get_account_summaries(active_only=False)
+        is_primary = len(existing) == 0
+
+        # Persist the freshly authenticated session to the DB FIRST, before
+        # warming the in-memory pool (#449). The inverse order — pool first,
+        # DB second — loses the session string permanently if anything between
+        # the two calls fails (network, process kill): the pool is rebuilt from
+        # the DB on restart, so an unpersisted client vanishes. Premium status
+        # is a best-effort enrichment updated afterwards.
+        account = Account(
+            phone=phone,
+            session_string=session_string,
+            is_primary=is_primary,
+            is_premium=False,
+        )
+        await db.add_account(account)
+
+        # Clear the pending-auth key only AFTER the account is durably
+        # persisted (#449). Clearing it before add_account opened a data-loss
+        # window: a crash between the two autocommit writes would leave no
+        # pending key AND no account, so a verify-code retry would hit the
+        # "No pending auth" guard above with the session gone. add_account is
+        # an idempotent ON CONFLICT(phone) upsert, so a retry after a crash
+        # between sign-in and this point safely re-persists the same session.
+        await db.set_setting(_pending_key(phone), "")
+
+        is_premium = False
+        try:
+            _, pool = await runtime.init_pool(config, db)
+            await pool.add_client(phone, session_string)
+            acquired = await pool.get_client_by_phone(phone)
+            if acquired:
+                session, acquired_phone = acquired
                 try:
-                    info = await auth.send_code(phone)
-                except Exception as exc:
-                    await auth.cleanup()
-                    print(f"Error sending auth code: {exc}")
-                    return
+                    me = await session.fetch_me()
+                    is_premium = bool(getattr(me, "premium", False))
+                except Exception:
+                    pass
+                finally:
+                    await pool.release_client(acquired_phone)
+            if is_premium:
+                await db.update_account_premium(phone, is_premium)
+        except Exception as exc:
+            print(
+                f"Account {phone} saved, but pool warm-up failed "
+                f"(premium unknown): {exc}"
+            )
 
-                await db.set_setting(_pending_key(phone), json.dumps(info))
-                await auth.cleanup()
-                code_type = info.get("code_type", "Telegram")
-                print(f"Code sent to {phone} via {code_type}.")
-                print(f"Run: account verify-code --phone {phone} --code CODE")
-                return
+        print(f"Account {phone} added successfully (primary={is_primary}).")
+    finally:
+        if pool is not None:
+            await pool.disconnect_all()
+        await db.close()
 
-            elif args.account_action == "verify-code":
-                phone = args.phone
-                code = args.code
-                password_2fa = getattr(args, "password", None) or None
 
-                pending_raw = await db.get_setting(_pending_key(phone))
-                if not pending_raw:
-                    print(f"ERROR: No pending auth for {phone}. Run 'account send-code' first.")
-                    return
-                pending = json.loads(pending_raw)
-                phone_code_hash = pending["phone_code_hash"]
+async def info_impl(config_path: str, *, phone: str | None = None) -> None:
+    """Show profile info plus live diagnostics for connected accounts."""
+    config, db = await runtime.init_db(config_path)
+    pool = None
+    try:
+        phone_filter = phone or None
+        _, pool = await runtime.init_pool(
+            config, db, phones=(phone_filter,) if phone_filter else None
+        )
+        ctx = AgentRuntimeContext.build(db=db, config=config, client_pool=pool)
+        print(await get_live_account_info_text(ctx, phone_filter or ""))
+    finally:
+        if pool is not None:
+            await pool.disconnect_all()
+        await db.close()
 
-                api_id, api_hash = await _resolve_credentials(args, config, db)
-                if api_id == 0 or not api_hash:
-                    print("ERROR: API credentials not configured.")
-                    return
 
-                auth = TelegramAuth(api_id, api_hash)
-                try:
-                    session_string = await auth.sign_in_fresh(
-                    phone, code, phone_code_hash,
-                    session_str=pending.get("session_str", ""),
-                    password_2fa=password_2fa,
-                    code_consumed=pending.get("code_consumed", False),
+async def list_impl(config_path: str) -> None:
+    """List all accounts with primary/active/premium status."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        accounts = await db.get_account_summaries(active_only=False)
+        if not accounts:
+            print("No accounts found.")
+            return
+        fmt = "{:<5} {:<16} {:<9} {:<8} {:<8}"
+        print(fmt.format("ID", "Phone", "Primary", "Active", "Premium"))
+        print("-" * 50)
+        for acc in accounts:
+            print(
+                fmt.format(
+                    acc.id or 0,
+                    acc.phone,
+                    "Yes" if acc.is_primary else "No",
+                    "Yes" if acc.is_active else "No",
+                    "Yes" if acc.is_premium else "No",
                 )
-                except ValueError as exc:
-                    if "2FA" in str(exc) or "password" in str(exc).lower():
-                        pending["code_consumed"] = True
-                        await db.set_setting(_pending_key(phone), json.dumps(pending))
-                        print(f"2FA required. Re-run with --code {code} --password YOUR_2FA_PASSWORD")
-                    else:
-                        print(f"Auth failed: {exc}")
-                    return
-                except Exception as exc:
-                    print(f"Auth failed: {exc}")
-                    return
+            )
+    finally:
+        await db.close()
 
-                existing = await db.get_account_summaries(active_only=False)
-                is_primary = len(existing) == 0
 
-                # Persist the freshly authenticated session to the DB FIRST, before
-                # warming the in-memory pool (#449). The inverse order — pool first,
-                # DB second — loses the session string permanently if anything between
-                # the two calls fails (network, process kill): the pool is rebuilt from
-                # the DB on restart, so an unpersisted client vanishes. Premium status
-                # is a best-effort enrichment updated afterwards.
-                account = Account(
-                    phone=phone,
-                    session_string=session_string,
-                    is_primary=is_primary,
-                    is_premium=False,
-                )
-                await db.add_account(account)
+async def toggle_impl(config_path: str, *, account_id: int) -> None:
+    """Toggle an account's active state."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        accounts = await db.get_account_summaries(active_only=False)
+        acc = next((a for a in accounts if a.id == account_id), None)
+        if not acc:
+            print(f"Account id={account_id} not found")
+            return
+        new_state = not acc.is_active
+        await db.set_account_active(account_id, new_state)
+        print(f"Account id={account_id} ({acc.phone}): active={new_state}")
+    finally:
+        await db.close()
 
-                # Clear the pending-auth key only AFTER the account is durably
-                # persisted (#449). Clearing it before add_account opened a data-loss
-                # window: a crash between the two autocommit writes would leave no
-                # pending key AND no account, so a verify-code retry would hit the
-                # "No pending auth" guard above with the session gone. add_account is
-                # an idempotent ON CONFLICT(phone) upsert, so a retry after a crash
-                # between sign-in and this point safely re-persists the same session.
-                await db.set_setting(_pending_key(phone), "")
 
-                is_premium = False
-                try:
-                    _, pool = await runtime.init_pool(config, db)
-                    await pool.add_client(phone, session_string)
-                    acquired = await pool.get_client_by_phone(phone)
-                    if acquired:
-                        session, acquired_phone = acquired
-                        try:
-                            me = await session.fetch_me()
-                            is_premium = bool(getattr(me, "premium", False))
-                        except Exception:
-                            pass
-                        finally:
-                            await pool.release_client(acquired_phone)
-                    if is_premium:
-                        await db.update_account_premium(phone, is_premium)
-                except Exception as exc:
-                    print(
-                        f"Account {phone} saved, but pool warm-up failed "
-                        f"(premium unknown): {exc}"
-                    )
+async def set_primary_impl(config_path: str, *, account_id: int) -> None:
+    """Make an account the primary one."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        changed = await db.repos.accounts.set_account_primary(account_id)
+        if changed:
+            print(f"Account id={account_id} set as primary")
+        else:
+            print(f"Account id={account_id} not found")
+    finally:
+        await db.close()
 
-                print(f"Account {phone} added successfully (primary={is_primary}).")
-                return
 
-            elif args.account_action == "info":
-                phone_filter = getattr(args, "phone", None) or None
-                _, pool = await runtime.init_pool(
-                    config, db, phones=(phone_filter,) if phone_filter else None
-                )
-                ctx = AgentRuntimeContext.build(db=db, config=config, client_pool=pool)
-                print(await get_live_account_info_text(ctx, phone_filter or ""))
-                return
-            if args.account_action == "list":
-                accounts = await db.get_account_summaries(active_only=False)
-                if not accounts:
-                    print("No accounts found.")
-                    return
-                fmt = "{:<5} {:<16} {:<9} {:<8} {:<8}"
-                print(fmt.format("ID", "Phone", "Primary", "Active", "Premium"))
-                print("-" * 50)
-                for acc in accounts:
-                    print(
-                        fmt.format(
-                            acc.id or 0,
-                            acc.phone,
-                            "Yes" if acc.is_primary else "No",
-                            "Yes" if acc.is_active else "No",
-                            "Yes" if acc.is_premium else "No",
-                        )
-                    )
-            elif args.account_action == "toggle":
-                accounts = await db.get_account_summaries(active_only=False)
-                acc = next((a for a in accounts if a.id == args.id), None)
-                if not acc:
-                    print(f"Account id={args.id} not found")
-                    return
-                new_state = not acc.is_active
-                await db.set_account_active(args.id, new_state)
-                print(f"Account id={args.id} ({acc.phone}): active={new_state}")
-            elif args.account_action == "set-primary":
-                changed = await db.repos.accounts.set_account_primary(args.id)
-                if changed:
-                    print(f"Account id={args.id} set as primary")
+async def delete_impl(config_path: str, *, account_id: int, notify_to: str | None = None) -> None:
+    """Delete an account, reassigning the notification target if needed."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        accounts = await db.get_account_summaries(active_only=False)
+        acc = next((a for a in accounts if a.id == account_id), None)
+        if not acc:
+            print(f"Account id={account_id} not found")
+            return
+        target_svc = NotificationTargetService(db)
+        replacement = notify_to
+        configured = await target_svc.get_configured_phone()
+        remaining = [a for a in accounts if a.phone != acc.phone]
+        if (
+            replacement is None
+            and configured == acc.phone
+            and len(remaining) >= 2
+            and sys.stdin.isatty()
+        ):
+            print("Этот аккаунт используется для уведомлений. На какой переназначить?")
+            print("  0. Primary (по умолчанию)")
+            for idx, other in enumerate(remaining, start=1):
+                marker = " [primary]" if other.is_primary else ""
+                print(f"  {idx}. {other.phone}{marker}")
+            try:
+                choice = input("Номер аккаунта [0]: ").strip()
+            except (EOFError, KeyboardInterrupt):
+                choice = ""
+                print()
+            if choice.isdigit() and 1 <= int(choice) <= len(remaining):
+                replacement = remaining[int(choice) - 1].phone
+        try:
+            reassignment = await target_svc.reassign_for_deleted_account(
+                acc.phone, replacement, accounts=accounts
+            )
+        except ValueError as exc:
+            print(f"ERROR: {exc}")
+            print("Аккаунт не удалён.")
+            return
+        await db.delete_account(account_id)
+        print(f"Deleted account id={account_id}")
+        if reassignment.action == "reassigned":
+            print(f"Уведомления переназначены на {reassignment.new_phone}.")
+        elif reassignment.action == "cleared":
+            print("Аккаунт уведомлений сброшен — используется Primary. Подсказка: --notify-to PHONE.")
+    finally:
+        await db.close()
+
+
+async def flood_status_impl(config_path: str) -> None:
+    """Show per-account flood-wait and resolve-backoff timers."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        accounts = await db.get_account_summaries(active_only=False)
+        if not accounts:
+            print("No accounts found.")
+            return
+        now = datetime.now(timezone.utc)
+        resolve_backoffs = await _load_resolve_backoffs(db, now=now)
+        fmt = "{:<16} {:<28} {:<14} {:<18}"
+        print(fmt.format("Phone", "Flood wait until", "Remaining", "Resolve backoff"))
+        print("-" * 78)
+        for acc in accounts:
+            if acc.flood_wait_until is None:
+                until_str = "OK"
+                remaining_str = ""
+            else:
+                flood_until = acc.flood_wait_until
+                if flood_until.tzinfo is None:
+                    flood_until = flood_until.replace(tzinfo=timezone.utc)
+                if flood_until > now:
+                    delta = flood_until - now
+                    remaining_str = f"{int(delta.total_seconds())}s"
+                    until_str = flood_until.strftime("%Y-%m-%d %H:%M:%S UTC")
                 else:
-                    print(f"Account id={args.id} not found")
-            elif args.account_action == "delete":
-                accounts = await db.get_account_summaries(active_only=False)
-                acc = next((a for a in accounts if a.id == args.id), None)
-                if not acc:
-                    print(f"Account id={args.id} not found")
-                    return
-                target_svc = NotificationTargetService(db)
-                replacement = getattr(args, "notify_to", None)
-                configured = await target_svc.get_configured_phone()
-                remaining = [a for a in accounts if a.phone != acc.phone]
-                if (
-                    replacement is None
-                    and configured == acc.phone
-                    and len(remaining) >= 2
-                    and sys.stdin.isatty()
-                ):
-                    print("Этот аккаунт используется для уведомлений. На какой переназначить?")
-                    print("  0. Primary (по умолчанию)")
-                    for idx, other in enumerate(remaining, start=1):
-                        marker = " [primary]" if other.is_primary else ""
-                        print(f"  {idx}. {other.phone}{marker}")
-                    try:
-                        choice = input("Номер аккаунта [0]: ").strip()
-                    except (EOFError, KeyboardInterrupt):
-                        choice = ""
-                        print()
-                    if choice.isdigit() and 1 <= int(choice) <= len(remaining):
-                        replacement = remaining[int(choice) - 1].phone
-                try:
-                    reassignment = await target_svc.reassign_for_deleted_account(
-                        acc.phone, replacement, accounts=accounts
-                    )
-                except ValueError as exc:
-                    print(f"ERROR: {exc}")
-                    print("Аккаунт не удалён.")
-                    return
-                await db.delete_account(args.id)
-                print(f"Deleted account id={args.id}")
-                if reassignment.action == "reassigned":
-                    print(f"Уведомления переназначены на {reassignment.new_phone}.")
-                elif reassignment.action == "cleared":
-                    print("Аккаунт уведомлений сброшен — используется Primary. Подсказка: --notify-to PHONE.")
-            elif args.account_action == "flood-status":
-                accounts = await db.get_account_summaries(active_only=False)
-                if not accounts:
-                    print("No accounts found.")
-                    return
-                now = datetime.now(timezone.utc)
-                resolve_backoffs = await _load_resolve_backoffs(db, now=now)
-                fmt = "{:<16} {:<28} {:<14} {:<18}"
-                print(fmt.format("Phone", "Flood wait until", "Remaining", "Resolve backoff"))
-                print("-" * 78)
-                for acc in accounts:
-                    if acc.flood_wait_until is None:
-                        until_str = "OK"
-                        remaining_str = ""
-                    else:
-                        flood_until = acc.flood_wait_until
-                        if flood_until.tzinfo is None:
-                            flood_until = flood_until.replace(tzinfo=timezone.utc)
-                        if flood_until > now:
-                            delta = flood_until - now
-                            remaining_str = f"{int(delta.total_seconds())}s"
-                            until_str = flood_until.strftime("%Y-%m-%d %H:%M:%S UTC")
-                        else:
-                            until_str = "OK (expired)"
-                            remaining_str = ""
-                    resolve_until = resolve_backoffs.get(acc.phone)
-                    if resolve_until is None:
-                        resolve_str = ""
-                    else:
-                        resolve_str = f"{int((resolve_until - now).total_seconds())}s"
-                    print(fmt.format(acc.phone, until_str, remaining_str, resolve_str))
-            elif args.account_action == "flood-clear":
-                accounts = await db.get_account_summaries(active_only=False)
-                acc = next((a for a in accounts if a.phone == args.phone), None)
-                if not acc:
-                    print(f"Account {args.phone} not found")
-                    return
-                await db.update_account_flood(args.phone, None)
-                print(f"Flood wait cleared for {args.phone}")
-        finally:
-            if pool:
-                await pool.disconnect_all()
-            await db.close()
+                    until_str = "OK (expired)"
+                    remaining_str = ""
+            resolve_until = resolve_backoffs.get(acc.phone)
+            if resolve_until is None:
+                resolve_str = ""
+            else:
+                resolve_str = f"{int((resolve_until - now).total_seconds())}s"
+            print(fmt.format(acc.phone, until_str, remaining_str, resolve_str))
+    finally:
+        await db.close()
 
-    asyncio.run(_run())
+
+async def flood_clear_impl(config_path: str, *, phone: str) -> None:
+    """Clear the flood-wait timer for an account."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        accounts = await db.get_account_summaries(active_only=False)
+        acc = next((a for a in accounts if a.phone == phone), None)
+        if not acc:
+            print(f"Account {phone} not found")
+            return
+        await db.update_account_flood(phone, None)
+        print(f"Flood wait cleared for {phone}")
+    finally:
+        await db.close()
+
+
+def run(args: argparse.Namespace) -> None:
+    """Thin argparse adapter over the ``*_impl`` bodies (legacy dispatch path).
+
+    The production CLI routes ``account`` through the Typer ``app`` (#1123); this
+    wrapper keeps the argparse leaf audit and command-level tests working. The
+    ``add`` alias still resolves to send-code / verify-code based on ``--code``.
+    Args are read via ``getattr`` defaults so partial test Namespaces stay usable
+    (#1117).
+    """
+    action = getattr(args, "account_action", None)
+    # ``add`` is a compatibility alias: with a code it verifies, otherwise it sends.
+    if action == "add":
+        action = "verify-code" if getattr(args, "code", None) else "send-code"
+
+    if action == "export-session":
+        asyncio.run(
+            export_session_impl(
+                args.config,
+                account_id=getattr(args, "id", None),
+                phone=getattr(args, "phone", None),
+                as_json=getattr(args, "json", False),
+            )
+        )
+    elif action == "import":
+        asyncio.run(
+            import_impl(
+                args.config,
+                phone=getattr(args, "phone", None),
+                session_string=getattr(args, "session_string", None),
+                session_string_stdin=getattr(args, "session_string_stdin", False),
+                force=getattr(args, "force", False),
+            )
+        )
+    elif action == "send-code":
+        asyncio.run(
+            send_code_impl(
+                args.config,
+                phone=args.phone,
+                api_id=getattr(args, "api_id", None),
+                api_hash=getattr(args, "api_hash", None),
+            )
+        )
+    elif action == "verify-code":
+        asyncio.run(
+            verify_code_impl(
+                args.config,
+                phone=args.phone,
+                code=args.code,
+                password=getattr(args, "password", None),
+                api_id=getattr(args, "api_id", None),
+                api_hash=getattr(args, "api_hash", None),
+            )
+        )
+    elif action == "info":
+        asyncio.run(info_impl(args.config, phone=getattr(args, "phone", None)))
+    elif action == "list":
+        asyncio.run(list_impl(args.config))
+    elif action == "toggle":
+        asyncio.run(toggle_impl(args.config, account_id=args.id))
+    elif action == "set-primary":
+        asyncio.run(set_primary_impl(args.config, account_id=args.id))
+    elif action == "delete":
+        asyncio.run(delete_impl(args.config, account_id=args.id, notify_to=getattr(args, "notify_to", None)))
+    elif action == "flood-status":
+        asyncio.run(flood_status_impl(args.config))
+    elif action == "flood-clear":
+        asyncio.run(flood_clear_impl(args.config, phone=args.phone))

--- a/src/cli/commands/agent.py
+++ b/src/cli/commands/agent.py
@@ -1,3 +1,15 @@
+"""Shared async bodies for the ``agent`` CLI group (epic #959, Wave 3 — #1123).
+
+Migrated off the argparse dispatcher onto the Typer ``app`` (see
+``src/cli/typer_commands.py``). Each leaf sub-command is a plain ``async def
+*_impl`` here — no local ``asyncio.run`` and no ``argparse.Namespace``. A thin
+``run(args)`` adapter is kept for the argparse leaf audit and existing tests.
+
+``test-escaping`` / ``test-tools`` and the ``chat`` streaming flow are delicate
+(agent backend, StringSession-bound state); only the argparse→Typer wiring
+changed — the streaming/escaping logic is preserved verbatim.
+"""
+
 from __future__ import annotations
 
 import argparse
@@ -151,216 +163,327 @@ async def _test_tools(db, config) -> None:
         sys.exit(1)
 
 
-def run(args: argparse.Namespace) -> None:
-    async def _run() -> None:
-        removed_log_handler = None
-        action = args.agent_action
-        if action == "chat":
-            removed_log_handler = runtime.redirect_logging_to_file()
-        config, db = await runtime.init_db(args.config)
-        auth = pool = mgr = None
-        try:
+async def threads_impl(config_path: str) -> None:
+    """List agent threads."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        threads = await db.get_agent_threads()
+        if not threads:
+            print("Нет тредов.")
+        else:
+            for t in threads:
+                print(f"[{t['id']}] {t['title']}  ({t['created_at']})")
+    finally:
+        await db.close()
 
-            if action == "threads":
-                threads = await db.get_agent_threads()
-                if not threads:
-                    print("Нет тредов.")
-                else:
-                    for t in threads:
-                        print(f"[{t['id']}] {t['title']}  ({t['created_at']})")
 
-            elif action == "thread-create":
-                title = getattr(args, "title", None) or "Новый тред"
-                tid = await db.create_agent_thread(title)
-                print(f"Создан тред #{tid}: {title}")
+async def thread_create_impl(config_path: str, *, title: str | None = None) -> None:
+    """Create a new agent thread."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        title = title or "Новый тред"
+        tid = await db.create_agent_thread(title)
+        print(f"Создан тред #{tid}: {title}")
+    finally:
+        await db.close()
 
-            elif action == "thread-delete":
-                await db.delete_agent_thread(args.thread_id)
-                print(f"Тред #{args.thread_id} удалён.")
 
-            elif action == "chat":
-                from src.agent.manager import AgentManager
+async def thread_delete_impl(config_path: str, *, thread_id: int) -> None:
+    """Delete an agent thread."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        await db.delete_agent_thread(thread_id)
+        print(f"Тред #{thread_id} удалён.")
+    finally:
+        await db.close()
 
-                auth, pool = await runtime.init_pool(config, db)
-                mgr = AgentManager(db, config, client_pool=pool)
-                await mgr.refresh_settings_cache(preflight=True)
-                mgr.initialize()
 
-                if args.prompt:
-                    if args.thread_id:
-                        thread_id = args.thread_id
-                    else:
-                        thread_id = await db.create_agent_thread("Новый тред")
-                        print(f"(создан тред #{thread_id})")
+async def chat_impl(
+    config_path: str,
+    *,
+    prompt: str | None = None,
+    thread_id: int | None = None,
+    model: str | None = None,
+) -> None:
+    """Interactive TUI chat, or a one-shot message when ``prompt`` is given."""
+    from src.agent.manager import AgentManager
 
-                    await db.save_agent_message(thread_id, "user", args.prompt)
+    # chat streams to stdout; move log noise to a file so it doesn't interleave.
+    removed_log_handler = runtime.redirect_logging_to_file()
+    config, db = await runtime.init_db(config_path)
+    auth = pool = mgr = None
+    try:
+        auth, pool = await runtime.init_pool(config, db)
+        mgr = AgentManager(db, config, client_pool=pool)
+        await mgr.refresh_settings_cache(preflight=True)
+        mgr.initialize()
 
-                    model = getattr(args, "model", None)
-                    full_text = ""
-                    text_started = False
-                    inline_status = False  # True when \r status is on screen
-                    async for chunk in mgr.chat_stream(thread_id, args.prompt, model=model):
-                        raw = chunk.removeprefix("data: ").strip()
-                        try:
-                            payload = json.loads(raw)
-                        except Exception:
-                            continue
-                        event_type = payload.get("type")
-                        if event_type in ("status", "countdown"):
-                            if not text_started:
-                                text = payload.get("text", "")
-                                print(f"\r⏳ {text:<60}",
-                                      end="", file=sys.stderr, flush=True)
-                                inline_status = True
-                            continue
-                        # Clear inline status before any other output
-                        if inline_status:
-                            print(f"\r{' ' * 64}\r",
-                                  end="", file=sys.stderr, flush=True)
-                            inline_status = False
-                        if event_type == "tool_start":
-                            print(f"🔧 {payload.get('tool', 'tool')}...",
-                                  file=sys.stderr, flush=True)
-                            continue
-                        if event_type == "tool_end":
-                            tool = payload.get("tool", "tool")
-                            dur = payload.get("duration", 0)
-                            icon = "❌" if payload.get("is_error") else "✅"
-                            summary = payload.get("summary", "")
-                            line = f"  {icon} {tool} ({dur}s)"
-                            if summary:
-                                line += f" — {summary}"
-                            print(line, file=sys.stderr, flush=True)
-                            continue
-                        if event_type in ("thinking", "tool_result"):
-                            continue
-                        if "text" in payload:
-                            if not text_started:
-                                print("Агент: ", end="", flush=True)
-                                text_started = True
-                            print(payload["text"], end="", flush=True)
-                            full_text += payload.get("text", "")
-                        if payload.get("done"):
-                            print()
-                            break
-                        if "error" in payload:
-                            print(f"\nОшибка: {payload['error']}")
-                            if payload.get("details"):
-                                print(f"Детали: {payload['details']}", file=sys.stderr)
-                            await db.delete_last_agent_exchange(thread_id)
-                            break
+        if prompt:
+            if thread_id:
+                resolved_thread_id = thread_id
+            else:
+                resolved_thread_id = await db.create_agent_thread("Новый тред")
+                print(f"(создан тред #{resolved_thread_id})")
 
-                    if full_text:
-                        await db.save_agent_message(thread_id, "assistant", full_text)
-                else:
-                    # Interactive TUI mode
-                    from src.cli.commands.agent_tui import AgentTuiApp
+            await db.save_agent_message(resolved_thread_id, "user", prompt)
 
-                    app = AgentTuiApp(db=db, config=config, agent_manager=mgr)
-                    await app.run_async()
-
-            elif action == "thread-rename":
-                await db.rename_agent_thread(args.thread_id, args.title[:100])
-                print(f"Тред #{args.thread_id} переименован: {args.title[:100]}")
-
-            elif action == "thread-stop":
-                from src.agent.manager import AgentManager
-
-                mgr = AgentManager(db, config)
-                cancelled = await mgr.cancel_stream(args.thread_id)
-                if cancelled:
-                    # Only safe to delete once we've actually cancelled the in-process
-                    # task. A fresh CLI AgentManager has an empty _active_tasks, so a
-                    # stream running in the web/worker process is NOT cancelled here;
-                    # deleting the last exchange then races that stream, which could
-                    # persist an assistant reply with no preceding user message. (#737)
-                    await db.delete_last_agent_exchange(args.thread_id)
-                    print(f"Тред #{args.thread_id}: генерация остановлена; последний обмен удалён.")
-                else:
-                    print(
-                        f"Тред #{args.thread_id}: активной генерации в этом процессе нет "
-                        "(возможно, выполняется в worker/web). Обмен не удалён, чтобы не "
-                        "осиротить ответ всё ещё работающего стрима."
-                    )
-
-            elif action == "messages":
-                msgs = await db.get_agent_messages(args.thread_id)
-                if args.limit:
-                    msgs = msgs[-args.limit :]
-                if not msgs:
-                    print("Нет сообщений.")
-                else:
-                    for m in msgs:
-                        role = "user" if m["role"] == "user" else "assistant"
-                        preview = m["content"][:200].replace("\n", "\\n")
-                        print(f"  [{role}] [{m['created_at']}] {preview}")
-
-            elif action == "context":
-                thread = await db.get_agent_thread(args.thread_id)
-                if thread is None:
-                    print(f"Тред #{args.thread_id} не найден.")
-                    return
-
-                messages, _ = await db.search_messages(
-                    query="",
-                    channel_id=args.channel_id,
-                    limit=args.limit,
-                    topic_id=args.topic_id,
-                )
-                ch = await db.get_channel_by_channel_id(args.channel_id)
-                title = ch.title if ch else str(args.channel_id)
-
-                topics = await db.get_forum_topics(args.channel_id)
-                topics_map = {t["id"]: t["title"] for t in topics}
-
-                from src.agent.context import format_context
-
-                content = format_context(messages, title, args.topic_id, topics_map)
-
-                await db.save_agent_message(thread_id=args.thread_id, role="user", content=content)
-                logger.info(
-                    "Context loaded for thread %d: %d messages, %d chars",
-                    args.thread_id,
-                    len(messages),
-                    len(content),
-                )
-                if len(content) > 200_000:
-                    logger.warning(
-                        "Large context for thread %d: %d chars (>200K)"
-                        " — may cause prompt overflow",
-                        args.thread_id,
-                        len(content),
-                    )
-                print(content[:500])
-                if len(content) > 500:
-                    print(f"... ({len(content)} символов всего)")
-
-            elif action == "test-escaping":
-                await _test_escaping(db, config)
-
-            elif action == "test-tools":
-                await _test_tools(db, config)
-        finally:
-            if mgr is not None:
+            full_text = ""
+            text_started = False
+            inline_status = False  # True when \r status is on screen
+            async for chunk in mgr.chat_stream(resolved_thread_id, prompt, model=model):
+                raw = chunk.removeprefix("data: ").strip()
                 try:
-                    await mgr.close_all()
+                    payload = json.loads(raw)
                 except Exception:
-                    logger.debug("Failed to close agent manager", exc_info=True)
-            if pool is not None:
-                try:
-                    await pool.disconnect_all()
-                except Exception:
-                    logger.debug("Failed to disconnect pool", exc_info=True)
-            if auth is not None:
-                try:
-                    await auth.cleanup()
-                except Exception:
-                    logger.debug("Failed to cleanup auth", exc_info=True)
+                    continue
+                event_type = payload.get("type")
+                if event_type in ("status", "countdown"):
+                    if not text_started:
+                        text = payload.get("text", "")
+                        print(f"\r⏳ {text:<60}",
+                              end="", file=sys.stderr, flush=True)
+                        inline_status = True
+                    continue
+                # Clear inline status before any other output
+                if inline_status:
+                    print(f"\r{' ' * 64}\r",
+                          end="", file=sys.stderr, flush=True)
+                    inline_status = False
+                if event_type == "tool_start":
+                    print(f"🔧 {payload.get('tool', 'tool')}...",
+                          file=sys.stderr, flush=True)
+                    continue
+                if event_type == "tool_end":
+                    tool = payload.get("tool", "tool")
+                    dur = payload.get("duration", 0)
+                    icon = "❌" if payload.get("is_error") else "✅"
+                    summary = payload.get("summary", "")
+                    line = f"  {icon} {tool} ({dur}s)"
+                    if summary:
+                        line += f" — {summary}"
+                    print(line, file=sys.stderr, flush=True)
+                    continue
+                if event_type in ("thinking", "tool_result"):
+                    continue
+                if "text" in payload:
+                    if not text_started:
+                        print("Агент: ", end="", flush=True)
+                        text_started = True
+                    print(payload["text"], end="", flush=True)
+                    full_text += payload.get("text", "")
+                if payload.get("done"):
+                    print()
+                    break
+                if "error" in payload:
+                    print(f"\nОшибка: {payload['error']}")
+                    if payload.get("details"):
+                        print(f"Детали: {payload['details']}", file=sys.stderr)
+                    await db.delete_last_agent_exchange(resolved_thread_id)
+                    break
+
+            if full_text:
+                await db.save_agent_message(resolved_thread_id, "assistant", full_text)
+        else:
+            # Interactive TUI mode
+            from src.cli.commands.agent_tui import AgentTuiApp
+
+            app = AgentTuiApp(db=db, config=config, agent_manager=mgr)
+            await app.run_async()
+    finally:
+        if mgr is not None:
             try:
-                await db.close()
+                await mgr.close_all()
             except Exception:
-                logger.debug("Failed to close database", exc_info=True)
-            if removed_log_handler is not None:
-                runtime.restore_logging(removed_log_handler)
+                logger.debug("Failed to close agent manager", exc_info=True)
+        if pool is not None:
+            try:
+                await pool.disconnect_all()
+            except Exception:
+                logger.debug("Failed to disconnect pool", exc_info=True)
+        if auth is not None:
+            try:
+                await auth.cleanup()
+            except Exception:
+                logger.debug("Failed to cleanup auth", exc_info=True)
+        try:
+            await db.close()
+        except Exception:
+            logger.debug("Failed to close database", exc_info=True)
+        if removed_log_handler is not None:
+            runtime.restore_logging(removed_log_handler)
 
-    asyncio.run(_run())
+
+async def thread_rename_impl(config_path: str, *, thread_id: int, title: str) -> None:
+    """Rename an agent thread."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        await db.rename_agent_thread(thread_id, title[:100])
+        print(f"Тред #{thread_id} переименован: {title[:100]}")
+    finally:
+        await db.close()
+
+
+async def thread_stop_impl(config_path: str, *, thread_id: int) -> None:
+    """Stop/cancel an ongoing agent response for a thread."""
+    from src.agent.manager import AgentManager
+
+    config, db = await runtime.init_db(config_path)
+    mgr = None
+    try:
+        mgr = AgentManager(db, config)
+        cancelled = await mgr.cancel_stream(thread_id)
+        if cancelled:
+            # Only safe to delete once we've actually cancelled the in-process
+            # task. A fresh CLI AgentManager has an empty _active_tasks, so a
+            # stream running in the web/worker process is NOT cancelled here;
+            # deleting the last exchange then races that stream, which could
+            # persist an assistant reply with no preceding user message. (#737)
+            await db.delete_last_agent_exchange(thread_id)
+            print(f"Тред #{thread_id}: генерация остановлена; последний обмен удалён.")
+        else:
+            print(
+                f"Тред #{thread_id}: активной генерации в этом процессе нет "
+                "(возможно, выполняется в worker/web). Обмен не удалён, чтобы не "
+                "осиротить ответ всё ещё работающего стрима."
+            )
+    finally:
+        if mgr is not None:
+            try:
+                await mgr.close_all()
+            except Exception:
+                logger.debug("Failed to close agent manager", exc_info=True)
+        await db.close()
+
+
+async def messages_impl(config_path: str, *, thread_id: int, limit: int | None = None) -> None:
+    """Show messages in an agent thread."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        msgs = await db.get_agent_messages(thread_id)
+        if limit:
+            msgs = msgs[-limit:]
+        if not msgs:
+            print("Нет сообщений.")
+        else:
+            for m in msgs:
+                role = "user" if m["role"] == "user" else "assistant"
+                preview = m["content"][:200].replace("\n", "\\n")
+                print(f"  [{role}] [{m['created_at']}] {preview}")
+    finally:
+        await db.close()
+
+
+async def context_impl(
+    config_path: str,
+    *,
+    thread_id: int,
+    channel_id: int,
+    limit: int = 100000,
+    topic_id: int | None = None,
+) -> None:
+    """Inject channel context (messages) into an agent thread."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        thread = await db.get_agent_thread(thread_id)
+        if thread is None:
+            print(f"Тред #{thread_id} не найден.")
+            return
+
+        messages, _ = await db.search_messages(
+            query="",
+            channel_id=channel_id,
+            limit=limit,
+            topic_id=topic_id,
+        )
+        ch = await db.get_channel_by_channel_id(channel_id)
+        title = ch.title if ch else str(channel_id)
+
+        topics = await db.get_forum_topics(channel_id)
+        topics_map = {t["id"]: t["title"] for t in topics}
+
+        from src.agent.context import format_context
+
+        content = format_context(messages, title, topic_id, topics_map)
+
+        await db.save_agent_message(thread_id=thread_id, role="user", content=content)
+        logger.info(
+            "Context loaded for thread %d: %d messages, %d chars",
+            thread_id,
+            len(messages),
+            len(content),
+        )
+        if len(content) > 200_000:
+            logger.warning(
+                "Large context for thread %d: %d chars (>200K)"
+                " — may cause prompt overflow",
+                thread_id,
+                len(content),
+            )
+        print(content[:500])
+        if len(content) > 500:
+            print(f"... ({len(content)} символов всего)")
+    finally:
+        await db.close()
+
+
+async def test_escaping_impl(config_path: str) -> None:
+    """Test agent handling of special characters (delicate — logic unchanged)."""
+    config, db = await runtime.init_db(config_path)
+    try:
+        await _test_escaping(db, config)
+    finally:
+        await db.close()
+
+
+async def test_tools_impl(config_path: str) -> None:
+    """Test that agent tool calls produce tool_start/tool_end events (delicate)."""
+    config, db = await runtime.init_db(config_path)
+    try:
+        await _test_tools(db, config)
+    finally:
+        await db.close()
+
+
+def run(args: argparse.Namespace) -> None:
+    """Thin argparse adapter over the ``*_impl`` bodies (legacy dispatch path).
+
+    The production CLI routes ``agent`` through the Typer ``app`` (#1123); this
+    wrapper keeps the argparse leaf audit and command-level tests working. Args are
+    read via ``getattr`` defaults so partial test Namespaces stay usable (#1117).
+    """
+    action = getattr(args, "agent_action", None)
+    if action == "threads":
+        asyncio.run(threads_impl(args.config))
+    elif action == "thread-create":
+        asyncio.run(thread_create_impl(args.config, title=getattr(args, "title", None)))
+    elif action == "thread-delete":
+        asyncio.run(thread_delete_impl(args.config, thread_id=args.thread_id))
+    elif action == "chat":
+        asyncio.run(
+            chat_impl(
+                args.config,
+                prompt=getattr(args, "prompt", None),
+                thread_id=getattr(args, "thread_id", None),
+                model=getattr(args, "model", None),
+            )
+        )
+    elif action == "thread-rename":
+        asyncio.run(thread_rename_impl(args.config, thread_id=args.thread_id, title=args.title))
+    elif action == "thread-stop":
+        asyncio.run(thread_stop_impl(args.config, thread_id=args.thread_id))
+    elif action == "messages":
+        asyncio.run(messages_impl(args.config, thread_id=args.thread_id, limit=getattr(args, "limit", None)))
+    elif action == "context":
+        asyncio.run(
+            context_impl(
+                args.config,
+                thread_id=args.thread_id,
+                channel_id=args.channel_id,
+                limit=getattr(args, "limit", 100000),
+                topic_id=getattr(args, "topic_id", None),
+            )
+        )
+    elif action == "test-escaping":
+        asyncio.run(test_escaping_impl(args.config))
+    elif action == "test-tools":
+        asyncio.run(test_tools_impl(args.config))

--- a/src/cli/commands/filter.py
+++ b/src/cli/commands/filter.py
@@ -1,3 +1,11 @@
+"""Shared async bodies for the ``filter`` CLI group (epic #959, Wave 3 — #1123).
+
+Migrated off the argparse dispatcher onto the Typer ``app`` (see
+``src/cli/typer_commands.py``). Each leaf sub-command is a plain ``async def
+*_impl`` here — no local ``asyncio.run`` and no ``argparse.Namespace``. A thin
+``run(args)`` adapter is kept for the argparse leaf audit and existing tests.
+"""
+
 from __future__ import annotations
 
 import argparse
@@ -51,167 +59,229 @@ def _print_result(result, verb: str = "Purged") -> None:
             print(f"  ✗ {err}")
 
 
-def run(args: argparse.Namespace) -> None:
-    async def _run() -> None:
-        _, db = await runtime.init_db(args.config)
-        try:
-            analyzer = ChannelAnalyzer(db)
+async def analyze_impl(config_path: str, *, quick: bool = False) -> None:
+    """Analyze channels and print the uniqueness / ratio / flags report."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        analyzer = ChannelAnalyzer(db)
+        report = await analyzer.analyze_all(quick=quick)
+        if not report.results:
+            print("No channels found.")
+            return
 
-            if not args.filter_action:
-                print("Usage: filter {analyze|apply|reset|purge|hard-delete}")
+        fmt = "{:<6} {:<25} {:<10} {:<10} {:<10} {:<10} {:<10} {:<15}"
+        header = ("ChanID", "Title", "Uniq%", "SubRatio", "Cyr%", "Short%", "XDupe%", "Flags")
+        print(fmt.format(*header))
+        print("-" * 100)
+        for r in report.results:
+            flags_str = ", ".join(r.flags) if r.flags else "-"
+            print(
+                fmt.format(
+                    r.channel_id,
+                    (r.title or "-")[:25],
+                    f"{r.uniqueness_pct:.1f}" if r.uniqueness_pct is not None else "-",
+                    f"{r.subscriber_ratio:.2f}" if r.subscriber_ratio is not None else "-",
+                    f"{r.cyrillic_pct:.1f}" if r.cyrillic_pct is not None else "-",
+                    f"{r.short_msg_pct:.1f}" if r.short_msg_pct is not None else "-",
+                    f"{r.cross_dupe_pct:.1f}" if r.cross_dupe_pct is not None else "-",
+                    flags_str[:15],
+                )
+            )
+        print(f"\nTotal: {report.total_channels}, Flagged: {report.filtered_count}")
+    finally:
+        await db.close()
+
+
+async def apply_impl(config_path: str) -> None:
+    """Analyze and mark filtered channels."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        analyzer = ChannelAnalyzer(db)
+        report = await analyzer.analyze_all()
+        count = await analyzer.apply_filters(report)
+        print(f"Applied filters: {count} channels marked as filtered.")
+    finally:
+        await db.close()
+
+
+async def precheck_impl(config_path: str) -> None:
+    """Apply the subscriber-ratio pre-filter (no Telegram needed)."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        analyzer = ChannelAnalyzer(db)
+        count = await analyzer.precheck_subscriber_ratio()
+        print(
+            f"Pre-filter applied: {count} channels marked as filtered"
+            " (low_subscriber_ratio)."
+        )
+    finally:
+        await db.close()
+
+
+async def toggle_impl(config_path: str, *, pk: int) -> None:
+    """Toggle the filter flag for a single channel."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        channel = await db.get_channel_by_pk(pk)
+        if channel is None:
+            print(f"Channel pk={pk} not found.")
+            return
+        new_state = not channel.is_filtered
+        await db.set_channel_filtered(pk, new_state)
+        status = "filtered" if new_state else "unfiltered"
+        print(f"Channel pk={pk} ({channel.title}) marked as {status}.")
+    finally:
+        await db.close()
+
+
+async def reset_impl(config_path: str, *, pks: str | None = None) -> None:
+    """Reset the filter flag for the given PKs, or all channels if none given."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        analyzer = ChannelAnalyzer(db)
+        if pks:
+            pk_list = _parse_pks(pks)
+            if not pk_list:
+                print("No valid PKs provided.")
                 return
+            count = await analyzer.reset_filters_for_pks(pk_list)
+            print(f"Reset filter flag for {count} channel(s).")
+        else:
+            await analyzer.reset_filters()
+            print("All channel filters have been reset.")
+    finally:
+        await db.close()
 
-            if args.filter_action == "analyze":
-                report = await analyzer.analyze_all(quick=getattr(args, "quick", False))
-                if not report.results:
-                    print("No channels found.")
-                    return
 
-                fmt = "{:<6} {:<25} {:<10} {:<10} {:<10} {:<10} {:<10} {:<15}"
-                header = (
-                    "ChanID",
-                    "Title",
-                    "Uniq%",
-                    "SubRatio",
-                    "Cyr%",
-                    "Short%",
-                    "XDupe%",
-                    "Flags",
-                )
-                print(fmt.format(*header))
-                print("-" * 100)
-                for r in report.results:
-                    flags_str = ", ".join(r.flags) if r.flags else "-"
-                    print(
-                        fmt.format(
-                            r.channel_id,
-                            (r.title or "-")[:25],
-                            f"{r.uniqueness_pct:.1f}" if r.uniqueness_pct is not None else "-",
-                            f"{r.subscriber_ratio:.2f}" if r.subscriber_ratio is not None else "-",
-                            f"{r.cyrillic_pct:.1f}" if r.cyrillic_pct is not None else "-",
-                            f"{r.short_msg_pct:.1f}" if r.short_msg_pct is not None else "-",
-                            f"{r.cross_dupe_pct:.1f}" if r.cross_dupe_pct is not None else "-",
-                            flags_str[:15],
-                        )
-                    )
+async def purge_impl(config_path: str, *, pks: str | None = None, yes: bool = False) -> None:
+    """Purge stored messages from filtered channels (confirmation unless --yes)."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        svc = _build_deletion_service(db)
+        pk_list: list[int] | None
+        if pks:
+            pk_list = _parse_pks(pks)
+            if not pk_list:
+                print("No valid PKs provided.")
+                return
+            scope = f"{len(pk_list)} selected channel(s)"
+        else:
+            pk_list = None
+            scope = "all filtered channels"
+        if not yes:
+            confirm = input(
+                f"Purge messages from {scope}? This deletes stored messages. [y/N] "
+            ).strip().lower()
+            if confirm != "y":
+                print("Aborted.")
+                return
+        if pk_list is not None:
+            result = await svc.purge_channels_by_pks(pk_list)
+        else:
+            result = await svc.purge_all_filtered()
+        _print_result(result, "Purged messages from")
+    finally:
+        await db.close()
 
-                print(
-                    f"\nTotal: {report.total_channels}, "
-                    f"Flagged: {report.filtered_count}"
-                )
 
-            elif args.filter_action == "apply":
-                report = await analyzer.analyze_all()
-                count = await analyzer.apply_filters(report)
-                print(f"Applied filters: {count} channels marked as filtered.")
+async def purge_messages_impl(config_path: str, *, channel_id: int, yes: bool = False) -> None:
+    """Delete all stored messages for a specific channel id (confirmation unless --yes)."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        channels = await db.get_channels()
+        ch = next((c for c in channels if c.channel_id == channel_id), None)
+        title = ch.title if ch else str(channel_id)
+        if not yes:
+            confirm = input(
+                f"Delete all messages for channel {title} ({channel_id}) from DB? [y/N] "
+            ).strip().lower()
+            if confirm != "y":
+                print("Aborted.")
+                return
+        count = await db.delete_messages_for_channel(channel_id)
+        print(f"Deleted {count} messages for channel {title} ({channel_id}).")
+    finally:
+        await db.close()
 
-            elif args.filter_action == "precheck":
-                count = await analyzer.precheck_subscriber_ratio()
-                print(
-                    f"Pre-filter applied: {count} channels marked as filtered"
-                    " (low_subscriber_ratio)."
-                )
 
-            elif args.filter_action == "toggle":
-                channel = await db.get_channel_by_pk(args.pk)
-                if channel is None:
-                    print(f"Channel pk={args.pk} not found.")
-                    return
-                new_state = not channel.is_filtered
-                await db.set_channel_filtered(args.pk, new_state)
-                status = "filtered" if new_state else "unfiltered"
-                print(f"Channel pk={args.pk} ({channel.title}) marked as {status}.")
+async def hard_delete_impl(config_path: str, *, pks: str | None = None, yes: bool = False) -> None:
+    """Hard-delete filtered channels from the DB (dev mode; irreversible)."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        dev_mode = (await db.get_setting("agent_dev_mode_enabled") or "0") == "1"
+        if not dev_mode:
+            print(
+                "Hard-delete requires developer mode. "
+                "Enable it in Settings → Developer mode."
+            )
+            return
+        svc = _build_deletion_service(db)
+        if pks:
+            pk_list = _parse_pks(pks)
+            if not pk_list:
+                print("No valid PKs provided.")
+                return
+        else:
+            channels = await db.get_channels_with_counts(
+                active_only=False,
+                include_filtered=True,
+            )
+            pk_list = [ch.id for ch in channels if ch.is_filtered and ch.id is not None]
+            if not pk_list:
+                print("No filtered channels to delete.")
+                return
+        if not yes:
+            confirm = input(
+                f"Hard-delete {len(pk_list)} channel(s) from DB? "
+                "This is irreversible. Type YES to confirm: "
+            )
+            # The "YES" word is a deliberate stronger barrier than purge's "y" for
+            # this irreversible op, but the comparison is case-insensitive to match
+            # the rest of the confirm gates (#1039) — "yes"/"Yes"/"YES" all confirm;
+            # "y" alone does not.
+            if confirm.strip().lower() != "yes":
+                print("Aborted.")
+                return
+        result = await svc.hard_delete_channels_by_pks(pk_list)
+        _print_result(result, "Hard-deleted")
+    finally:
+        await db.close()
 
-            elif args.filter_action == "reset":
-                if hasattr(args, "pks") and args.pks:
-                    pks = _parse_pks(args.pks)
-                    if not pks:
-                        print("No valid PKs provided.")
-                        return
-                    count = await analyzer.reset_filters_for_pks(pks)
-                    print(f"Reset filter flag for {count} channel(s).")
-                else:
-                    await analyzer.reset_filters()
-                    print("All channel filters have been reset.")
 
-            elif args.filter_action == "purge":
-                svc = _build_deletion_service(db)
-                pks: list[int] | None
-                if hasattr(args, "pks") and args.pks:
-                    pks = _parse_pks(args.pks)
-                    if not pks:
-                        print("No valid PKs provided.")
-                        return
-                    scope = f"{len(pks)} selected channel(s)"
-                else:
-                    pks = None
-                    scope = "all filtered channels"
-                if not getattr(args, "yes", False):
-                    confirm = input(
-                        f"Purge messages from {scope}? This deletes stored messages. [y/N] "
-                    ).strip().lower()
-                    if confirm != "y":
-                        print("Aborted.")
-                        return
-                if pks is not None:
-                    result = await svc.purge_channels_by_pks(pks)
-                else:
-                    result = await svc.purge_all_filtered()
-                _print_result(result, "Purged messages from")
+def run(args: argparse.Namespace) -> None:
+    """Thin argparse adapter over the ``*_impl`` bodies (legacy dispatch path).
 
-            elif args.filter_action == "purge-messages":
-                channel_id = args.channel_id
-                channels = await db.get_channels()
-                ch = next((c for c in channels if c.channel_id == channel_id), None)
-                title = ch.title if ch else str(channel_id)
-                if not getattr(args, "yes", False):
-                    confirm = input(
-                        f"Delete all messages for channel {title} ({channel_id}) from DB? [y/N] "
-                    ).strip().lower()
-                    if confirm != "y":
-                        print("Aborted.")
-                        return
-                count = await db.delete_messages_for_channel(channel_id)
-                print(f"Deleted {count} messages for channel {title} ({channel_id}).")
-
-            elif args.filter_action == "hard-delete":
-                dev_mode = (await db.get_setting("agent_dev_mode_enabled") or "0") == "1"
-                if not dev_mode:
-                    print(
-                        "Hard-delete requires developer mode. "
-                        "Enable it in Settings → Developer mode."
-                    )
-                    return
-                svc = _build_deletion_service(db)
-                if hasattr(args, "pks") and args.pks:
-                    pks = _parse_pks(args.pks)
-                    if not pks:
-                        print("No valid PKs provided.")
-                        return
-                else:
-                    channels = await db.get_channels_with_counts(
-                        active_only=False,
-                        include_filtered=True,
-                    )
-                    pks = [ch.id for ch in channels if ch.is_filtered and ch.id is not None]
-                    if not pks:
-                        print("No filtered channels to delete.")
-                        return
-                if not getattr(args, "yes", False):
-                    confirm = input(
-                        f"Hard-delete {len(pks)} channel(s) from DB? "
-                        "This is irreversible. Type YES to confirm: "
-                    )
-                    # The "YES" word is a deliberate stronger barrier than purge's
-                    # "y" for this irreversible op, but the comparison is
-                    # case-insensitive to match the rest of the confirm gates
-                    # (#1039) — "yes"/"Yes"/"YES" all confirm; "y" alone does not.
-                    if confirm.strip().lower() != "yes":
-                        print("Aborted.")
-                        return
-                result = await svc.hard_delete_channels_by_pks(pks)
-                _print_result(result, "Hard-deleted")
-        finally:
-            await db.close()
-
-    asyncio.run(_run())
+    The production CLI routes ``filter`` through the Typer ``app`` (#1123); this
+    wrapper keeps the argparse leaf audit and command-level tests working. Args are
+    read via ``getattr`` defaults so partial test Namespaces stay usable (#1117).
+    """
+    action = getattr(args, "filter_action", None)
+    if not action:
+        print("Usage: filter {analyze|apply|reset|purge|hard-delete}")
+        return
+    if action == "analyze":
+        asyncio.run(analyze_impl(args.config, quick=getattr(args, "quick", False)))
+    elif action == "apply":
+        asyncio.run(apply_impl(args.config))
+    elif action == "precheck":
+        asyncio.run(precheck_impl(args.config))
+    elif action == "toggle":
+        asyncio.run(toggle_impl(args.config, pk=args.pk))
+    elif action == "reset":
+        asyncio.run(reset_impl(args.config, pks=getattr(args, "pks", None)))
+    elif action == "purge":
+        asyncio.run(
+            purge_impl(args.config, pks=getattr(args, "pks", None), yes=getattr(args, "yes", False))
+        )
+    elif action == "purge-messages":
+        asyncio.run(
+            purge_messages_impl(
+                args.config, channel_id=args.channel_id, yes=getattr(args, "yes", False)
+            )
+        )
+    elif action == "hard-delete":
+        asyncio.run(
+            hard_delete_impl(
+                args.config, pks=getattr(args, "pks", None), yes=getattr(args, "yes", False)
+            )
+        )

--- a/src/cli/commands/photo_loader.py
+++ b/src/cli/commands/photo_loader.py
@@ -1,9 +1,23 @@
+"""Shared async bodies for the ``photo-loader`` CLI group (epic #959, Wave 3 — #1123).
+
+Migrated off the argparse dispatcher onto the Typer ``app`` (see
+``src/cli/typer_commands.py``). Each leaf sub-command is a plain ``async def
+*_impl`` here — no local ``asyncio.run`` and no ``argparse.Namespace``. A thin
+``run(args)`` adapter is kept for the argparse leaf audit and existing tests.
+
+Every sub-command needs the photo-loader service stack (pool + publish + task +
+auto services); :func:`_run_with_services` builds it once, runs the body, and
+tears the pool down — so the per-command bodies stay focused on their own logic.
+"""
+
 from __future__ import annotations
 
 import argparse
 import asyncio
 import sys
+from collections.abc import Awaitable, Callable
 from datetime import datetime
+from typing import TypeVar
 
 from src.cli import runtime
 from src.database.bundles import PhotoLoaderBundle
@@ -12,12 +26,52 @@ from src.services.channel_service import ChannelService
 from src.services.photo_auto_upload_service import PhotoAutoUploadService
 from src.services.photo_publish_service import PhotoPublishService
 from src.services.photo_task_service import PhotoTarget, PhotoTaskService
-from src.telegram.backends import adapt_transport_session
-from src.utils.datetime import parse_required_schedule_datetime
+
+T = TypeVar("T")
+
+
+class _Services:
+    """The photo-loader service bundle a sub-command operates on."""
+
+    def __init__(self, db, pool, bundle, publish, tasks, auto, channel_service) -> None:
+        self.db = db
+        self.pool = pool
+        self.bundle = bundle
+        self.publish = publish
+        self.tasks = tasks
+        self.auto = auto
+        self.channel_service = channel_service
+
+
+async def _run_with_services(config_path: str, body: Callable[[_Services], Awaitable[T]]) -> T | None:
+    """Build the photo-loader service stack, run ``body``, then tear the pool down.
+
+    A ``ValueError`` from an unresolvable target (bad username, "me" without a
+    connected account, …) is reported cleanly and exits 1 — matching the pre-Typer
+    behaviour, not a raw traceback.
+    """
+    config, db = await runtime.init_db(config_path)
+    _, pool = await runtime.init_pool(config, db)
+    bundle = PhotoLoaderBundle.from_database(db)
+    publish = PhotoPublishService(pool)
+    tasks = PhotoTaskService(bundle, publish)
+    auto = PhotoAutoUploadService(bundle, publish)
+    channel_service = ChannelService(db, pool, None)  # type: ignore[arg-type]
+    services = _Services(db, pool, bundle, publish, tasks, auto, channel_service)
+    try:
+        return await body(services)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+    finally:
+        await pool.disconnect_all()
+        await db.close()
 
 
 async def _resolve_self_target(pool, phone: str | None) -> PhotoTarget:
     """Resolve "me"/"self" to the account's own Saved Messages dialog id."""
+    from src.telegram.backends import adapt_transport_session
+
     if phone:
         # A specific account was requested. Its Saved Messages id is account-specific,
         # and deferred paths (schedule-send/batch-create/auto-create) persist `phone`
@@ -39,7 +93,7 @@ async def _resolve_self_target(pool, phone: str | None) -> PhotoTarget:
         me = await session.fetch_me()
     finally:
         # Release the lease promptly (mirrors channel.py); the subsequent send/
-        # schedule call re-acquires it. disconnect_all() in run()'s finally is the
+        # schedule call re-acquires it. disconnect_all() in the finally is the
         # backstop, but explicit release keeps the pool tidy for other callers.
         await pool.release_client(acquired_phone)
     self_id = getattr(me, "id", None)
@@ -71,184 +125,333 @@ async def _resolve_target(raw: str, pool, phone: str | None = None) -> PhotoTarg
 
 
 def _parse_schedule_at(value: str) -> datetime:
+    from src.utils.datetime import parse_required_schedule_datetime
+
     return parse_required_schedule_datetime(value)
 
 
+async def dialogs_impl(config_path: str, *, phone: str) -> None:
+    """List dialogs for an account."""
+    async def _body(s: _Services) -> None:
+        dialogs = await s.channel_service.get_my_dialogs(phone)
+        for dialog in dialogs:
+            print(
+                f"{dialog['channel_id']:>14}  {dialog['channel_type']:<12} {dialog['title']}"
+            )
+    await _run_with_services(config_path, _body)
+
+
+async def refresh_impl(config_path: str, *, phone: str) -> None:
+    """Refresh the dialog cache for the photo loader."""
+    async def _body(s: _Services) -> None:
+        dialogs = await s.channel_service.get_my_dialogs(phone, refresh=True)
+        print(f"Dialogs refreshed: {len(dialogs)} total.")
+    await _run_with_services(config_path, _body)
+
+
+async def send_impl(
+    config_path: str, *, phone: str, target: str, files: list[str], mode: str = "album", caption: str | None = None
+) -> None:
+    """Send photos now."""
+    async def _body(s: _Services) -> None:
+        item = await s.tasks.send_now(
+            phone=phone,
+            target=await _resolve_target(target, s.pool, phone=phone),
+            file_paths=files,
+            mode=mode,
+            caption=caption,
+        )
+        print(f"Sent photo item #{item.id} status={item.status}")
+    await _run_with_services(config_path, _body)
+
+
+async def schedule_send_impl(
+    config_path: str,
+    *,
+    phone: str,
+    target: str,
+    files: list[str],
+    at: str,
+    mode: str = "album",
+    caption: str | None = None,
+) -> None:
+    """Schedule a photo send via Telegram."""
+    async def _body(s: _Services) -> None:
+        item = await s.tasks.schedule_send(
+            phone=phone,
+            target=await _resolve_target(target, s.pool, phone=phone),
+            file_paths=files,
+            mode=mode,
+            schedule_at=_parse_schedule_at(at),
+            caption=caption,
+        )
+        print(f"Scheduled photo item #{item.id} status={item.status}")
+    await _run_with_services(config_path, _body)
+
+
+async def batch_create_impl(
+    config_path: str, *, phone: str, target: str, manifest: str, caption: str | None = None
+) -> None:
+    """Create a delayed batch from a manifest."""
+    async def _body(s: _Services) -> None:
+        entries = s.tasks.load_manifest(manifest)
+        batch_id = await s.tasks.create_batch(
+            phone=phone,
+            target=await _resolve_target(target, s.pool, phone=phone),
+            entries=entries,
+            caption=caption,
+        )
+        print(f"Created photo batch #{batch_id}")
+    await _run_with_services(config_path, _body)
+
+
+async def batch_list_impl(config_path: str) -> None:
+    """List photo batches."""
+    async def _body(s: _Services) -> None:
+        batches = await s.tasks.list_batches()
+        for batch in batches:
+            print(
+                f"#{batch.id} phone={batch.phone} target={batch.target_dialog_id} "
+                f"status={batch.status}"
+            )
+    await _run_with_services(config_path, _body)
+
+
+async def items_impl(config_path: str, *, batch_id: int | None = None, limit: int = 100) -> None:
+    """List photo batch items."""
+    async def _body(s: _Services) -> None:
+        if batch_id is not None:
+            items = await s.bundle.list_items_for_batch(batch_id, limit=limit)
+        else:
+            items = await s.tasks.list_items(limit=limit)
+        for item in items:
+            print(
+                f"#{item.id} batch={item.batch_id or '-'} phone={item.phone} "
+                f"target={item.target_dialog_id} status={item.status}"
+            )
+    await _run_with_services(config_path, _body)
+
+
+async def batch_cancel_impl(config_path: str, *, item_id: int) -> None:
+    """Cancel a photo batch item."""
+    async def _body(s: _Services) -> None:
+        ok = await s.tasks.cancel_item(item_id)
+        print("Cancelled" if ok else "Not cancelled")
+    await _run_with_services(config_path, _body)
+
+
+async def auto_create_impl(
+    config_path: str,
+    *,
+    phone: str,
+    target: str,
+    folder: str,
+    interval: int,
+    mode: str = "album",
+    caption: str | None = None,
+) -> None:
+    """Create an auto-upload job."""
+    async def _body(s: _Services) -> None:
+        resolved = await _resolve_target(target, s.pool, phone=phone)
+        job_id = await s.auto.create_job(
+            PhotoAutoUploadJob(
+                phone=phone,
+                target_dialog_id=resolved.dialog_id,
+                target_title=resolved.title,
+                target_type=resolved.target_type,
+                folder_path=folder,
+                send_mode=PhotoSendMode(mode),
+                caption=caption,
+                interval_minutes=interval,
+            )
+        )
+        print(f"Created auto job #{job_id}")
+    await _run_with_services(config_path, _body)
+
+
+async def auto_list_impl(config_path: str) -> None:
+    """List auto-upload jobs."""
+    async def _body(s: _Services) -> None:
+        jobs = await s.auto.list_jobs()
+        for job in jobs:
+            print(
+                f"#{job.id} target={job.target_dialog_id} folder={job.folder_path} "
+                f"interval={job.interval_minutes} active={job.is_active}"
+            )
+    await _run_with_services(config_path, _body)
+
+
+async def auto_update_impl(
+    config_path: str,
+    *,
+    job_id: int,
+    folder: str | None = None,
+    interval: int | None = None,
+    mode: str | None = None,
+    caption: str | None = None,
+    active: bool = False,
+    paused: bool = False,
+) -> None:
+    """Update an auto-upload job."""
+    async def _body(s: _Services) -> None:
+        kwargs = {
+            "folder_path": folder,
+            "send_mode": PhotoSendMode(mode) if mode else None,
+            "caption": caption,
+            "interval_minutes": interval,
+            "is_active": None,
+        }
+        if active:
+            kwargs["is_active"] = True
+        if paused:
+            kwargs["is_active"] = False
+        await s.auto.update_job(job_id, **kwargs)
+        print(f"Updated auto job #{job_id}")
+    await _run_with_services(config_path, _body)
+
+
+async def auto_toggle_impl(config_path: str, *, job_id: int) -> None:
+    """Toggle an auto-upload job's active state."""
+    async def _body(s: _Services) -> None:
+        job = await s.auto.get_job(job_id)
+        if not job:
+            print("Auto job not found")
+            return
+        await s.auto.update_job(job_id, is_active=not job.is_active)
+        print(f"Toggled auto job #{job_id} to {not job.is_active}")
+    await _run_with_services(config_path, _body)
+
+
+async def auto_delete_impl(config_path: str, *, job_id: int) -> None:
+    """Delete an auto-upload job."""
+    async def _body(s: _Services) -> None:
+        await s.auto.delete_job(job_id)
+        print(f"Deleted auto job #{job_id}")
+    await _run_with_services(config_path, _body)
+
+
+async def run_due_impl(config_path: str, *, item_id: int | None = None, dry_run: bool = False) -> None:
+    """Run due photo items and auto jobs now (or preview them with --dry-run)."""
+    async def _body(s: _Services) -> None:
+        if dry_run:
+            # Preview only: never touch scheduled photo items (the task path has no
+            # dry-run); show the auto-job plan and exit before any send/mark.
+            previews = await s.auto.run_due(dry_run=True)
+            assert isinstance(previews, list)  # narrow run_due's int|list return
+            print(f"[dry-run] Would process {len(previews)} due auto job(s); nothing sent.")
+            for preview in previews:
+                title = preview.target_title or preview.target_dialog_id
+                print(
+                    f"  job #{preview.job_id} → {title} "
+                    f"(dialog_id={preview.target_dialog_id}, mode={preview.send_mode.value}): "
+                    f"{len(preview.files)} file(s)"
+                )
+                for file_path in preview.files:
+                    print(f"    - {file_path}")
+            return
+        items = await s.tasks.run_due(item_id=item_id)
+        jobs = 0
+        if item_id is None:
+            processed = await s.auto.run_due()
+            assert isinstance(processed, int)  # non-dry-run returns a count
+            jobs = processed
+        print(f"Processed due photo items={items} auto_jobs={jobs}")
+    await _run_with_services(config_path, _body)
+
+
 def run(args: argparse.Namespace) -> None:
-    async def _run() -> None:
-        config, db = await runtime.init_db(args.config)
-        _, pool = await runtime.init_pool(config, db)
-        bundle = PhotoLoaderBundle.from_database(db)
-        publish = PhotoPublishService(pool)
-        tasks = PhotoTaskService(bundle, publish)
-        auto = PhotoAutoUploadService(bundle, publish)
-        channel_service = ChannelService(db, pool, None)  # type: ignore[arg-type]
-        try:
-            action = args.photo_loader_action
-            if action == "dialogs":
-                dialogs = await channel_service.get_my_dialogs(args.phone)
-                for dialog in dialogs:
-                    print(
-                        f"{dialog['channel_id']:>14}  {dialog['channel_type']:<12} "
-                        f"{dialog['title']}"
-                    )
-                return
+    """Thin argparse adapter over the ``*_impl`` bodies (legacy dispatch path).
 
-            if action == "refresh":
-                dialogs = await channel_service.get_my_dialogs(args.phone, refresh=True)
-                print(f"Dialogs refreshed: {len(dialogs)} total.")
-                return
-
-            if action == "send":
-                item = await tasks.send_now(
-                    phone=args.phone,
-                    target=await _resolve_target(args.target, pool, phone=args.phone),
-                    file_paths=args.files,
-                    mode=args.mode,
-                    caption=args.caption,
-                )
-                print(f"Sent photo item #{item.id} status={item.status}")
-                return
-
-            if action == "schedule-send":
-                item = await tasks.schedule_send(
-                    phone=args.phone,
-                    target=await _resolve_target(args.target, pool, phone=args.phone),
-                    file_paths=args.files,
-                    mode=args.mode,
-                    schedule_at=_parse_schedule_at(args.at),
-                    caption=args.caption,
-                )
-                print(f"Scheduled photo item #{item.id} status={item.status}")
-                return
-
-            if action == "batch-create":
-                manifest = tasks.load_manifest(args.manifest)
-                batch_id = await tasks.create_batch(
-                    phone=args.phone,
-                    target=await _resolve_target(args.target, pool, phone=args.phone),
-                    entries=manifest,
-                    caption=args.caption,
-                )
-                print(f"Created photo batch #{batch_id}")
-                return
-
-            if action == "batch-list":
-                batches = await tasks.list_batches()
-                for batch in batches:
-                    print(
-                        f"#{batch.id} phone={batch.phone} target={batch.target_dialog_id} "
-                        f"status={batch.status}"
-                    )
-                return
-
-            if action == "items":
-                if args.batch_id is not None:
-                    items = await bundle.list_items_for_batch(args.batch_id, limit=args.limit)
-                else:
-                    items = await tasks.list_items(limit=args.limit)
-                for item in items:
-                    print(
-                        f"#{item.id} batch={item.batch_id or '-'} phone={item.phone} "
-                        f"target={item.target_dialog_id} status={item.status}"
-                    )
-                return
-
-            if action == "batch-cancel":
-                ok = await tasks.cancel_item(args.id)
-                print("Cancelled" if ok else "Not cancelled")
-                return
-
-            if action == "auto-create":
-                target = await _resolve_target(args.target, pool, phone=args.phone)
-                job_id = await auto.create_job(
-                    PhotoAutoUploadJob(
-                        phone=args.phone,
-                        target_dialog_id=target.dialog_id,
-                        target_title=target.title,
-                        target_type=target.target_type,
-                        folder_path=args.folder,
-                        send_mode=PhotoSendMode(args.mode),
-                        caption=args.caption,
-                        interval_minutes=args.interval,
-                    )
-                )
-                print(f"Created auto job #{job_id}")
-                return
-
-            if action == "auto-list":
-                jobs = await auto.list_jobs()
-                for job in jobs:
-                    print(
-                        f"#{job.id} target={job.target_dialog_id} folder={job.folder_path} "
-                        f"interval={job.interval_minutes} active={job.is_active}"
-                    )
-                return
-
-            if action == "auto-update":
-                kwargs = {
-                    "folder_path": args.folder,
-                    "send_mode": PhotoSendMode(args.mode) if args.mode else None,
-                    "caption": args.caption,
-                    "interval_minutes": args.interval,
-                    "is_active": None,
-                }
-                if args.active:
-                    kwargs["is_active"] = True
-                if args.paused:
-                    kwargs["is_active"] = False
-                await auto.update_job(args.id, **kwargs)
-                print(f"Updated auto job #{args.id}")
-                return
-
-            if action == "auto-toggle":
-                job = await auto.get_job(args.id)
-                if not job:
-                    print("Auto job not found")
-                    return
-                await auto.update_job(args.id, is_active=not job.is_active)
-                print(f"Toggled auto job #{args.id} to {not job.is_active}")
-                return
-
-            if action == "auto-delete":
-                await auto.delete_job(args.id)
-                print(f"Deleted auto job #{args.id}")
-                return
-
-            if action == "run-due":
-                item_id = getattr(args, "item_id", None)
-                dry_run = getattr(args, "dry_run", False)
-                if dry_run:
-                    # Preview only: never touch scheduled photo items (the task path has no
-                    # dry-run); show the auto-job plan and exit before any send/mark.
-                    previews = await auto.run_due(dry_run=True)
-                    assert isinstance(previews, list)  # narrow run_due's int|list return
-                    print(f"[dry-run] Would process {len(previews)} due auto job(s); nothing sent.")
-                    for preview in previews:
-                        title = preview.target_title or preview.target_dialog_id
-                        print(
-                            f"  job #{preview.job_id} → {title} "
-                            f"(dialog_id={preview.target_dialog_id}, mode={preview.send_mode.value}): "
-                            f"{len(preview.files)} file(s)"
-                        )
-                        for file_path in preview.files:
-                            print(f"    - {file_path}")
-                    return
-                items = await tasks.run_due(item_id=item_id)
-                jobs = 0
-                if item_id is None:
-                    processed = await auto.run_due()
-                    assert isinstance(processed, int)  # non-dry-run returns a count
-                    jobs = processed
-                print(f"Processed due photo items={items} auto_jobs={jobs}")
-                return
-        except ValueError as exc:
-            # Unresolvable target (bad username, "me" without a connected account,
-            # etc.) — fail with a clear message instead of a raw traceback.
-            print(f"Error: {exc}", file=sys.stderr)
-            sys.exit(1)
-        finally:
-            await pool.disconnect_all()
-            await db.close()
-
-    asyncio.run(_run())
+    The production CLI routes ``photo-loader`` through the Typer ``app`` (#1123);
+    this wrapper keeps the argparse leaf audit and command-level tests working. Args
+    are read via ``getattr`` defaults so partial test Namespaces stay usable (#1117).
+    """
+    action = getattr(args, "photo_loader_action", None)
+    if action == "dialogs":
+        asyncio.run(dialogs_impl(args.config, phone=args.phone))
+    elif action == "refresh":
+        asyncio.run(refresh_impl(args.config, phone=args.phone))
+    elif action == "send":
+        asyncio.run(
+            send_impl(
+                args.config,
+                phone=args.phone,
+                target=args.target,
+                files=args.files,
+                mode=getattr(args, "mode", "album"),
+                caption=getattr(args, "caption", None),
+            )
+        )
+    elif action == "schedule-send":
+        asyncio.run(
+            schedule_send_impl(
+                args.config,
+                phone=args.phone,
+                target=args.target,
+                files=args.files,
+                at=args.at,
+                mode=getattr(args, "mode", "album"),
+                caption=getattr(args, "caption", None),
+            )
+        )
+    elif action == "batch-create":
+        asyncio.run(
+            batch_create_impl(
+                args.config,
+                phone=args.phone,
+                target=args.target,
+                manifest=args.manifest,
+                caption=getattr(args, "caption", None),
+            )
+        )
+    elif action == "batch-list":
+        asyncio.run(batch_list_impl(args.config))
+    elif action == "items":
+        asyncio.run(
+            items_impl(
+                args.config,
+                batch_id=getattr(args, "batch_id", None),
+                limit=getattr(args, "limit", 100),
+            )
+        )
+    elif action == "batch-cancel":
+        asyncio.run(batch_cancel_impl(args.config, item_id=args.id))
+    elif action == "auto-create":
+        asyncio.run(
+            auto_create_impl(
+                args.config,
+                phone=args.phone,
+                target=args.target,
+                folder=args.folder,
+                interval=args.interval,
+                mode=getattr(args, "mode", "album"),
+                caption=getattr(args, "caption", None),
+            )
+        )
+    elif action == "auto-list":
+        asyncio.run(auto_list_impl(args.config))
+    elif action == "auto-update":
+        asyncio.run(
+            auto_update_impl(
+                args.config,
+                job_id=args.id,
+                folder=getattr(args, "folder", None),
+                interval=getattr(args, "interval", None),
+                mode=getattr(args, "mode", None),
+                caption=getattr(args, "caption", None),
+                active=getattr(args, "active", False),
+                paused=getattr(args, "paused", False),
+            )
+        )
+    elif action == "auto-toggle":
+        asyncio.run(auto_toggle_impl(args.config, job_id=args.id))
+    elif action == "auto-delete":
+        asyncio.run(auto_delete_impl(args.config, job_id=args.id))
+    elif action == "run-due":
+        asyncio.run(
+            run_due_impl(
+                args.config,
+                item_id=getattr(args, "item_id", None),
+                dry_run=getattr(args, "dry_run", False),
+            )
+        )

--- a/src/cli/commands/scheduler.py
+++ b/src/cli/commands/scheduler.py
@@ -1,3 +1,14 @@
+"""Shared async bodies for the ``scheduler`` CLI group (epic #959, Wave 3 — #1123).
+
+Migrated off the argparse dispatcher onto the Typer ``app`` (see
+``src/cli/typer_commands.py``). Each leaf sub-command is a plain ``async def
+*_impl`` here — no local ``asyncio.run`` and no ``argparse.Namespace``. A thin
+``run(args)`` adapter is kept for the argparse leaf audit and existing tests.
+
+Only ``start`` / ``trigger`` talk to Telegram; every other action is a pure DB
+operation and must not pay (or risk) a full multi-account pool connect.
+"""
+
 from __future__ import annotations
 
 import argparse
@@ -11,162 +22,238 @@ from src.services.collection_service import CollectionService
 from src.services.task_enqueuer import TaskEnqueuer
 from src.telegram.collector import Collector
 
-# Only these actions actually talk to Telegram; everything else is a pure DB
-# operation and must not pay (or risk) a full multi-account pool connect.
-_POOL_REQUIRED_ACTIONS = frozenset({"start", "trigger"})
+
+async def start_impl(config_path: str) -> None:
+    """Start the scheduler in the foreground (needs a connected account)."""
+    config, db = await runtime.init_db(config_path)
+    pool = None
+    try:
+        _, pool = await runtime.init_pool(config, db)
+        if not pool.clients:
+            logging.error("No connected accounts.")
+            return
+        collector = Collector(pool, db, config.scheduler)
+        channel_bundle = ChannelBundle.from_database(db)
+        collection_service = CollectionService(channel_bundle, collector, collection_queue=None)
+        task_enqueuer = TaskEnqueuer(db, collection_service)
+
+        manager = SchedulerManager(config.scheduler, task_enqueuer=task_enqueuer)
+        await manager.start()
+        print(
+            f"Scheduler started (every {config.scheduler.collect_interval_minutes} min). "
+            "Press Ctrl+C to stop."
+        )
+        try:
+            while True:
+                await asyncio.sleep(1)
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            await manager.stop()
+            print("\nScheduler stopped.")
+    finally:
+        if pool is not None:
+            await pool.disconnect_all()
+        await db.close()
+
+
+async def trigger_impl(config_path: str) -> None:
+    """Trigger a one-shot enqueue of all channels (needs a connected account)."""
+    config, db = await runtime.init_db(config_path)
+    pool = None
+    try:
+        _, pool = await runtime.init_pool(config, db)
+        if not pool.clients:
+            logging.error("No connected accounts.")
+            return
+        collector = Collector(pool, db, config.scheduler)
+        channel_bundle = ChannelBundle.from_database(db)
+        collection_service = CollectionService(channel_bundle, collector, collection_queue=None)
+        result = await collection_service.enqueue_all_channels(
+            resolve_backoff_remaining_sec=pool.get_resolve_username_backoff_remaining_sec(),
+        )
+        print(
+            f"Enqueued {result.queued_count} channels "
+            f"(skipped {result.skipped_existing_count}, "
+            f"total {result.total_candidates}). "
+            f"Run 'serve' to execute tasks."
+        )
+    finally:
+        if pool is not None:
+            await pool.disconnect_all()
+        await db.close()
+
+
+async def status_impl(config_path: str) -> None:
+    """Show scheduler configuration and disabled-job status."""
+    config, db = await runtime.init_db(config_path)
+    try:
+        interval = config.scheduler.collect_interval_minutes
+        autostart = await db.get_setting("scheduler_autostart") or "0"
+        queue_paused = await db.get_setting("collection_queue_paused") or "0"
+        print("Scheduler config:")
+        print(f"  Interval: {interval} min")
+        print(f"  Autostart: {'yes' if autostart == '1' else 'no'}")
+        print(f"  Queue paused: {'yes' if queue_paused == '1' else 'no'}")
+        settings = await db.repos.settings.list_all()
+        disabled_jobs = [
+            (k.removeprefix("scheduler_job_disabled:"), v)
+            for k, v in settings if k.startswith("scheduler_job_disabled:")
+        ]
+        if disabled_jobs:
+            print("  Disabled jobs:")
+            for job_id, val in disabled_jobs:
+                if val == "1":
+                    print(f"    - {job_id}")
+    finally:
+        await db.close()
+
+
+async def stop_impl(config_path: str) -> None:
+    """Disable scheduler autostart."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        await db.set_setting("scheduler_autostart", "0")
+        print("Scheduler autostart disabled. Running scheduler will stop on next restart.")
+    finally:
+        await db.close()
+
+
+async def job_toggle_impl(config_path: str, *, job_id: str) -> None:
+    """Toggle a scheduler job enabled/disabled."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        # pipeline_run_ is no longer a periodic job (#835/2) — canonicalize to the live
+        # content_generate_ id so toggling it disables the real job, not a dead key.
+        if job_id.startswith("pipeline_run_"):
+            job_id = "content_generate_" + job_id.removeprefix("pipeline_run_")
+        key = f"scheduler_job_disabled:{job_id}"
+        current = await db.repos.settings.get_setting(key)
+        new_disabled = current != "1"
+        await db.repos.settings.set_setting(key, "1" if new_disabled else "0")
+        status = "disabled" if new_disabled else "enabled"
+        print(f"Job '{job_id}' {status}.")
+    finally:
+        await db.close()
+
+
+async def set_interval_impl(config_path: str, *, job_id: str, minutes: int) -> None:
+    """Set a scheduler job interval (clamped to 1–1440 minutes)."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        minutes = max(1, min(minutes, 1440))
+        # Mirror the web set_job_interval handler — sq_/pipeline intervals live on
+        # their own records, not in a settings key nobody reads (the old
+        # scheduler_job_{id}_interval write was a silent no-op, audit #835/9).
+        if job_id == "collect_all":
+            await db.repos.settings.set_setting("collect_interval_minutes", str(minutes))
+        elif job_id == "warm_all_dialogs":
+            await db.repos.settings.set_setting("warm_dialogs_interval_minutes", str(minutes))
+        elif job_id.startswith("sq_"):
+            sq_id = int(job_id.removeprefix("sq_"))
+            sq = await db.repos.search_queries.get_by_id(sq_id)
+            if not sq:
+                print(f"Search query {sq_id} not found.")
+                return
+            await db.repos.search_queries.update(
+                sq_id, sq.model_copy(update={"interval_minutes": minutes})
+            )
+        elif job_id.startswith(("pipeline_run_", "content_generate_")):
+            pid = int(job_id.removeprefix("pipeline_run_").removeprefix("content_generate_"))
+            pipeline = await db.repos.content_pipelines.get_by_id(pid)
+            if not pipeline:
+                print(f"Pipeline {pid} not found.")
+                return
+            await db.repos.content_pipelines.update_generate_interval(pid, minutes)
+        else:
+            print(f"Unknown job_id '{job_id}'.")
+            return
+        print(f"Interval for '{job_id}' set to {minutes} min.")
+    finally:
+        await db.close()
+
+
+async def task_cancel_impl(config_path: str, *, task_id: int) -> None:
+    """Cancel a pending collection task by id."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        ok = await db.repos.tasks.cancel_collection_task(task_id)
+        if ok:
+            print(f"Task {task_id} cancelled.")
+        else:
+            print(f"Task {task_id} not found or already completed.")
+    finally:
+        await db.close()
+
+
+async def clear_pending_impl(config_path: str) -> None:
+    """Clear all pending collection tasks."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        deleted = await db.repos.tasks.delete_pending_channel_tasks()
+        print(f"Cleared {deleted} pending collection tasks.")
+    finally:
+        await db.close()
+
+
+async def queue_pause_impl(config_path: str) -> None:
+    """Pause the collection queue (queued tasks stay pending)."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        await db.set_setting("collection_queue_paused", "1")
+        # Setting alone is read only at worker startup; signal a running worker too
+        # so the pause actually takes effect now (audit #835/5).
+        from src.services.telegram_command_service import TelegramCommandService
+
+        await TelegramCommandService(db).enqueue(
+            "collection.pause", payload={}, requested_by="cli:scheduler.queue-pause"
+        )
+        print(
+            "Collection queue paused. The running worker stops pulling new tasks; "
+            "queued tasks remain pending."
+        )
+    finally:
+        await db.close()
+
+
+async def queue_resume_impl(config_path: str) -> None:
+    """Resume the collection queue."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        await db.set_setting("collection_queue_paused", "0")
+        from src.services.telegram_command_service import TelegramCommandService
+
+        await TelegramCommandService(db).enqueue(
+            "collection.resume", payload={}, requested_by="cli:scheduler.queue-resume"
+        )
+        print("Collection queue resumed.")
+    finally:
+        await db.close()
 
 
 def run(args: argparse.Namespace) -> None:
-    async def _run() -> None:
-        config, db = await runtime.init_db(args.config)
-        pool = None
-        collection_service = None
-        task_enqueuer = None
+    """Thin argparse adapter over the ``*_impl`` bodies (legacy dispatch path).
 
-        try:
-            if args.scheduler_action in _POOL_REQUIRED_ACTIONS:
-                _, pool = await runtime.init_pool(config, db)
-                if not pool.clients:
-                    logging.error("No connected accounts.")
-                    return
-                collector = Collector(pool, db, config.scheduler)
-                channel_bundle = ChannelBundle.from_database(db)
-                collection_service = CollectionService(
-                    channel_bundle, collector, collection_queue=None
-                )
-                task_enqueuer = TaskEnqueuer(db, collection_service)
-
-            if args.scheduler_action == "start":
-                manager = SchedulerManager(
-                    config.scheduler,
-                    task_enqueuer=task_enqueuer,
-                )
-                await manager.start()
-                print(
-                    f"Scheduler started (every {config.scheduler.collect_interval_minutes} min). "
-                    "Press Ctrl+C to stop."
-                )
-                try:
-                    while True:
-                        await asyncio.sleep(1)
-                except (KeyboardInterrupt, asyncio.CancelledError):
-                    await manager.stop()
-                    print("\nScheduler stopped.")
-            elif args.scheduler_action == "trigger":
-                result = await collection_service.enqueue_all_channels(
-                    resolve_backoff_remaining_sec=pool.get_resolve_username_backoff_remaining_sec(),
-                )
-                print(
-                    f"Enqueued {result.queued_count} channels "
-                    f"(skipped {result.skipped_existing_count}, "
-                    f"total {result.total_candidates}). "
-                    f"Run 'serve' to execute tasks."
-                )
-
-            elif args.scheduler_action == "status":
-                interval = config.scheduler.collect_interval_minutes
-                autostart = await db.get_setting("scheduler_autostart") or "0"
-                queue_paused = await db.get_setting("collection_queue_paused") or "0"
-                print("Scheduler config:")
-                print(f"  Interval: {interval} min")
-                print(f"  Autostart: {'yes' if autostart == '1' else 'no'}")
-                print(f"  Queue paused: {'yes' if queue_paused == '1' else 'no'}")
-                settings = await db.repos.settings.list_all()
-                disabled_jobs = [
-                    (k.removeprefix("scheduler_job_disabled:"), v)
-                    for k, v in settings if k.startswith("scheduler_job_disabled:")
-                ]
-                if disabled_jobs:
-                    print("  Disabled jobs:")
-                    for job_id, val in disabled_jobs:
-                        if val == "1":
-                            print(f"    - {job_id}")
-
-            elif args.scheduler_action == "stop":
-                await db.set_setting("scheduler_autostart", "0")
-                print("Scheduler autostart disabled. Running scheduler will stop on next restart.")
-
-            elif args.scheduler_action == "job-toggle":
-                # pipeline_run_ is no longer a periodic job (#835/2) — canonicalize to the live
-                # content_generate_ id so toggling it disables the real job, not a dead key.
-                job_id = args.job_id
-                if job_id.startswith("pipeline_run_"):
-                    job_id = "content_generate_" + job_id.removeprefix("pipeline_run_")
-                key = f"scheduler_job_disabled:{job_id}"
-                current = await db.repos.settings.get_setting(key)
-                new_disabled = current != "1"
-                await db.repos.settings.set_setting(key, "1" if new_disabled else "0")
-                status = "disabled" if new_disabled else "enabled"
-                print(f"Job '{job_id}' {status}.")
-
-            elif args.scheduler_action == "set-interval":
-                job_id = args.job_id
-                minutes = max(1, min(args.minutes, 1440))
-                # Mirror the web set_job_interval handler — sq_/pipeline intervals
-                # live on their own records, not in a settings key nobody reads
-                # (the old scheduler_job_{id}_interval write was a silent no-op,
-                # audit #835/9).
-                if job_id == "collect_all":
-                    await db.repos.settings.set_setting("collect_interval_minutes", str(minutes))
-                elif job_id == "warm_all_dialogs":
-                    await db.repos.settings.set_setting("warm_dialogs_interval_minutes", str(minutes))
-                elif job_id.startswith("sq_"):
-                    sq_id = int(job_id.removeprefix("sq_"))
-                    sq = await db.repos.search_queries.get_by_id(sq_id)
-                    if not sq:
-                        print(f"Search query {sq_id} not found.")
-                        return
-                    await db.repos.search_queries.update(
-                        sq_id, sq.model_copy(update={"interval_minutes": minutes})
-                    )
-                elif job_id.startswith(("pipeline_run_", "content_generate_")):
-                    pid = int(job_id.removeprefix("pipeline_run_").removeprefix("content_generate_"))
-                    pipeline = await db.repos.content_pipelines.get_by_id(pid)
-                    if not pipeline:
-                        print(f"Pipeline {pid} not found.")
-                        return
-                    await db.repos.content_pipelines.update_generate_interval(pid, minutes)
-                else:
-                    print(f"Unknown job_id '{job_id}'.")
-                    return
-                print(f"Interval for '{job_id}' set to {minutes} min.")
-
-            elif args.scheduler_action == "task-cancel":
-                ok = await db.repos.tasks.cancel_collection_task(args.task_id)
-                if ok:
-                    print(f"Task {args.task_id} cancelled.")
-                else:
-                    print(f"Task {args.task_id} not found or already completed.")
-
-            elif args.scheduler_action == "clear-pending":
-                deleted = await db.repos.tasks.delete_pending_channel_tasks()
-                print(f"Cleared {deleted} pending collection tasks.")
-
-            elif args.scheduler_action == "queue-pause":
-                await db.set_setting("collection_queue_paused", "1")
-                # Setting alone is read only at worker startup; signal a running
-                # worker too so the pause actually takes effect now (audit #835/5).
-                from src.services.telegram_command_service import TelegramCommandService
-
-                await TelegramCommandService(db).enqueue(
-                    "collection.pause", payload={}, requested_by="cli:scheduler.queue-pause"
-                )
-                print(
-                    "Collection queue paused. The running worker stops pulling new tasks; "
-                    "queued tasks remain pending."
-                )
-
-            elif args.scheduler_action == "queue-resume":
-                await db.set_setting("collection_queue_paused", "0")
-                from src.services.telegram_command_service import TelegramCommandService
-
-                await TelegramCommandService(db).enqueue(
-                    "collection.resume", payload={}, requested_by="cli:scheduler.queue-resume"
-                )
-                print("Collection queue resumed.")
-        finally:
-            if pool is not None:
-                await pool.disconnect_all()
-            await db.close()
-
-    asyncio.run(_run())
+    The production CLI routes ``scheduler`` through the Typer ``app`` (#1123); this
+    wrapper keeps the argparse leaf audit and command-level tests working. Args are
+    read via ``getattr`` defaults so partial test Namespaces stay usable (#1117).
+    """
+    action = getattr(args, "scheduler_action", None)
+    if action == "start":
+        asyncio.run(start_impl(args.config))
+    elif action == "trigger":
+        asyncio.run(trigger_impl(args.config))
+    elif action == "status":
+        asyncio.run(status_impl(args.config))
+    elif action == "stop":
+        asyncio.run(stop_impl(args.config))
+    elif action == "job-toggle":
+        asyncio.run(job_toggle_impl(args.config, job_id=args.job_id))
+    elif action == "set-interval":
+        asyncio.run(set_interval_impl(args.config, job_id=args.job_id, minutes=args.minutes))
+    elif action == "task-cancel":
+        asyncio.run(task_cancel_impl(args.config, task_id=args.task_id))
+    elif action == "clear-pending":
+        asyncio.run(clear_pending_impl(args.config))
+    elif action == "queue-pause":
+        asyncio.run(queue_pause_impl(args.config))
+    elif action == "queue-resume":
+        asyncio.run(queue_resume_impl(args.config))

--- a/src/cli/commands/search_query.py
+++ b/src/cli/commands/search_query.py
@@ -1,3 +1,12 @@
+"""Shared async bodies for the ``search-query`` CLI group (epic #959, Wave 3 — #1123).
+
+Migrated off the argparse dispatcher onto the Typer ``app`` (see
+``src/cli/typer_commands.py``). Each leaf sub-command is a plain ``async def
+*_impl`` here — no local ``asyncio.run`` and no ``argparse.Namespace``. A thin
+``run(args)`` adapter is kept for the argparse leaf audit and the existing
+command-level tests.
+"""
+
 from __future__ import annotations
 
 import argparse
@@ -31,154 +40,271 @@ async def _chat_filter_warning(svc: SearchQueryService, chat_filter: str) -> str
         return ""
 
 
-def run(args: argparse.Namespace) -> None:
-    async def _run() -> None:
-        _, db = await runtime.init_db(args.config)
+async def list_impl(config_path: str) -> None:
+    """List all search queries with 30-day match counts and last-run times."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        svc = SearchQueryService(SearchQueryBundle.from_database(db))
+        items = await svc.get_with_stats()
+        if not items:
+            print("No search queries found.")
+            return
+        fmt = "{:<5} {:<40} {:<10} {:<10} {:<20}"
+        print(fmt.format("ID", "Query", "Interval", "Total30d", "Last run"))
+        print("-" * 90)
+        for item in items:
+            sq = item["query"]
+            print(
+                fmt.format(
+                    sq.id or 0,
+                    sq.query[:40],
+                    f"{sq.interval_minutes}m",
+                    item["total_30d"],
+                    (item["last_run"] or "—")[:20],
+                )
+            )
+            chat_filter = getattr(sq, "chat_filter", "")
+            if chat_filter:
+                print(f"      chats: {chat_filter}")
+                if item.get("chat_filter_warnings"):
+                    print(f"      warning: {item['chat_filter_warnings']}")
+    finally:
+        await db.close()
+
+
+async def get_impl(config_path: str, *, query_id: int) -> None:
+    """Show full details for one search query by id."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        svc = SearchQueryService(SearchQueryBundle.from_database(db))
+        sq = await svc.get(query_id)
+        if not sq:
+            print(f"Search query id={query_id} not found")
+            return
+        print(f"ID: {sq.id}")
+        print(f"Query: {sq.query}")
+        print(f"Interval: {sq.interval_minutes}m")
+        print(f"Active: {sq.is_active}")
+        print(f"Regex: {sq.is_regex}")
+        print(f"FTS: {sq.is_fts}")
+        print(f"Notify: {sq.notify_on_collect}")
+        print(f"Track stats: {sq.track_stats}")
+        print(f"Max length: {sq.max_length if sq.max_length is not None else '—'}")
+        print(f"Exclude patterns: {sq.exclude_patterns or '—'}")
+        chat_filter = getattr(sq, "chat_filter", "")
+        print(f"Chats: {chat_filter or 'all'}")
+        warning = await _chat_filter_warning(svc, chat_filter)
+        if warning:
+            print(f"Warning: {warning}")
+    finally:
+        await db.close()
+
+
+async def add_impl(
+    config_path: str,
+    *,
+    query: str,
+    interval: int = 60,
+    is_regex: bool = False,
+    is_fts: bool = False,
+    notify: bool = False,
+    track_stats: bool = True,
+    exclude_patterns: str = "",
+    max_length: int | None = None,
+    chats: str = "",
+) -> None:
+    """Add a new search query."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        svc = SearchQueryService(SearchQueryBundle.from_database(db))
+        exclude = exclude_patterns.replace("\\n", "\n") if exclude_patterns else ""
         try:
-            svc = SearchQueryService(SearchQueryBundle.from_database(db))
+            sq_id = await svc.add(
+                query,
+                interval,
+                is_regex=is_regex,
+                is_fts=is_fts,
+                notify_on_collect=notify,
+                track_stats=track_stats,
+                exclude_patterns=exclude,
+                max_length=max_length,
+                chat_filter=chats,
+            )
+        except ValidationError as e:
+            print(f"Error: {e.errors()[0]['msg']}")
+            return
+        print(f"Added search query id={sq_id}: {query}")
+        warning = await _chat_filter_warning(svc, chats)
+        if warning:
+            print(f"Warning: {warning}")
+    finally:
+        await db.close()
 
-            if args.search_query_action == "list":
-                items = await svc.get_with_stats()
-                if not items:
-                    print("No search queries found.")
-                    return
-                fmt = "{:<5} {:<40} {:<10} {:<10} {:<20}"
-                print(fmt.format("ID", "Query", "Interval", "Total30d", "Last run"))
-                print("-" * 90)
-                for item in items:
-                    sq = item["query"]
-                    print(
-                        fmt.format(
-                            sq.id or 0,
-                            sq.query[:40],
-                            f"{sq.interval_minutes}m",
-                            item["total_30d"],
-                            (item["last_run"] or "—")[:20],
-                        )
-                    )
-                    chat_filter = getattr(sq, "chat_filter", "")
-                    if chat_filter:
-                        print(f"      chats: {chat_filter}")
-                        if item.get("chat_filter_warnings"):
-                            print(f"      warning: {item['chat_filter_warnings']}")
 
-            elif args.search_query_action == "get":
-                sq = await svc.get(args.id)
-                if not sq:
-                    print(f"Search query id={args.id} not found")
-                    return
-                print(f"ID: {sq.id}")
-                print(f"Query: {sq.query}")
-                print(f"Interval: {sq.interval_minutes}m")
-                print(f"Active: {sq.is_active}")
-                print(f"Regex: {sq.is_regex}")
-                print(f"FTS: {sq.is_fts}")
-                print(f"Notify: {sq.notify_on_collect}")
-                print(f"Track stats: {sq.track_stats}")
-                print(f"Max length: {sq.max_length if sq.max_length is not None else '—'}")
-                print(f"Exclude patterns: {sq.exclude_patterns or '—'}")
-                chat_filter = getattr(sq, "chat_filter", "")
-                print(f"Chats: {chat_filter or 'all'}")
-                warning = await _chat_filter_warning(svc, chat_filter)
-                if warning:
-                    print(f"Warning: {warning}")
+async def edit_impl(
+    config_path: str,
+    *,
+    query_id: int,
+    query: str | None = None,
+    interval: int | None = None,
+    is_regex: bool | None = None,
+    is_fts: bool | None = None,
+    notify: bool | None = None,
+    track_stats: bool | None = None,
+    exclude_patterns: str | None = None,
+    max_length: int | None = None,
+    chats: str | None = None,
+) -> None:
+    """Edit an existing search query; unset flags keep their current value."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        svc = SearchQueryService(SearchQueryBundle.from_database(db))
+        sq = await svc.get(query_id)
+        if not sq:
+            print(f"Search query id={query_id} not found")
+            return
+        notify_val = notify if notify is not None else sq.notify_on_collect
+        tstats = track_stats if track_stats is not None else sq.track_stats
+        is_fts_val = is_fts if is_fts is not None else sq.is_fts
+        exclude = (
+            exclude_patterns.replace("\\n", "\n")
+            if exclude_patterns is not None
+            else sq.exclude_patterns
+        )
+        max_len = (
+            None
+            if max_length == -1
+            else max_length if max_length is not None else sq.max_length
+        )
+        try:
+            await svc.update(
+                query_id,
+                query if query else sq.query,
+                interval if interval is not None else sq.interval_minutes,
+                is_regex=is_regex if is_regex is not None else sq.is_regex,
+                is_fts=is_fts_val,
+                notify_on_collect=notify_val,
+                track_stats=tstats,
+                exclude_patterns=exclude,
+                max_length=max_len,
+                chat_filter=(
+                    chats if chats is not None else getattr(sq, "chat_filter", "")
+                ),
+            )
+        except ValidationError as e:
+            print(f"Error: {e.errors()[0]['msg']}")
+            return
+        print(f"Updated search query id={query_id}")
+        warning = await _chat_filter_warning(
+            svc,
+            chats if chats is not None else getattr(sq, "chat_filter", ""),
+        )
+        if warning:
+            print(f"Warning: {warning}")
+    finally:
+        await db.close()
 
-            elif args.search_query_action == "add":
-                exclude = (
-                    args.exclude_patterns.replace("\\n", "\n") if args.exclude_patterns else ""
-                )
-                try:
-                    sq_id = await svc.add(
-                        args.query,
-                        args.interval,
-                        is_regex=args.regex,
-                        is_fts=args.fts,
-                        notify_on_collect=args.notify,
-                        track_stats=args.track_stats,
-                        exclude_patterns=exclude,
-                        max_length=args.max_length,
-                        chat_filter=getattr(args, "chats", ""),
-                    )
-                except ValidationError as e:
-                    print(f"Error: {e.errors()[0]['msg']}")
-                    return
-                print(f"Added search query id={sq_id}: {args.query}")
-                warning = await _chat_filter_warning(svc, getattr(args, "chats", ""))
-                if warning:
-                    print(f"Warning: {warning}")
 
-            elif args.search_query_action == "edit":
-                sq = await svc.get(args.id)
-                if not sq:
-                    print(f"Search query id={args.id} not found")
-                    return
-                notify = args.notify if args.notify is not None else sq.notify_on_collect
-                tstats = args.track_stats if args.track_stats is not None else sq.track_stats
-                is_fts = args.fts if args.fts is not None else sq.is_fts
-                exclude = (
-                    args.exclude_patterns.replace("\\n", "\n")
-                    if args.exclude_patterns is not None
-                    else sq.exclude_patterns
-                )
-                max_len = (
-                    None
-                    if args.max_length == -1
-                    else args.max_length if args.max_length is not None else sq.max_length
-                )
-                try:
-                    await svc.update(
-                        args.id,
-                        args.query if args.query else sq.query,
-                        args.interval if args.interval is not None else sq.interval_minutes,
-                        is_regex=args.regex if args.regex is not None else sq.is_regex,
-                        is_fts=is_fts,
-                        notify_on_collect=notify,
-                        track_stats=tstats,
-                        exclude_patterns=exclude,
-                        max_length=max_len,
-                        chat_filter=(
-                            args.chats
-                            if getattr(args, "chats", None) is not None
-                            else getattr(sq, "chat_filter", "")
-                        ),
-                    )
-                except ValidationError as e:
-                    print(f"Error: {e.errors()[0]['msg']}")
-                    return
-                print(f"Updated search query id={args.id}")
-                warning = await _chat_filter_warning(
-                    svc,
-                    args.chats
-                    if getattr(args, "chats", None) is not None
-                    else getattr(sq, "chat_filter", ""),
-                )
-                if warning:
-                    print(f"Warning: {warning}")
+async def delete_impl(config_path: str, *, query_id: int) -> None:
+    """Delete a search query by id."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        svc = SearchQueryService(SearchQueryBundle.from_database(db))
+        await svc.delete(query_id)
+        print(f"Deleted search query id={query_id}")
+    finally:
+        await db.close()
 
-            elif args.search_query_action == "delete":
-                await svc.delete(args.id)
-                print(f"Deleted search query id={args.id}")
 
-            elif args.search_query_action == "toggle":
-                await svc.toggle(args.id)
-                print(f"Toggled search query id={args.id}")
+async def toggle_impl(config_path: str, *, query_id: int) -> None:
+    """Toggle a search query's active state."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        svc = SearchQueryService(SearchQueryBundle.from_database(db))
+        await svc.toggle(query_id)
+        print(f"Toggled search query id={query_id}")
+    finally:
+        await db.close()
 
-            elif args.search_query_action == "run":
-                count = await svc.run_once(args.id)
-                print(f"Search query id={args.id} executed: {count} matches found.")
 
-            elif args.search_query_action == "stats":
-                stats = await svc.get_daily_stats(args.id, args.days)
-                if not stats:
-                    print("No stats found.")
-                    return
-                max_count = max(s.count for s in stats)
-                for s in stats:
-                    bar_len = int(s.count / max_count * 40) if max_count else 0
-                    bar = "#" * bar_len
-                    print(f"{s.day}  {bar:<40} {s.count}")
+async def run_impl(config_path: str, *, query_id: int) -> None:
+    """Run a search query once and report how many matches were found."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        svc = SearchQueryService(SearchQueryBundle.from_database(db))
+        count = await svc.run_once(query_id)
+        print(f"Search query id={query_id} executed: {count} matches found.")
+    finally:
+        await db.close()
 
-        finally:
-            await db.close()
 
-    asyncio.run(_run())
+async def stats_impl(config_path: str, *, query_id: int, days: int = 30) -> None:
+    """Show a daily match-count histogram for a search query."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        svc = SearchQueryService(SearchQueryBundle.from_database(db))
+        stats = await svc.get_daily_stats(query_id, days)
+        if not stats:
+            print("No stats found.")
+            return
+        max_count = max(s.count for s in stats)
+        for s in stats:
+            bar_len = int(s.count / max_count * 40) if max_count else 0
+            bar = "#" * bar_len
+            print(f"{s.day}  {bar:<40} {s.count}")
+    finally:
+        await db.close()
+
+
+def run(args: argparse.Namespace) -> None:
+    """Thin argparse adapter over the ``*_impl`` bodies (legacy dispatch path).
+
+    The production CLI routes ``search-query`` through the Typer ``app`` (#1123);
+    this wrapper keeps the argparse leaf audit and command-level tests working.
+    All args are read via ``getattr`` defaults so partial test Namespaces stay
+    usable (see #1117).
+    """
+    action = getattr(args, "search_query_action", None)
+    if action == "list":
+        asyncio.run(list_impl(args.config))
+    elif action == "get":
+        asyncio.run(get_impl(args.config, query_id=args.id))
+    elif action == "add":
+        asyncio.run(
+            add_impl(
+                args.config,
+                query=args.query,
+                interval=getattr(args, "interval", 60),
+                is_regex=getattr(args, "regex", False),
+                is_fts=getattr(args, "fts", False),
+                notify=getattr(args, "notify", False),
+                track_stats=getattr(args, "track_stats", True),
+                exclude_patterns=getattr(args, "exclude_patterns", ""),
+                max_length=getattr(args, "max_length", None),
+                chats=getattr(args, "chats", ""),
+            )
+        )
+    elif action == "edit":
+        asyncio.run(
+            edit_impl(
+                args.config,
+                query_id=args.id,
+                query=getattr(args, "query", None),
+                interval=getattr(args, "interval", None),
+                is_regex=getattr(args, "regex", None),
+                is_fts=getattr(args, "fts", None),
+                notify=getattr(args, "notify", None),
+                track_stats=getattr(args, "track_stats", None),
+                exclude_patterns=getattr(args, "exclude_patterns", None),
+                max_length=getattr(args, "max_length", None),
+                chats=getattr(args, "chats", None),
+            )
+        )
+    elif action == "delete":
+        asyncio.run(delete_impl(args.config, query_id=args.id))
+    elif action == "toggle":
+        asyncio.run(toggle_impl(args.config, query_id=args.id))
+    elif action == "run":
+        asyncio.run(run_impl(args.config, query_id=args.id))
+    elif action == "stats":
+        asyncio.run(stats_impl(args.config, query_id=args.id, days=getattr(args, "days", 30)))

--- a/src/cli/commands/settings.py
+++ b/src/cli/commands/settings.py
@@ -1,3 +1,14 @@
+"""Shared async bodies for the ``settings`` CLI group (epic #959, Wave 3 — #1123).
+
+Migrated off the argparse dispatcher onto the Typer ``app`` (see
+``src/cli/typer_commands.py``). Each leaf sub-command is a plain ``async def
+*_impl`` here — no local ``asyncio.run`` and no ``argparse.Namespace``. A thin
+``run(args)`` adapter is kept for the argparse leaf audit and existing tests.
+
+Several sub-commands are get-or-set: passing a value writes it, omitting all
+values prints the current value(s).
+"""
+
 from __future__ import annotations
 
 import argparse
@@ -7,143 +18,244 @@ from datetime import datetime, timezone
 from src.cli import runtime
 
 
-def run(args: argparse.Namespace) -> None:
-    async def _run() -> None:
-        _config, db = await runtime.init_db(args.config)
-        try:
-            action = getattr(args, "settings_action", None) or "get"
+async def get_impl(config_path: str, *, key: str | None = None) -> None:
+    """Show one setting (``--key``) or all settings."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        if key:
+            value = await db.get_setting(key)
+            print(f"{key} = {value or '(not set)'}")
+        else:
+            rows = await db.repos.settings.list_all()
+            if not rows:
+                print("No settings found.")
+                return
+            fmt = "{:<50} {}"
+            print(fmt.format("Key", "Value"))
+            print("-" * 80)
+            for k, v in rows:
+                print(fmt.format(k, v[:80] if v else ""))
+    finally:
+        await db.close()
 
-            if action == "get":
-                key = getattr(args, "key", None)
-                if key:
-                    value = await db.get_setting(key)
-                    print(f"{key} = {value or '(not set)'}")
-                else:
-                    rows = await db.repos.settings.list_all()
-                    if not rows:
-                        print("No settings found.")
-                        return
-                    fmt = "{:<50} {}"
-                    print(fmt.format("Key", "Value"))
-                    print("-" * 80)
-                    for k, v in rows:
-                        print(fmt.format(k, v[:80] if v else ""))
 
-            elif action == "set":
-                await db.set_setting(args.key, args.value)
-                print(f"Set {args.key} = {args.value}")
+async def set_impl(config_path: str, *, key: str, value: str) -> None:
+    """Set a single setting key to a value."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        await db.set_setting(key, value)
+        print(f"Set {key} = {value}")
+    finally:
+        await db.close()
 
-            elif action == "info":
-                stats = await db.get_stats()
-                print("System information:")
-                for key, value in stats.items():
-                    print(f"  {key}: {value}")
 
-            elif action == "server-time":
-                # CLI counterpart of the get_server_time agent tool — same UTC fields.
-                now = datetime.now(timezone.utc)
-                print("Текущее время сервера (UTC):")
-                print(f"  ISO8601: {now.isoformat()}")
-                print(f"  Unix: {int(now.timestamp())}")
-                print(f"  Читаемо: {now.strftime('%Y-%m-%d %H:%M:%S UTC')}")
+async def info_impl(config_path: str) -> None:
+    """Show system diagnostics."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        stats = await db.get_stats()
+        print("System information:")
+        for key, value in stats.items():
+            print(f"  {key}: {value}")
+    finally:
+        await db.close()
 
-            elif action == "agent":
-                # Write the keys the runtime/web actually read — the old
-                # agent_backend / agent_default_prompt_template keys were dead
-                # (nothing read them), so CLI config had zero effect (audit #838/7).
-                from src.agent.prompt_template import AGENT_PROMPT_TEMPLATE_SETTING
 
-                agent_backend_setting = "agent_backend_override"
-                updated = []
-                backend = getattr(args, "backend", None)
-                prompt_template = getattr(args, "prompt_template", None)
-                if backend:
-                    await db.set_setting(agent_backend_setting, backend)
-                    updated.append(f"{agent_backend_setting} = {backend}")
-                if prompt_template:
-                    await db.set_setting(AGENT_PROMPT_TEMPLATE_SETTING, prompt_template)
-                    updated.append(f"{AGENT_PROMPT_TEMPLATE_SETTING} = {prompt_template[:60]}...")
-                if updated:
-                    for u in updated:
-                        print(f"Set {u}")
-                else:
-                    for key in (agent_backend_setting, AGENT_PROMPT_TEMPLATE_SETTING):
-                        val = await db.get_setting(key)
-                        print(f"  {key} = {val or '(not set)'}")
+async def server_time_impl(config_path: str) -> None:
+    """Show the current server time (UTC) — CLI counterpart of get_server_time."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        now = datetime.now(timezone.utc)
+        print("Текущее время сервера (UTC):")
+        print(f"  ISO8601: {now.isoformat()}")
+        print(f"  Unix: {int(now.timestamp())}")
+        print(f"  Читаемо: {now.strftime('%Y-%m-%d %H:%M:%S UTC')}")
+    finally:
+        await db.close()
 
-            elif action == "filter-criteria":
-                mapping = {
-                    "min_uniqueness": "filter_min_uniqueness",
-                    "min_sub_ratio": "filter_min_subscriber_ratio",
-                    "max_cross_dupe": "filter_max_cross_dupe_pct",
-                    "min_cyrillic": "filter_min_cyrillic_pct",
-                }
-                updated = []
-                for attr, setting_key in mapping.items():
-                    val = getattr(args, attr, None)
-                    if val is not None:
-                        await db.set_setting(setting_key, str(val))
-                        updated.append(f"{setting_key} = {val}")
-                if updated:
-                    for u in updated:
-                        print(f"Set {u}")
-                else:
-                    for attr, setting_key in mapping.items():
-                        val = await db.get_setting(setting_key)
-                        print(f"  {setting_key} = {val or '(not set)'}")
 
-            elif action == "reactions":
-                from src.services.telegram_command_dispatcher import (
-                    REACTION_MIN_INTERVAL_CEILING_SEC,
+async def agent_impl(
+    config_path: str, *, backend: str | None = None, prompt_template: str | None = None
+) -> None:
+    """Configure (or show) the agent backend override and default prompt template."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        # Write the keys the runtime/web actually read — the old
+        # agent_backend / agent_default_prompt_template keys were dead
+        # (nothing read them), so CLI config had zero effect (audit #838/7).
+        from src.agent.prompt_template import AGENT_PROMPT_TEMPLATE_SETTING
+
+        agent_backend_setting = "agent_backend_override"
+        updated = []
+        if backend:
+            await db.set_setting(agent_backend_setting, backend)
+            updated.append(f"{agent_backend_setting} = {backend}")
+        if prompt_template:
+            await db.set_setting(AGENT_PROMPT_TEMPLATE_SETTING, prompt_template)
+            updated.append(f"{AGENT_PROMPT_TEMPLATE_SETTING} = {prompt_template[:60]}...")
+        if updated:
+            for u in updated:
+                print(f"Set {u}")
+        else:
+            for key in (agent_backend_setting, AGENT_PROMPT_TEMPLATE_SETTING):
+                val = await db.get_setting(key)
+                print(f"  {key} = {val or '(not set)'}")
+    finally:
+        await db.close()
+
+
+async def filter_criteria_impl(
+    config_path: str,
+    *,
+    min_uniqueness: float | None = None,
+    min_sub_ratio: float | None = None,
+    max_cross_dupe: float | None = None,
+    min_cyrillic: float | None = None,
+) -> None:
+    """Configure (or show) the channel-filter thresholds."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        mapping = {
+            "min_uniqueness": "filter_min_uniqueness",
+            "min_sub_ratio": "filter_min_subscriber_ratio",
+            "max_cross_dupe": "filter_max_cross_dupe_pct",
+            "min_cyrillic": "filter_min_cyrillic_pct",
+        }
+        values = {
+            "min_uniqueness": min_uniqueness,
+            "min_sub_ratio": min_sub_ratio,
+            "max_cross_dupe": max_cross_dupe,
+            "min_cyrillic": min_cyrillic,
+        }
+        updated = []
+        for attr, setting_key in mapping.items():
+            val = values[attr]
+            if val is not None:
+                await db.set_setting(setting_key, str(val))
+                updated.append(f"{setting_key} = {val}")
+        if updated:
+            for u in updated:
+                print(f"Set {u}")
+        else:
+            for attr, setting_key in mapping.items():
+                val = await db.get_setting(setting_key)
+                print(f"  {setting_key} = {val or '(not set)'}")
+    finally:
+        await db.close()
+
+
+async def reactions_impl(config_path: str, *, min_interval: int | None = None) -> None:
+    """Configure (or show) the per-account reaction cadence (clamped 1–300)."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        from src.services.telegram_command_dispatcher import (
+            REACTION_MIN_INTERVAL_CEILING_SEC,
+            REACTION_MIN_INTERVAL_FLOOR_SEC,
+            REACTION_MIN_INTERVAL_SETTING,
+        )
+
+        if min_interval is not None:
+            clamped = int(
+                max(
                     REACTION_MIN_INTERVAL_FLOOR_SEC,
-                    REACTION_MIN_INTERVAL_SETTING,
+                    min(REACTION_MIN_INTERVAL_CEILING_SEC, min_interval),
                 )
+            )
+            await db.set_setting(REACTION_MIN_INTERVAL_SETTING, str(clamped))
+            print(f"Set {REACTION_MIN_INTERVAL_SETTING} = {clamped}")
+        else:
+            val = await db.get_setting(REACTION_MIN_INTERVAL_SETTING)
+            print(f"  {REACTION_MIN_INTERVAL_SETTING} = {val or '(not set)'}")
+    finally:
+        await db.close()
 
-                min_interval = getattr(args, "min_interval", None)
-                if min_interval is not None:
-                    clamped = int(
-                        max(
-                            REACTION_MIN_INTERVAL_FLOOR_SEC,
-                            min(REACTION_MIN_INTERVAL_CEILING_SEC, min_interval),
-                        )
-                    )
-                    await db.set_setting(REACTION_MIN_INTERVAL_SETTING, str(clamped))
-                    print(f"Set {REACTION_MIN_INTERVAL_SETTING} = {clamped}")
-                else:
-                    val = await db.get_setting(REACTION_MIN_INTERVAL_SETTING)
-                    print(f"  {REACTION_MIN_INTERVAL_SETTING} = {val or '(not set)'}")
 
-            elif action == "semantic":
-                # Write the embeddings keys the runtime reads — the old
-                # semantic_provider/_model/_api_key keys were dead (audit #838/7).
-                from src.services.embedding_service import (
-                    EMBEDDINGS_API_KEY_SETTING,
-                    EMBEDDINGS_MODEL_SETTING,
-                    EMBEDDINGS_PROVIDER_SETTING,
-                )
+async def semantic_impl(
+    config_path: str,
+    *,
+    provider: str | None = None,
+    model: str | None = None,
+    api_key: str | None = None,
+) -> None:
+    """Configure (or show) the semantic-search embedding provider/model/key."""
+    _, db = await runtime.init_db(config_path)
+    try:
+        # Write the embeddings keys the runtime reads — the old
+        # semantic_provider/_model/_api_key keys were dead (audit #838/7).
+        from src.services.embedding_service import (
+            EMBEDDINGS_API_KEY_SETTING,
+            EMBEDDINGS_MODEL_SETTING,
+            EMBEDDINGS_PROVIDER_SETTING,
+        )
 
-                semantic_keys = [
-                    ("provider", EMBEDDINGS_PROVIDER_SETTING),
-                    ("model", EMBEDDINGS_MODEL_SETTING),
-                    ("api_key", EMBEDDINGS_API_KEY_SETTING),
-                ]
-                updated = []
-                for attr, setting_key in semantic_keys:
-                    val = getattr(args, attr, None)
-                    if val is not None:
-                        await db.set_setting(setting_key, val)
-                        display = val[:20] + "..." if attr == "api_key" and len(val) > 20 else val
-                        updated.append(f"{setting_key} = {display}")
-                if updated:
-                    for u in updated:
-                        print(f"Set {u}")
-                else:
-                    for _attr, setting_key in semantic_keys:
-                        val = await db.get_setting(setting_key)
-                        if setting_key == EMBEDDINGS_API_KEY_SETTING and val:
-                            val = val[:8] + "..."
-                        print(f"  {setting_key} = {val or '(not set)'}")
-        finally:
-            await db.close()
+        semantic_keys = [
+            ("provider", EMBEDDINGS_PROVIDER_SETTING),
+            ("model", EMBEDDINGS_MODEL_SETTING),
+            ("api_key", EMBEDDINGS_API_KEY_SETTING),
+        ]
+        values = {"provider": provider, "model": model, "api_key": api_key}
+        updated = []
+        for attr, setting_key in semantic_keys:
+            val = values[attr]
+            if val is not None:
+                await db.set_setting(setting_key, val)
+                display = val[:20] + "..." if attr == "api_key" and len(val) > 20 else val
+                updated.append(f"{setting_key} = {display}")
+        if updated:
+            for u in updated:
+                print(f"Set {u}")
+        else:
+            for _attr, setting_key in semantic_keys:
+                val = await db.get_setting(setting_key)
+                if setting_key == EMBEDDINGS_API_KEY_SETTING and val:
+                    val = val[:8] + "..."
+                print(f"  {setting_key} = {val or '(not set)'}")
+    finally:
+        await db.close()
 
-    asyncio.run(_run())
+
+def run(args: argparse.Namespace) -> None:
+    """Thin argparse adapter over the ``*_impl`` bodies (legacy dispatch path).
+
+    The production CLI routes ``settings`` through the Typer ``app`` (#1123); this
+    wrapper keeps the argparse leaf audit and command-level tests working. Args are
+    read via ``getattr`` defaults so partial test Namespaces stay usable (#1117).
+    """
+    action = getattr(args, "settings_action", None) or "get"
+    if action == "get":
+        asyncio.run(get_impl(args.config, key=getattr(args, "key", None)))
+    elif action == "set":
+        asyncio.run(set_impl(args.config, key=args.key, value=args.value))
+    elif action == "info":
+        asyncio.run(info_impl(args.config))
+    elif action == "server-time":
+        asyncio.run(server_time_impl(args.config))
+    elif action == "agent":
+        asyncio.run(
+            agent_impl(
+                args.config,
+                backend=getattr(args, "backend", None),
+                prompt_template=getattr(args, "prompt_template", None),
+            )
+        )
+    elif action == "filter-criteria":
+        asyncio.run(
+            filter_criteria_impl(
+                args.config,
+                min_uniqueness=getattr(args, "min_uniqueness", None),
+                min_sub_ratio=getattr(args, "min_sub_ratio", None),
+                max_cross_dupe=getattr(args, "max_cross_dupe", None),
+                min_cyrillic=getattr(args, "min_cyrillic", None),
+            )
+        )
+    elif action == "reactions":
+        asyncio.run(reactions_impl(args.config, min_interval=getattr(args, "min_interval", None)))
+    elif action == "semantic":
+        asyncio.run(
+            semantic_impl(
+                args.config,
+                provider=getattr(args, "provider", None),
+                model=getattr(args, "model", None),
+                api_key=getattr(args, "api_key", None),
+            )
+        )

--- a/src/cli/typer_commands.py
+++ b/src/cli/typer_commands.py
@@ -68,6 +68,7 @@ from src.cli.commands import image as image_cmd
 from src.cli.commands import mcp_server as mcp_server_cmd
 from src.cli.commands import messages as messages_cmd
 from src.cli.commands import notification as notification_cmd
+from src.cli.commands import photo_loader as photo_loader_cmd
 from src.cli.commands import provider as provider_cmd
 from src.cli.commands import scheduler as scheduler_cmd
 from src.cli.commands import search as search_cmd
@@ -118,6 +119,7 @@ MIGRATED_COMMANDS: frozenset[str] = frozenset(
         "debug", "export", "translate", "image", "provider", "notification",
         # Wave 3 (#1123) — medium groups
         "search-query", "filter", "settings", "scheduler", "account", "agent",
+        "photo-loader",
     }
 )
 
@@ -128,6 +130,17 @@ class ExportFormat(str, Enum):
     json = "json"
     html = "html"
     both = "both"
+
+
+class PhotoMode(str, Enum):
+    """``photo-loader … --mode`` choices — mirrors the argparse ``choices=[…]``.
+
+    Subclasses ``str`` so the command body receives a plain ``"album"``/``"separate"``
+    and ``.value`` round-trips cleanly into the *_impl bodies.
+    """
+
+    album = "album"
+    separate = "separate"
 
 
 # --------------------------------------------------------------------------- #
@@ -1484,6 +1497,218 @@ def agent_test_tools(ctx: typer.Context) -> None:
 
 
 # --------------------------------------------------------------------------- #
+# photo-loader → dialogs / refresh / send / schedule-send / batch-create /
+#                batch-list / items / batch-cancel / auto-create / auto-list /
+#                auto-update / auto-toggle / auto-delete / run-due
+# --------------------------------------------------------------------------- #
+
+photo_loader_app = typer.Typer(no_args_is_help=True, help="Photo upload automation")
+app.add_typer(photo_loader_app, name="photo-loader")
+
+
+@photo_loader_app.command("dialogs")
+def photo_loader_dialogs(
+    ctx: typer.Context,
+    phone: str = typer.Option(..., "--phone", help="Account phone"),
+) -> None:
+    """List dialogs for an account."""
+    apply_startup(ctx)
+    run_async(photo_loader_cmd.dialogs_impl(ctx.obj.config, phone=phone))
+
+
+@photo_loader_app.command("refresh")
+def photo_loader_refresh(
+    ctx: typer.Context,
+    phone: str = typer.Option(..., "--phone", help="Account phone"),
+) -> None:
+    """Refresh dialog cache for photo loader."""
+    apply_startup(ctx)
+    run_async(photo_loader_cmd.refresh_impl(ctx.obj.config, phone=phone))
+
+
+@photo_loader_app.command("send")
+def photo_loader_send(
+    ctx: typer.Context,
+    phone: str = typer.Option(..., "--phone", help="Account phone"),
+    target: str = typer.Option(..., "--target", help="Dialog id"),
+    files: list[str] = typer.Option(..., "--files", help="Photo file paths"),
+    mode: PhotoMode = typer.Option(PhotoMode.album, "--mode"),
+    caption: str | None = typer.Option(None, "--caption", help="Caption"),
+) -> None:
+    """Send photos now."""
+    apply_startup(ctx)
+    run_async(
+        photo_loader_cmd.send_impl(
+            ctx.obj.config, phone=phone, target=target, files=files, mode=mode.value, caption=caption
+        )
+    )
+
+
+@photo_loader_app.command("schedule-send")
+def photo_loader_schedule_send(
+    ctx: typer.Context,
+    phone: str = typer.Option(..., "--phone", help="Account phone"),
+    target: str = typer.Option(..., "--target", help="Dialog id"),
+    files: list[str] = typer.Option(..., "--files", help="Photo file paths"),
+    at: str = typer.Option(..., "--at", help="ISO datetime"),
+    mode: PhotoMode = typer.Option(PhotoMode.album, "--mode"),
+    caption: str | None = typer.Option(None, "--caption", help="Caption"),
+) -> None:
+    """Schedule photo send via Telegram."""
+    apply_startup(ctx)
+    run_async(
+        photo_loader_cmd.schedule_send_impl(
+            ctx.obj.config,
+            phone=phone,
+            target=target,
+            files=files,
+            at=at,
+            mode=mode.value,
+            caption=caption,
+        )
+    )
+
+
+@photo_loader_app.command("batch-create")
+def photo_loader_batch_create(
+    ctx: typer.Context,
+    phone: str = typer.Option(..., "--phone", help="Account phone"),
+    target: str = typer.Option(..., "--target", help="Dialog id"),
+    manifest: str = typer.Option(..., "--manifest", help="JSON/YAML manifest path"),
+    caption: str | None = typer.Option(None, "--caption", help="Default caption"),
+) -> None:
+    """Create delayed batch from manifest."""
+    apply_startup(ctx)
+    run_async(
+        photo_loader_cmd.batch_create_impl(
+            ctx.obj.config, phone=phone, target=target, manifest=manifest, caption=caption
+        )
+    )
+
+
+@photo_loader_app.command("batch-list")
+def photo_loader_batch_list(ctx: typer.Context) -> None:
+    """List photo batches."""
+    apply_startup(ctx)
+    run_async(photo_loader_cmd.batch_list_impl(ctx.obj.config))
+
+
+@photo_loader_app.command("items")
+def photo_loader_items(
+    ctx: typer.Context,
+    batch_id: int | None = typer.Option(None, "--batch-id", help="Filter by batch id"),
+    limit: int = typer.Option(100, "--limit", help="Max items to show"),
+) -> None:
+    """List photo batch items."""
+    apply_startup(ctx)
+    run_async(photo_loader_cmd.items_impl(ctx.obj.config, batch_id=batch_id, limit=limit))
+
+
+@photo_loader_app.command("batch-cancel")
+def photo_loader_batch_cancel(
+    ctx: typer.Context,
+    item_id: int = typer.Argument(..., metavar="id", help="Photo item id"),
+) -> None:
+    """Cancel a photo batch item."""
+    apply_startup(ctx)
+    run_async(photo_loader_cmd.batch_cancel_impl(ctx.obj.config, item_id=item_id))
+
+
+@photo_loader_app.command("auto-create")
+def photo_loader_auto_create(
+    ctx: typer.Context,
+    phone: str = typer.Option(..., "--phone", help="Account phone"),
+    target: str = typer.Option(..., "--target", help="Dialog id"),
+    folder: str = typer.Option(..., "--folder", help="Folder path"),
+    interval: int = typer.Option(..., "--interval", help="Interval in minutes"),
+    mode: PhotoMode = typer.Option(PhotoMode.album, "--mode"),
+    caption: str | None = typer.Option(None, "--caption", help="Caption"),
+) -> None:
+    """Create auto-upload job."""
+    apply_startup(ctx)
+    run_async(
+        photo_loader_cmd.auto_create_impl(
+            ctx.obj.config,
+            phone=phone,
+            target=target,
+            folder=folder,
+            interval=interval,
+            mode=mode.value,
+            caption=caption,
+        )
+    )
+
+
+@photo_loader_app.command("auto-list")
+def photo_loader_auto_list(ctx: typer.Context) -> None:
+    """List auto-upload jobs."""
+    apply_startup(ctx)
+    run_async(photo_loader_cmd.auto_list_impl(ctx.obj.config))
+
+
+@photo_loader_app.command("auto-update")
+def photo_loader_auto_update(
+    ctx: typer.Context,
+    job_id: int = typer.Argument(..., metavar="id", help="Job id"),
+    folder: str | None = typer.Option(None, "--folder", help="Folder path"),
+    interval: int | None = typer.Option(None, "--interval", help="Interval in minutes"),
+    mode: PhotoMode | None = typer.Option(None, "--mode"),
+    caption: str | None = typer.Option(None, "--caption", help="Caption"),
+    active: bool = typer.Option(False, "--active", help="Enable job"),
+    paused: bool = typer.Option(False, "--paused", help="Pause job"),
+) -> None:
+    """Update auto-upload job."""
+    apply_startup(ctx)
+    run_async(
+        photo_loader_cmd.auto_update_impl(
+            ctx.obj.config,
+            job_id=job_id,
+            folder=folder,
+            interval=interval,
+            mode=mode.value if mode else None,
+            caption=caption,
+            active=active,
+            paused=paused,
+        )
+    )
+
+
+@photo_loader_app.command("auto-toggle")
+def photo_loader_auto_toggle(
+    ctx: typer.Context,
+    job_id: int = typer.Argument(..., metavar="id", help="Job id"),
+) -> None:
+    """Toggle auto-upload job."""
+    apply_startup(ctx)
+    run_async(photo_loader_cmd.auto_toggle_impl(ctx.obj.config, job_id=job_id))
+
+
+@photo_loader_app.command("auto-delete")
+def photo_loader_auto_delete(
+    ctx: typer.Context,
+    job_id: int = typer.Argument(..., metavar="id", help="Job id"),
+) -> None:
+    """Delete auto-upload job."""
+    apply_startup(ctx)
+    run_async(photo_loader_cmd.auto_delete_impl(ctx.obj.config, job_id=job_id))
+
+
+@photo_loader_app.command("run-due")
+def photo_loader_run_due(
+    ctx: typer.Context,
+    item_id: int | None = typer.Option(None, "--item-id", help="Run only one due photo item"),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Preview which auto-job files would be posted (where/when) without sending or marking",
+    ),
+) -> None:
+    """Run due photo items and auto jobs now."""
+    apply_startup(ctx)
+    run_async(photo_loader_cmd.run_due_impl(ctx.obj.config, item_id=item_id, dry_run=dry_run))
+
+
+# --------------------------------------------------------------------------- #
 # argparse → Typer delegation
 # --------------------------------------------------------------------------- #
 
@@ -1577,6 +1802,9 @@ def _argv_from_namespace(args: argparse.Namespace) -> list[str]:
     elif command == "agent":
         argv.append("agent")
         argv += _agent_argv(args)
+    elif command == "photo-loader":
+        argv.append("photo-loader")
+        argv += _photo_loader_argv(args)
     return argv
 
 
@@ -1706,6 +1934,81 @@ def _notification_argv(args: argparse.Namespace) -> list[str]:
             tail += ["--message", args.message]
     elif action == "set-account":
         tail += ["--phone", args.phone]
+    return tail
+
+
+def _photo_loader_argv(args: argparse.Namespace) -> list[str]:
+    """argv tail for ``photo-loader`` — the action plus its flags / positionals.
+
+    ``--files`` is a repeated option (one ``--files <path>`` per file). ``--mode``
+    carries the album/separate choice. batch-cancel / auto-* take a positional id
+    emitted after ``--``.
+    """
+    action = getattr(args, "photo_loader_action", None)
+    if action is None:
+        return []
+    tail = [action]
+
+    def _emit_files() -> None:
+        for f in args.files:
+            tail.extend(["--files", f])
+
+    if action in ("dialogs", "refresh"):
+        tail += ["--phone", args.phone]
+    elif action == "send":
+        tail += ["--phone", args.phone, "--target", args.target]
+        _emit_files()
+        if getattr(args, "mode", "album") != "album":
+            tail += ["--mode", args.mode]
+        if getattr(args, "caption", None):
+            tail += ["--caption", args.caption]
+    elif action == "schedule-send":
+        tail += ["--phone", args.phone, "--target", args.target]
+        _emit_files()
+        tail += ["--at", args.at]
+        if getattr(args, "mode", "album") != "album":
+            tail += ["--mode", args.mode]
+        if getattr(args, "caption", None):
+            tail += ["--caption", args.caption]
+    elif action == "batch-create":
+        tail += ["--phone", args.phone, "--target", args.target, "--manifest", args.manifest]
+        if getattr(args, "caption", None):
+            tail += ["--caption", args.caption]
+    elif action == "items":
+        if getattr(args, "batch_id", None) is not None:
+            tail += ["--batch-id", str(args.batch_id)]
+        if getattr(args, "limit", 100) != 100:
+            tail += ["--limit", str(args.limit)]
+    elif action in ("batch-cancel", "auto-toggle", "auto-delete"):
+        tail += ["--", str(args.id)]
+    elif action == "auto-create":
+        tail += [
+            "--phone", args.phone, "--target", args.target,
+            "--folder", args.folder, "--interval", str(args.interval),
+        ]
+        if getattr(args, "mode", "album") != "album":
+            tail += ["--mode", args.mode]
+        if getattr(args, "caption", None):
+            tail += ["--caption", args.caption]
+    elif action == "auto-update":
+        if getattr(args, "folder", None):
+            tail += ["--folder", args.folder]
+        if getattr(args, "interval", None) is not None:
+            tail += ["--interval", str(args.interval)]
+        if getattr(args, "mode", None):
+            tail += ["--mode", args.mode]
+        if getattr(args, "caption", None):
+            tail += ["--caption", args.caption]
+        if getattr(args, "active", False):
+            tail.append("--active")
+        if getattr(args, "paused", False):
+            tail.append("--paused")
+        tail += ["--", str(args.id)]
+    elif action == "run-due":
+        if getattr(args, "item_id", None) is not None:
+            tail += ["--item-id", str(args.item_id)]
+        if getattr(args, "dry_run", False):
+            tail.append("--dry-run")
     return tail
 
 

--- a/src/cli/typer_commands.py
+++ b/src/cli/typer_commands.py
@@ -759,8 +759,8 @@ def search_query_add(
     regex: bool = typer.Option(False, "--regex", help="Use regex matching"),
     fts: bool = typer.Option(False, "--fts", help="Use FTS5 boolean syntax (no quoting)"),
     notify: bool = typer.Option(False, "--notify", help="Notify on collect"),
-    track_stats: bool = typer.Option(
-        True, "--track-stats/--no-track-stats", help="Track stats (default: on)"
+    no_track_stats: bool = typer.Option(
+        False, "--no-track-stats", help="Disable stat tracking (default: tracking on)"
     ),
     exclude_patterns: str = typer.Option(
         "", "--exclude-patterns", help="Exclude patterns, one per line (use \\n)"
@@ -770,6 +770,9 @@ def search_query_add(
 ) -> None:
     """Add search query."""
     apply_startup(ctx)
+    # argparse declares ONLY ``--no-track-stats`` (store_false, default True) on
+    # ``add`` — no ``--track-stats`` flag. Mirror that exactly so the Typer surface
+    # is not one flag wider than argparse (#1123 review).
     run_async(
         search_query_cmd.add_impl(
             ctx.obj.config,
@@ -778,7 +781,7 @@ def search_query_add(
             is_regex=regex,
             is_fts=fts,
             notify=notify,
-            track_stats=track_stats,
+            track_stats=not no_track_stats,
             exclude_patterns=exclude_patterns,
             max_length=max_length,
             chats=chats,
@@ -967,8 +970,23 @@ def filter_hard_delete(
 #            / reactions / semantic
 # --------------------------------------------------------------------------- #
 
-settings_app = typer.Typer(no_args_is_help=True, help="System settings management")
+settings_app = typer.Typer(
+    invoke_without_command=True, help="System settings management"
+)
 app.add_typer(settings_app, name="settings")
+
+
+@settings_app.callback()
+def settings_main(ctx: typer.Context) -> None:
+    """Bare ``settings`` (no sub-command) runs ``get`` — argparse parity (#1123 review).
+
+    The legacy dispatcher defaulted ``settings_action`` to ``get`` and listed all
+    settings; preserve that on the direct Typer surface, not just the argparse
+    bridge. With a sub-command this is a no-op and the sub-command runs normally.
+    """
+    if ctx.invoked_subcommand is None:
+        apply_startup(ctx)
+        run_async(settings_cmd.get_impl(ctx.obj.config, key=None))
 
 
 @settings_app.command("get")
@@ -1997,7 +2015,10 @@ def _photo_loader_argv(args: argparse.Namespace) -> list[str]:
             tail += ["--interval", str(args.interval)]
         if getattr(args, "mode", None):
             tail += ["--mode", args.mode]
-        if getattr(args, "caption", None):
+        # ``--caption ""`` is a deliberate CLEAR (repo writes when caption is not
+        # None); use ``is not None`` so an empty string is not dropped as "unset"
+        # the way truthiness would (#1123 review).
+        if getattr(args, "caption", None) is not None:
             tail += ["--caption", args.caption]
         if getattr(args, "active", False):
             tail.append("--active")

--- a/src/cli/typer_commands.py
+++ b/src/cli/typer_commands.py
@@ -59,6 +59,7 @@ except ImportError:  # pragma: no cover - defensive fallback
     _NO_ARGS_HELP_EXCEPTIONS = (click.exceptions.NoArgsIsHelpError,)
 
 from src.cli.commands import account as account_cmd
+from src.cli.commands import agent as agent_cmd
 from src.cli.commands import collect as collect_cmd
 from src.cli.commands import debug as debug_cmd
 from src.cli.commands import export as export_cmd
@@ -116,7 +117,7 @@ MIGRATED_COMMANDS: frozenset[str] = frozenset(
         # Wave 2 (#1122) — flat simple groups
         "debug", "export", "translate", "image", "provider", "notification",
         # Wave 3 (#1123) — medium groups
-        "search-query", "filter", "settings", "scheduler", "account",
+        "search-query", "filter", "settings", "scheduler", "account", "agent",
     }
 )
 
@@ -1366,6 +1367,123 @@ def account_import(
 
 
 # --------------------------------------------------------------------------- #
+# agent → threads / thread-create / thread-delete / chat / thread-rename /
+#         thread-stop / messages / context / test-escaping / test-tools
+# --------------------------------------------------------------------------- #
+
+agent_app = typer.Typer(no_args_is_help=True, help="Agent chat management")
+app.add_typer(agent_app, name="agent")
+
+
+@agent_app.command("threads")
+def agent_threads(ctx: typer.Context) -> None:
+    """List agent threads."""
+    apply_startup(ctx)
+    run_async(agent_cmd.threads_impl(ctx.obj.config))
+
+
+@agent_app.command("thread-create")
+def agent_thread_create(
+    ctx: typer.Context,
+    title: str | None = typer.Option(None, "--title", help="Thread title"),
+) -> None:
+    """Create new thread."""
+    apply_startup(ctx)
+    run_async(agent_cmd.thread_create_impl(ctx.obj.config, title=title))
+
+
+@agent_app.command("thread-delete")
+def agent_thread_delete(
+    ctx: typer.Context,
+    thread_id: int = typer.Argument(..., help="Thread ID"),
+) -> None:
+    """Delete thread."""
+    apply_startup(ctx)
+    run_async(agent_cmd.thread_delete_impl(ctx.obj.config, thread_id=thread_id))
+
+
+@agent_app.command("chat")
+def agent_chat(
+    ctx: typer.Context,
+    prompt: str | None = typer.Option(
+        None, "-p", "--prompt", help="Message text (non-interactive mode)"
+    ),
+    thread_id: int | None = typer.Option(None, "--thread-id"),
+    model: str | None = typer.Option(None, "--model", help="Model name"),
+) -> None:
+    """Interactive TUI chat or one-shot message (with -p)."""
+    apply_startup(ctx)
+    run_async(agent_cmd.chat_impl(ctx.obj.config, prompt=prompt, thread_id=thread_id, model=model))
+
+
+@agent_app.command("thread-rename")
+def agent_thread_rename(
+    ctx: typer.Context,
+    thread_id: int = typer.Argument(..., help="Thread ID"),
+    title: str = typer.Argument(..., help="New title"),
+) -> None:
+    """Rename thread."""
+    apply_startup(ctx)
+    run_async(agent_cmd.thread_rename_impl(ctx.obj.config, thread_id=thread_id, title=title))
+
+
+@agent_app.command("thread-stop")
+def agent_thread_stop(
+    ctx: typer.Context,
+    thread_id: int = typer.Argument(..., help="Thread ID"),
+) -> None:
+    """Stop/cancel an ongoing agent response for a thread."""
+    apply_startup(ctx)
+    run_async(agent_cmd.thread_stop_impl(ctx.obj.config, thread_id=thread_id))
+
+
+@agent_app.command("messages")
+def agent_messages(
+    ctx: typer.Context,
+    thread_id: int = typer.Argument(..., help="Thread ID"),
+    limit: int | None = typer.Option(None, "--limit", help="Last N messages"),
+) -> None:
+    """Show thread messages."""
+    apply_startup(ctx)
+    run_async(agent_cmd.messages_impl(ctx.obj.config, thread_id=thread_id, limit=limit))
+
+
+@agent_app.command("context")
+def agent_context(
+    ctx: typer.Context,
+    thread_id: int = typer.Argument(..., help="Thread ID"),
+    channel_id: int = typer.Option(..., "--channel-id"),
+    limit: int = typer.Option(100000, "--limit", help="Max messages"),
+    topic_id: int | None = typer.Option(None, "--topic-id"),
+) -> None:
+    """Inject channel context into thread."""
+    apply_startup(ctx)
+    run_async(
+        agent_cmd.context_impl(
+            ctx.obj.config,
+            thread_id=thread_id,
+            channel_id=channel_id,
+            limit=limit,
+            topic_id=topic_id,
+        )
+    )
+
+
+@agent_app.command("test-escaping")
+def agent_test_escaping(ctx: typer.Context) -> None:
+    """Test agent with special characters."""
+    apply_startup(ctx)
+    run_async(agent_cmd.test_escaping_impl(ctx.obj.config))
+
+
+@agent_app.command("test-tools")
+def agent_test_tools(ctx: typer.Context) -> None:
+    """Test that agent tool calls produce tool_start/tool_end events."""
+    apply_startup(ctx)
+    run_async(agent_cmd.test_tools_impl(ctx.obj.config))
+
+
+# --------------------------------------------------------------------------- #
 # argparse → Typer delegation
 # --------------------------------------------------------------------------- #
 
@@ -1456,6 +1574,9 @@ def _argv_from_namespace(args: argparse.Namespace) -> list[str]:
     elif command == "account":
         argv.append("account")
         argv += _account_argv(args)
+    elif command == "agent":
+        argv.append("agent")
+        argv += _agent_argv(args)
     return argv
 
 
@@ -1585,6 +1706,46 @@ def _notification_argv(args: argparse.Namespace) -> list[str]:
             tail += ["--message", args.message]
     elif action == "set-account":
         tail += ["--phone", args.phone]
+    return tail
+
+
+def _agent_argv(args: argparse.Namespace) -> list[str]:
+    """argv tail for ``agent`` — the action plus its flags / positionals.
+
+    Positionals (thread ids, the rename title) and the free-text chat ``--prompt``
+    go after ``--`` so values that look option-like survive Click's parser.
+    """
+    action = getattr(args, "agent_action", None)
+    if action is None:
+        return []
+    tail = [action]
+    if action == "thread-create":
+        if getattr(args, "title", None):
+            tail += ["--title", args.title]
+    elif action in ("thread-delete", "thread-stop"):
+        tail += ["--", str(args.thread_id)]
+    elif action == "chat":
+        if getattr(args, "thread_id", None) is not None:
+            tail += ["--thread-id", str(args.thread_id)]
+        if getattr(args, "model", None):
+            tail += ["--model", args.model]
+        if getattr(args, "prompt", None) is not None:
+            # ``--prompt=<text>`` (attached form) so a value with a leading ``-``
+            # is not mistaken for another option by Click.
+            tail.append(f"--prompt={args.prompt}")
+    elif action == "thread-rename":
+        tail += ["--", str(args.thread_id), args.title]
+    elif action == "messages":
+        if getattr(args, "limit", None) is not None:
+            tail += ["--limit", str(args.limit)]
+        tail += ["--", str(args.thread_id)]
+    elif action == "context":
+        tail += ["--channel-id", str(args.channel_id)]
+        if getattr(args, "limit", 100000) != 100000:
+            tail += ["--limit", str(args.limit)]
+        if getattr(args, "topic_id", None) is not None:
+            tail += ["--topic-id", str(args.topic_id)]
+        tail += ["--", str(args.thread_id)]
     return tail
 
 

--- a/src/cli/typer_commands.py
+++ b/src/cli/typer_commands.py
@@ -67,6 +67,7 @@ from src.cli.commands import mcp_server as mcp_server_cmd
 from src.cli.commands import messages as messages_cmd
 from src.cli.commands import notification as notification_cmd
 from src.cli.commands import provider as provider_cmd
+from src.cli.commands import scheduler as scheduler_cmd
 from src.cli.commands import search as search_cmd
 from src.cli.commands import search_query as search_query_cmd
 from src.cli.commands import serve as serve_cmd
@@ -114,7 +115,7 @@ MIGRATED_COMMANDS: frozenset[str] = frozenset(
         # Wave 2 (#1122) — flat simple groups
         "debug", "export", "translate", "image", "provider", "notification",
         # Wave 3 (#1123) — medium groups
-        "search-query", "filter", "settings",
+        "search-query", "filter", "settings", "scheduler",
     }
 )
 
@@ -1059,6 +1060,95 @@ def settings_semantic(
 
 
 # --------------------------------------------------------------------------- #
+# scheduler → start / trigger / status / stop / job-toggle / set-interval
+#             / task-cancel / clear-pending / queue-pause / queue-resume
+# --------------------------------------------------------------------------- #
+
+scheduler_app = typer.Typer(no_args_is_help=True, help="Scheduler control")
+app.add_typer(scheduler_app, name="scheduler")
+
+
+@scheduler_app.command("start")
+def scheduler_start(ctx: typer.Context) -> None:
+    """Start scheduler (foreground)."""
+    apply_startup(ctx)
+    run_async(scheduler_cmd.start_impl(ctx.obj.config))
+
+
+@scheduler_app.command("trigger")
+def scheduler_trigger(ctx: typer.Context) -> None:
+    """Trigger one-shot collection."""
+    apply_startup(ctx)
+    run_async(scheduler_cmd.trigger_impl(ctx.obj.config))
+
+
+@scheduler_app.command("status")
+def scheduler_status(ctx: typer.Context) -> None:
+    """Show scheduler configuration and status."""
+    apply_startup(ctx)
+    run_async(scheduler_cmd.status_impl(ctx.obj.config))
+
+
+@scheduler_app.command("stop")
+def scheduler_stop(ctx: typer.Context) -> None:
+    """Disable scheduler autostart."""
+    apply_startup(ctx)
+    run_async(scheduler_cmd.stop_impl(ctx.obj.config))
+
+
+@scheduler_app.command("job-toggle")
+def scheduler_job_toggle(
+    ctx: typer.Context,
+    job_id: str = typer.Argument(..., help="Job identifier (e.g. collect_all, sq_1)"),
+) -> None:
+    """Toggle scheduler job enabled/disabled."""
+    apply_startup(ctx)
+    run_async(scheduler_cmd.job_toggle_impl(ctx.obj.config, job_id=job_id))
+
+
+@scheduler_app.command("set-interval")
+def scheduler_set_interval(
+    ctx: typer.Context,
+    job_id: str = typer.Argument(..., help="Job identifier"),
+    minutes: int = typer.Argument(..., help="Interval in minutes (1-1440)"),
+) -> None:
+    """Set scheduler job interval."""
+    apply_startup(ctx)
+    run_async(scheduler_cmd.set_interval_impl(ctx.obj.config, job_id=job_id, minutes=minutes))
+
+
+@scheduler_app.command("task-cancel")
+def scheduler_task_cancel(
+    ctx: typer.Context,
+    task_id: int = typer.Argument(..., help="Task ID to cancel"),
+) -> None:
+    """Cancel a collection task."""
+    apply_startup(ctx)
+    run_async(scheduler_cmd.task_cancel_impl(ctx.obj.config, task_id=task_id))
+
+
+@scheduler_app.command("clear-pending")
+def scheduler_clear_pending(ctx: typer.Context) -> None:
+    """Clear all pending collection tasks."""
+    apply_startup(ctx)
+    run_async(scheduler_cmd.clear_pending_impl(ctx.obj.config))
+
+
+@scheduler_app.command("queue-pause")
+def scheduler_queue_pause(ctx: typer.Context) -> None:
+    """Pause the collection queue (queued tasks stay pending)."""
+    apply_startup(ctx)
+    run_async(scheduler_cmd.queue_pause_impl(ctx.obj.config))
+
+
+@scheduler_app.command("queue-resume")
+def scheduler_queue_resume(ctx: typer.Context) -> None:
+    """Resume the collection queue."""
+    apply_startup(ctx)
+    run_async(scheduler_cmd.queue_resume_impl(ctx.obj.config))
+
+
+# --------------------------------------------------------------------------- #
 # argparse → Typer delegation
 # --------------------------------------------------------------------------- #
 
@@ -1143,6 +1233,9 @@ def _argv_from_namespace(args: argparse.Namespace) -> list[str]:
     elif command == "settings":
         argv.append("settings")
         argv += _settings_argv(args)
+    elif command == "scheduler":
+        argv.append("scheduler")
+        argv += _scheduler_argv(args)
     return argv
 
 
@@ -1272,6 +1365,25 @@ def _notification_argv(args: argparse.Namespace) -> list[str]:
             tail += ["--message", args.message]
     elif action == "set-account":
         tail += ["--phone", args.phone]
+    return tail
+
+
+def _scheduler_argv(args: argparse.Namespace) -> list[str]:
+    """argv tail for ``scheduler`` — the action plus its positional args.
+
+    job-toggle/set-interval/task-cancel carry positionals; they are emitted after
+    ``--`` so a value that looks option-like survives Click's parser.
+    """
+    action = getattr(args, "scheduler_action", None)
+    if action is None:
+        return []
+    tail = [action]
+    if action == "job-toggle":
+        tail += ["--", args.job_id]
+    elif action == "set-interval":
+        tail += ["--", args.job_id, str(args.minutes)]
+    elif action == "task-cancel":
+        tail += ["--", str(args.task_id)]
     return tail
 
 

--- a/src/cli/typer_commands.py
+++ b/src/cli/typer_commands.py
@@ -1549,6 +1549,12 @@ def photo_loader_send(
     ctx: typer.Context,
     phone: str = typer.Option(..., "--phone", help="Account phone"),
     target: str = typer.Option(..., "--target", help="Dialog id"),
+    # argparse uses ``--files a b c`` (nargs='+'). Click options can't be variadic
+    # (``nargs=-1`` is arguments-only), so the Typer leaf takes the repeated form
+    # ``--files a --files b``. The production path is unaffected: main.py parses with
+    # argparse first and ``_photo_loader_argv`` rewrites ``--files a b`` into the
+    # repeated form before invoking Typer. The single-flag form is restored when the
+    # argparse layer is removed in the final wave (#1125, #1123 review).
     files: list[str] = typer.Option(..., "--files", help="Photo file paths"),
     mode: PhotoMode = typer.Option(PhotoMode.album, "--mode"),
     caption: str | None = typer.Option(None, "--caption", help="Caption"),

--- a/src/cli/typer_commands.py
+++ b/src/cli/typer_commands.py
@@ -67,6 +67,7 @@ from src.cli.commands import messages as messages_cmd
 from src.cli.commands import notification as notification_cmd
 from src.cli.commands import provider as provider_cmd
 from src.cli.commands import search as search_cmd
+from src.cli.commands import search_query as search_query_cmd
 from src.cli.commands import serve as serve_cmd
 from src.cli.commands import server_control as server_control_cmd
 from src.cli.commands import translate as translate_cmd
@@ -110,6 +111,8 @@ MIGRATED_COMMANDS: frozenset[str] = frozenset(
         "serve", "worker", "stop", "restart", "mcp-server", "collect", "search", "messages",
         # Wave 2 (#1122) — flat simple groups
         "debug", "export", "translate", "image", "provider", "notification",
+        # Wave 3 (#1123) — medium groups
+        "search-query",
     }
 )
 
@@ -706,6 +709,154 @@ def notification_set_account(
 
 
 # --------------------------------------------------------------------------- #
+# search-query → list / get / add / edit / delete / toggle / run / stats
+# --------------------------------------------------------------------------- #
+
+search_query_app = typer.Typer(no_args_is_help=True, help="Search query management")
+app.add_typer(search_query_app, name="search-query")
+
+
+@search_query_app.command("list")
+def search_query_list(ctx: typer.Context) -> None:
+    """List search queries."""
+    apply_startup(ctx)
+    run_async(search_query_cmd.list_impl(ctx.obj.config))
+
+
+@search_query_app.command("get")
+def search_query_get(
+    ctx: typer.Context,
+    query_id: int = typer.Argument(..., metavar="id", help="Search query id"),
+) -> None:
+    """Show search query details."""
+    apply_startup(ctx)
+    run_async(search_query_cmd.get_impl(ctx.obj.config, query_id=query_id))
+
+
+@search_query_app.command("add")
+def search_query_add(
+    ctx: typer.Context,
+    query: str = typer.Argument(..., help="FTS5 search query text"),
+    interval: int = typer.Option(60, "--interval", help="Run interval in minutes"),
+    regex: bool = typer.Option(False, "--regex", help="Use regex matching"),
+    fts: bool = typer.Option(False, "--fts", help="Use FTS5 boolean syntax (no quoting)"),
+    notify: bool = typer.Option(False, "--notify", help="Notify on collect"),
+    track_stats: bool = typer.Option(
+        True, "--track-stats/--no-track-stats", help="Track stats (default: on)"
+    ),
+    exclude_patterns: str = typer.Option(
+        "", "--exclude-patterns", help="Exclude patterns, one per line (use \\n)"
+    ),
+    max_length: int | None = typer.Option(None, "--max-length", help="Max message text length"),
+    chats: str = typer.Option("", "--chats", help="Chat filter: IDs, usernames or t.me links"),
+) -> None:
+    """Add search query."""
+    apply_startup(ctx)
+    run_async(
+        search_query_cmd.add_impl(
+            ctx.obj.config,
+            query=query,
+            interval=interval,
+            is_regex=regex,
+            is_fts=fts,
+            notify=notify,
+            track_stats=track_stats,
+            exclude_patterns=exclude_patterns,
+            max_length=max_length,
+            chats=chats,
+        )
+    )
+
+
+@search_query_app.command("edit")
+def search_query_edit(
+    ctx: typer.Context,
+    query_id: int = typer.Argument(..., metavar="id", help="Search query id"),
+    query: str | None = typer.Option(None, "--query", help="New query text"),
+    interval: int | None = typer.Option(None, "--interval", help="New interval in minutes"),
+    regex: bool | None = typer.Option(None, "--regex/--no-regex", help="Toggle regex matching"),
+    fts: bool | None = typer.Option(None, "--fts/--no-fts", help="Toggle FTS5 syntax"),
+    notify: bool | None = typer.Option(None, "--notify/--no-notify", help="Toggle notify on collect"),
+    track_stats: bool | None = typer.Option(
+        None, "--track-stats/--no-track-stats", help="Toggle stat tracking"
+    ),
+    exclude_patterns: str | None = typer.Option(
+        None, "--exclude-patterns", help="Exclude patterns (use \\n)"
+    ),
+    max_length: int | None = typer.Option(None, "--max-length", help="Max message text length"),
+    clear_max_length: bool = typer.Option(
+        False, "--no-max-length", help="Clear the max-length limit"
+    ),
+    chats: str | None = typer.Option(
+        None, "--chats", help="Chat filter: IDs, usernames or t.me links"
+    ),
+    clear_chats: bool = typer.Option(False, "--clear-chats", help="Clear the chat filter"),
+) -> None:
+    """Edit search query; unset flags keep their current value."""
+    apply_startup(ctx)
+    # ``--no-max-length`` maps to the sentinel -1 the impl treats as "clear";
+    # ``--clear-chats`` maps to "" — mirrors the argparse store_const declarations.
+    resolved_max_length = -1 if clear_max_length else max_length
+    resolved_chats = "" if clear_chats else chats
+    run_async(
+        search_query_cmd.edit_impl(
+            ctx.obj.config,
+            query_id=query_id,
+            query=query,
+            interval=interval,
+            is_regex=regex,
+            is_fts=fts,
+            notify=notify,
+            track_stats=track_stats,
+            exclude_patterns=exclude_patterns,
+            max_length=resolved_max_length,
+            chats=resolved_chats,
+        )
+    )
+
+
+@search_query_app.command("delete")
+def search_query_delete(
+    ctx: typer.Context,
+    query_id: int = typer.Argument(..., metavar="id", help="Search query id"),
+) -> None:
+    """Delete search query."""
+    apply_startup(ctx)
+    run_async(search_query_cmd.delete_impl(ctx.obj.config, query_id=query_id))
+
+
+@search_query_app.command("toggle")
+def search_query_toggle(
+    ctx: typer.Context,
+    query_id: int = typer.Argument(..., metavar="id", help="Search query id"),
+) -> None:
+    """Toggle search query active state."""
+    apply_startup(ctx)
+    run_async(search_query_cmd.toggle_impl(ctx.obj.config, query_id=query_id))
+
+
+@search_query_app.command("run")
+def search_query_run(
+    ctx: typer.Context,
+    query_id: int = typer.Argument(..., metavar="id", help="Search query id"),
+) -> None:
+    """Run a search query once and show matches."""
+    apply_startup(ctx)
+    run_async(search_query_cmd.run_impl(ctx.obj.config, query_id=query_id))
+
+
+@search_query_app.command("stats")
+def search_query_stats(
+    ctx: typer.Context,
+    query_id: int = typer.Argument(..., metavar="id", help="Search query id"),
+    days: int = typer.Option(30, "--days", help="Number of days"),
+) -> None:
+    """Show daily stats for a search query."""
+    apply_startup(ctx)
+    run_async(search_query_cmd.stats_impl(ctx.obj.config, query_id=query_id, days=days))
+
+
+# --------------------------------------------------------------------------- #
 # argparse → Typer delegation
 # --------------------------------------------------------------------------- #
 
@@ -781,6 +932,9 @@ def _argv_from_namespace(args: argparse.Namespace) -> list[str]:
     elif command == "notification":
         argv.append("notification")
         argv += _notification_argv(args)
+    elif command == "search-query":
+        argv.append("search-query")
+        argv += _search_query_argv(args)
     return argv
 
 
@@ -910,6 +1064,90 @@ def _notification_argv(args: argparse.Namespace) -> list[str]:
             tail += ["--message", args.message]
     elif action == "set-account":
         tail += ["--phone", args.phone]
+    return tail
+
+
+def _search_query_argv(args: argparse.Namespace) -> list[str]:
+    """argv tail for ``search-query`` — the action plus its flags / positionals.
+
+    ``add`` and ``edit`` share many flags but with different defaults: ``add`` has
+    store_true flags (absent unless set) and a positional query; ``edit`` uses
+    tri-state flags (``--x`` / ``--no-x``, default ``None`` = leave unchanged) plus
+    the ``--no-max-length`` / ``--clear-chats`` sentinels. We emit each flag only
+    when it diverges from its default so the Typer command sees the same resolved
+    state argparse produced.
+    """
+    action = getattr(args, "search_query_action", None)
+    if action is None:
+        return []
+    tail = [action]
+    if action == "get":
+        tail += ["--", str(args.id)]
+    elif action in ("delete", "toggle", "run"):
+        tail += ["--", str(args.id)]
+    elif action == "stats":
+        if getattr(args, "days", 30) != 30:
+            tail += ["--days", str(args.days)]
+        tail += ["--", str(args.id)]
+    elif action == "add":
+        if getattr(args, "interval", 60) != 60:
+            tail += ["--interval", str(args.interval)]
+        if getattr(args, "regex", False):
+            tail.append("--regex")
+        if getattr(args, "fts", False):
+            tail.append("--fts")
+        if getattr(args, "notify", False):
+            tail.append("--notify")
+        if getattr(args, "track_stats", True) is False:
+            tail.append("--no-track-stats")
+        if getattr(args, "exclude_patterns", ""):
+            tail += ["--exclude-patterns", args.exclude_patterns]
+        if getattr(args, "max_length", None) is not None:
+            tail += ["--max-length", str(args.max_length)]
+        if getattr(args, "chats", ""):
+            tail += ["--chats", args.chats]
+        # Positional query after ``--`` so a leading ``-`` survives Click parsing.
+        tail += ["--", args.query]
+    elif action == "edit":
+        if getattr(args, "query", None):
+            tail += ["--query", args.query]
+        if getattr(args, "interval", None) is not None:
+            tail += ["--interval", str(args.interval)]
+        regex = getattr(args, "regex", None)
+        if regex is True:
+            tail.append("--regex")
+        elif regex is False:
+            tail.append("--no-regex")
+        fts = getattr(args, "fts", None)
+        if fts is True:
+            tail.append("--fts")
+        elif fts is False:
+            tail.append("--no-fts")
+        notify = getattr(args, "notify", None)
+        if notify is True:
+            tail.append("--notify")
+        elif notify is False:
+            tail.append("--no-notify")
+        track_stats = getattr(args, "track_stats", None)
+        if track_stats is True:
+            tail.append("--track-stats")
+        elif track_stats is False:
+            tail.append("--no-track-stats")
+        if getattr(args, "exclude_patterns", None) is not None:
+            tail += ["--exclude-patterns", args.exclude_patterns]
+        max_length = getattr(args, "max_length", None)
+        # argparse maps --no-max-length onto the -1 store_const sentinel.
+        if max_length == -1:
+            tail.append("--no-max-length")
+        elif max_length is not None:
+            tail += ["--max-length", str(max_length)]
+        chats = getattr(args, "chats", None)
+        # --clear-chats is the "" store_const; --chats carries any other value.
+        if chats == "":
+            tail.append("--clear-chats")
+        elif chats is not None:
+            tail += ["--chats", chats]
+        tail += ["--", str(args.id)]
     return tail
 
 

--- a/src/cli/typer_commands.py
+++ b/src/cli/typer_commands.py
@@ -71,6 +71,7 @@ from src.cli.commands import search as search_cmd
 from src.cli.commands import search_query as search_query_cmd
 from src.cli.commands import serve as serve_cmd
 from src.cli.commands import server_control as server_control_cmd
+from src.cli.commands import settings as settings_cmd
 from src.cli.commands import translate as translate_cmd
 from src.cli.commands import worker as worker_cmd
 from src.cli.typer_app import app, apply_startup, run_async
@@ -113,7 +114,7 @@ MIGRATED_COMMANDS: frozenset[str] = frozenset(
         # Wave 2 (#1122) — flat simple groups
         "debug", "export", "translate", "image", "provider", "notification",
         # Wave 3 (#1123) — medium groups
-        "search-query", "filter",
+        "search-query", "filter", "settings",
     }
 )
 
@@ -946,6 +947,118 @@ def filter_hard_delete(
 
 
 # --------------------------------------------------------------------------- #
+# settings → get / set / info / server-time / agent / filter-criteria
+#            / reactions / semantic
+# --------------------------------------------------------------------------- #
+
+settings_app = typer.Typer(no_args_is_help=True, help="System settings management")
+app.add_typer(settings_app, name="settings")
+
+
+@settings_app.command("get")
+def settings_get(
+    ctx: typer.Context,
+    key: str | None = typer.Option(None, "--key", help="Specific setting key (default: show all)"),
+) -> None:
+    """Show settings."""
+    apply_startup(ctx)
+    run_async(settings_cmd.get_impl(ctx.obj.config, key=key))
+
+
+@settings_app.command("set")
+def settings_set(
+    ctx: typer.Context,
+    key: str = typer.Argument(..., help="Setting key"),
+    value: str = typer.Argument(..., help="Setting value"),
+) -> None:
+    """Set a setting value."""
+    apply_startup(ctx)
+    run_async(settings_cmd.set_impl(ctx.obj.config, key=key, value=value))
+
+
+@settings_app.command("info")
+def settings_info(ctx: typer.Context) -> None:
+    """Show system diagnostics."""
+    apply_startup(ctx)
+    run_async(settings_cmd.info_impl(ctx.obj.config))
+
+
+@settings_app.command("server-time")
+def settings_server_time(ctx: typer.Context) -> None:
+    """Show current server time (UTC)."""
+    apply_startup(ctx)
+    run_async(settings_cmd.server_time_impl(ctx.obj.config))
+
+
+@settings_app.command("agent")
+def settings_agent(
+    ctx: typer.Context,
+    backend: str | None = typer.Option(
+        None, "--backend", help="Agent backend override (auto, claude, deepagents, codex, adk)"
+    ),
+    prompt_template: str | None = typer.Option(
+        None, "--prompt-template", help="Default prompt template"
+    ),
+) -> None:
+    """Configure agent backend and defaults."""
+    apply_startup(ctx)
+    run_async(
+        settings_cmd.agent_impl(ctx.obj.config, backend=backend, prompt_template=prompt_template)
+    )
+
+
+@settings_app.command("filter-criteria")
+def settings_filter_criteria(
+    ctx: typer.Context,
+    min_uniqueness: float | None = typer.Option(None, "--min-uniqueness"),
+    min_sub_ratio: float | None = typer.Option(None, "--min-sub-ratio"),
+    max_cross_dupe: float | None = typer.Option(None, "--max-cross-dupe"),
+    min_cyrillic: float | None = typer.Option(None, "--min-cyrillic"),
+) -> None:
+    """Configure filter thresholds."""
+    apply_startup(ctx)
+    run_async(
+        settings_cmd.filter_criteria_impl(
+            ctx.obj.config,
+            min_uniqueness=min_uniqueness,
+            min_sub_ratio=min_sub_ratio,
+            max_cross_dupe=max_cross_dupe,
+            min_cyrillic=min_cyrillic,
+        )
+    )
+
+
+@settings_app.command("reactions")
+def settings_reactions(
+    ctx: typer.Context,
+    min_interval: int | None = typer.Option(
+        None,
+        "--min-interval",
+        help="Minimum seconds between reactions per account (clamped to 1–300; default 30)",
+    ),
+) -> None:
+    """Configure reaction sending cadence."""
+    apply_startup(ctx)
+    run_async(settings_cmd.reactions_impl(ctx.obj.config, min_interval=min_interval))
+
+
+@settings_app.command("semantic")
+def settings_semantic(
+    ctx: typer.Context,
+    provider: str | None = typer.Option(None, "--provider", help="Embedding provider"),
+    model: str | None = typer.Option(None, "--model", help="Embedding model"),
+    api_key: str | None = typer.Option(None, "--api-key", help="Embedding API key"),
+) -> None:
+    """Configure semantic search."""
+    apply_startup(ctx)
+    run_async(
+        settings_cmd.semantic_impl(
+            ctx.obj.config, provider=provider, model=model, api_key=api_key
+        )
+    )
+
+
+# --------------------------------------------------------------------------- #
 # argparse → Typer delegation
 # --------------------------------------------------------------------------- #
 
@@ -1027,6 +1140,9 @@ def _argv_from_namespace(args: argparse.Namespace) -> list[str]:
     elif command == "filter":
         argv.append("filter")
         argv += _filter_argv(args)
+    elif command == "settings":
+        argv.append("settings")
+        argv += _settings_argv(args)
     return argv
 
 
@@ -1156,6 +1272,48 @@ def _notification_argv(args: argparse.Namespace) -> list[str]:
             tail += ["--message", args.message]
     elif action == "set-account":
         tail += ["--phone", args.phone]
+    return tail
+
+
+def _settings_argv(args: argparse.Namespace) -> list[str]:
+    """argv tail for ``settings`` — the action plus its flags / positionals.
+
+    Default-less to the original argparse: ``settings`` with no action ran ``get``;
+    the get-or-set sub-commands emit only the flags that were actually provided.
+    """
+    action = getattr(args, "settings_action", None) or "get"
+    tail = [action]
+    if action == "get":
+        if getattr(args, "key", None):
+            tail += ["--key", args.key]
+    elif action == "set":
+        # key and value are positionals; emit after ``--`` so a value with a
+        # leading ``-`` survives Click's option parsing.
+        tail += ["--", args.key, args.value]
+    elif action == "agent":
+        if getattr(args, "backend", None):
+            tail += ["--backend", args.backend]
+        if getattr(args, "prompt_template", None):
+            tail += ["--prompt-template", args.prompt_template]
+    elif action == "filter-criteria":
+        if getattr(args, "min_uniqueness", None) is not None:
+            tail += ["--min-uniqueness", str(args.min_uniqueness)]
+        if getattr(args, "min_sub_ratio", None) is not None:
+            tail += ["--min-sub-ratio", str(args.min_sub_ratio)]
+        if getattr(args, "max_cross_dupe", None) is not None:
+            tail += ["--max-cross-dupe", str(args.max_cross_dupe)]
+        if getattr(args, "min_cyrillic", None) is not None:
+            tail += ["--min-cyrillic", str(args.min_cyrillic)]
+    elif action == "reactions":
+        if getattr(args, "min_interval", None) is not None:
+            tail += ["--min-interval", str(args.min_interval)]
+    elif action == "semantic":
+        if getattr(args, "provider", None) is not None:
+            tail += ["--provider", args.provider]
+        if getattr(args, "model", None) is not None:
+            tail += ["--model", args.model]
+        if getattr(args, "api_key", None) is not None:
+            tail += ["--api-key", args.api_key]
     return tail
 
 

--- a/src/cli/typer_commands.py
+++ b/src/cli/typer_commands.py
@@ -61,6 +61,7 @@ except ImportError:  # pragma: no cover - defensive fallback
 from src.cli.commands import collect as collect_cmd
 from src.cli.commands import debug as debug_cmd
 from src.cli.commands import export as export_cmd
+from src.cli.commands import filter as filter_cmd
 from src.cli.commands import image as image_cmd
 from src.cli.commands import mcp_server as mcp_server_cmd
 from src.cli.commands import messages as messages_cmd
@@ -112,7 +113,7 @@ MIGRATED_COMMANDS: frozenset[str] = frozenset(
         # Wave 2 (#1122) — flat simple groups
         "debug", "export", "translate", "image", "provider", "notification",
         # Wave 3 (#1123) — medium groups
-        "search-query",
+        "search-query", "filter",
     }
 )
 
@@ -857,6 +858,94 @@ def search_query_stats(
 
 
 # --------------------------------------------------------------------------- #
+# filter → analyze / apply / reset / precheck / toggle / purge / purge-messages
+#          / hard-delete
+# --------------------------------------------------------------------------- #
+
+filter_app = typer.Typer(no_args_is_help=True, help="Channel content filter")
+app.add_typer(filter_app, name="filter")
+
+
+@filter_app.command("analyze")
+def filter_analyze(
+    ctx: typer.Context,
+    quick: bool = typer.Option(
+        False, "--quick", help="Skip cross-channel duplicate analysis (fast on large DBs)"
+    ),
+) -> None:
+    """Analyze channels and show report."""
+    apply_startup(ctx)
+    run_async(filter_cmd.analyze_impl(ctx.obj.config, quick=quick))
+
+
+@filter_app.command("apply")
+def filter_apply(ctx: typer.Context) -> None:
+    """Analyze and mark filtered channels."""
+    apply_startup(ctx)
+    run_async(filter_cmd.apply_impl(ctx.obj.config))
+
+
+@filter_app.command("reset")
+def filter_reset(
+    ctx: typer.Context,
+    pks: str | None = typer.Option(None, "--pks", help="Comma-separated PKs (default: all)"),
+) -> None:
+    """Reset channel filter flag."""
+    apply_startup(ctx)
+    run_async(filter_cmd.reset_impl(ctx.obj.config, pks=pks))
+
+
+@filter_app.command("precheck")
+def filter_precheck(ctx: typer.Context) -> None:
+    """Apply pre-filter by subscriber ratio (no Telegram needed)."""
+    apply_startup(ctx)
+    run_async(filter_cmd.precheck_impl(ctx.obj.config))
+
+
+@filter_app.command("toggle")
+def filter_toggle(
+    ctx: typer.Context,
+    pk: int = typer.Argument(..., help="Channel primary key"),
+) -> None:
+    """Toggle filter for a single channel."""
+    apply_startup(ctx)
+    run_async(filter_cmd.toggle_impl(ctx.obj.config, pk=pk))
+
+
+@filter_app.command("purge")
+def filter_purge(
+    ctx: typer.Context,
+    pks: str | None = typer.Option(None, "--pks", help="Comma-separated PKs (default: all)"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
+) -> None:
+    """Purge messages from filtered channels."""
+    apply_startup(ctx)
+    run_async(filter_cmd.purge_impl(ctx.obj.config, pks=pks, yes=yes))
+
+
+@filter_app.command("purge-messages")
+def filter_purge_messages(
+    ctx: typer.Context,
+    channel_id: int = typer.Option(..., "--channel-id", help="Channel ID whose messages to delete"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt"),
+) -> None:
+    """Delete messages for a specific channel from DB."""
+    apply_startup(ctx)
+    run_async(filter_cmd.purge_messages_impl(ctx.obj.config, channel_id=channel_id, yes=yes))
+
+
+@filter_app.command("hard-delete")
+def filter_hard_delete(
+    ctx: typer.Context,
+    pks: str | None = typer.Option(None, "--pks", help="Comma-separated PKs (default: all)"),
+    yes: bool = typer.Option(False, "--yes", help="Skip confirmation prompt"),
+) -> None:
+    """Hard-delete filtered channels from DB (dev/testing)."""
+    apply_startup(ctx)
+    run_async(filter_cmd.hard_delete_impl(ctx.obj.config, pks=pks, yes=yes))
+
+
+# --------------------------------------------------------------------------- #
 # argparse → Typer delegation
 # --------------------------------------------------------------------------- #
 
@@ -935,6 +1024,9 @@ def _argv_from_namespace(args: argparse.Namespace) -> list[str]:
     elif command == "search-query":
         argv.append("search-query")
         argv += _search_query_argv(args)
+    elif command == "filter":
+        argv.append("filter")
+        argv += _filter_argv(args)
     return argv
 
 
@@ -1064,6 +1156,29 @@ def _notification_argv(args: argparse.Namespace) -> list[str]:
             tail += ["--message", args.message]
     elif action == "set-account":
         tail += ["--phone", args.phone]
+    return tail
+
+
+def _filter_argv(args: argparse.Namespace) -> list[str]:
+    """argv tail for ``filter`` — the action plus its flags / positional pk."""
+    action = getattr(args, "filter_action", None)
+    if action is None:
+        return []
+    tail = [action]
+    if action == "analyze":
+        if getattr(args, "quick", False):
+            tail.append("--quick")
+    elif action == "toggle":
+        tail += ["--", str(args.pk)]
+    elif action in ("reset", "purge", "hard-delete"):
+        if getattr(args, "pks", None):
+            tail += ["--pks", args.pks]
+        if action in ("purge", "hard-delete") and getattr(args, "yes", False):
+            tail.append("--yes")
+    elif action == "purge-messages":
+        tail += ["--channel-id", str(args.channel_id)]
+        if getattr(args, "yes", False):
+            tail.append("--yes")
     return tail
 
 

--- a/src/cli/typer_commands.py
+++ b/src/cli/typer_commands.py
@@ -58,6 +58,7 @@ except ImportError:  # pragma: no cover - defensive fallback
     _CLICK_EXCEPTIONS = (click.exceptions.ClickException,)
     _NO_ARGS_HELP_EXCEPTIONS = (click.exceptions.NoArgsIsHelpError,)
 
+from src.cli.commands import account as account_cmd
 from src.cli.commands import collect as collect_cmd
 from src.cli.commands import debug as debug_cmd
 from src.cli.commands import export as export_cmd
@@ -115,7 +116,7 @@ MIGRATED_COMMANDS: frozenset[str] = frozenset(
         # Wave 2 (#1122) — flat simple groups
         "debug", "export", "translate", "image", "provider", "notification",
         # Wave 3 (#1123) — medium groups
-        "search-query", "filter", "settings", "scheduler",
+        "search-query", "filter", "settings", "scheduler", "account",
     }
 )
 
@@ -1149,6 +1150,222 @@ def scheduler_queue_resume(ctx: typer.Context) -> None:
 
 
 # --------------------------------------------------------------------------- #
+# account → list / info / toggle / set-primary / delete / send-code /
+#           verify-code / add / flood-status / flood-clear / export-session /
+#           import  (export-session & import are the SSO secret-handling ops, #828)
+# --------------------------------------------------------------------------- #
+
+account_app = typer.Typer(no_args_is_help=True, help="Account management")
+app.add_typer(account_app, name="account")
+
+
+@account_app.command("list")
+def account_list(ctx: typer.Context) -> None:
+    """List accounts."""
+    apply_startup(ctx)
+    run_async(account_cmd.list_impl(ctx.obj.config))
+
+
+@account_app.command("info")
+def account_info(
+    ctx: typer.Context,
+    phone: str | None = typer.Option(None, "--phone", help="Filter by phone number"),
+) -> None:
+    """Show profile info for connected accounts."""
+    apply_startup(ctx)
+    run_async(account_cmd.info_impl(ctx.obj.config, phone=phone))
+
+
+@account_app.command("toggle")
+def account_toggle(
+    ctx: typer.Context,
+    account_id: int = typer.Argument(..., metavar="id", help="Account id"),
+) -> None:
+    """Toggle account active state."""
+    apply_startup(ctx)
+    run_async(account_cmd.toggle_impl(ctx.obj.config, account_id=account_id))
+
+
+@account_app.command("set-primary")
+def account_set_primary(
+    ctx: typer.Context,
+    account_id: int = typer.Argument(..., metavar="id", help="Account id"),
+) -> None:
+    """Make account the primary one."""
+    apply_startup(ctx)
+    run_async(account_cmd.set_primary_impl(ctx.obj.config, account_id=account_id))
+
+
+@account_app.command("delete")
+def account_delete(
+    ctx: typer.Context,
+    account_id: int = typer.Argument(..., metavar="id", help="Account id"),
+    notify_to: str | None = typer.Option(
+        None,
+        "--notify-to",
+        help="Phone to reassign notifications to if deleting the notification account",
+    ),
+) -> None:
+    """Delete account."""
+    apply_startup(ctx)
+    run_async(account_cmd.delete_impl(ctx.obj.config, account_id=account_id, notify_to=notify_to))
+
+
+@account_app.command("send-code")
+def account_send_code(
+    ctx: typer.Context,
+    phone: str = typer.Option(..., "--phone", help="Phone number with country code"),
+    api_id: int | None = typer.Option(
+        None, "--api-id", help="Telegram API ID (uses stored if omitted)"
+    ),
+    api_hash: str | None = typer.Option(
+        None, "--api-hash", help="Telegram API hash (uses stored if omitted)"
+    ),
+) -> None:
+    """Send Telegram auth code to phone."""
+    apply_startup(ctx)
+    run_async(account_cmd.send_code_impl(ctx.obj.config, phone=phone, api_id=api_id, api_hash=api_hash))
+
+
+@account_app.command("verify-code")
+def account_verify_code(
+    ctx: typer.Context,
+    phone: str = typer.Option(..., "--phone", help="Phone number with country code"),
+    code: str = typer.Option(..., "--code", help="Auth code received in Telegram"),
+    password: str | None = typer.Option(None, "--password", help="2FA password (if required)"),
+    api_id: int | None = typer.Option(
+        None, "--api-id", help="Telegram API ID (uses stored if omitted)"
+    ),
+    api_hash: str | None = typer.Option(
+        None, "--api-hash", help="Telegram API hash (uses stored if omitted)"
+    ),
+) -> None:
+    """Verify Telegram auth code and add account."""
+    apply_startup(ctx)
+    run_async(
+        account_cmd.verify_code_impl(
+            ctx.obj.config, phone=phone, code=code, password=password, api_id=api_id, api_hash=api_hash
+        )
+    )
+
+
+@account_app.command("add")
+def account_add(
+    ctx: typer.Context,
+    phone: str = typer.Option(..., "--phone", help="Phone number with country code"),
+    code: str | None = typer.Option(None, "--code", help="Auth code received in Telegram"),
+    password: str | None = typer.Option(None, "--password", help="2FA password (if required)"),
+    api_id: int | None = typer.Option(
+        None, "--api-id", help="Telegram API ID (uses stored if omitted)"
+    ),
+    api_hash: str | None = typer.Option(
+        None, "--api-hash", help="Telegram API hash (uses stored if omitted)"
+    ),
+) -> None:
+    """Compatibility alias for send-code / verify-code account onboarding."""
+    apply_startup(ctx)
+    # ``add`` resolves to verify-code when a --code is supplied, else send-code —
+    # exactly as the old argparse run() adapter did.
+    if code:
+        run_async(
+            account_cmd.verify_code_impl(
+                ctx.obj.config,
+                phone=phone,
+                code=code,
+                password=password,
+                api_id=api_id,
+                api_hash=api_hash,
+            )
+        )
+    else:
+        run_async(
+            account_cmd.send_code_impl(ctx.obj.config, phone=phone, api_id=api_id, api_hash=api_hash)
+        )
+
+
+@account_app.command("flood-status")
+def account_flood_status(ctx: typer.Context) -> None:
+    """Show flood wait timers for all accounts."""
+    apply_startup(ctx)
+    run_async(account_cmd.flood_status_impl(ctx.obj.config))
+
+
+@account_app.command("flood-clear")
+def account_flood_clear(
+    ctx: typer.Context,
+    phone: str = typer.Option(..., "--phone", help="Account phone number"),
+) -> None:
+    """Clear flood wait for an account."""
+    apply_startup(ctx)
+    run_async(account_cmd.flood_clear_impl(ctx.obj.config, phone=phone))
+
+
+@account_app.command("export-session")
+def account_export_session(
+    ctx: typer.Context,
+    account_id: int | None = typer.Option(None, "--id", help="Account id"),
+    phone: str | None = typer.Option(None, "--phone", help="Account phone number"),
+    as_json: bool = typer.Option(False, "--json", help="Emit {phone, session_string} JSON"),
+) -> None:
+    """Print the decrypted StringSession for SSO (⚠️ full account access — keep secret).
+
+    Exactly one of --id / --phone is required (the argparse mutually-exclusive
+    group is enforced here in the body — Typer has no native mutex group). The
+    session string is NEVER logged.
+    """
+    apply_startup(ctx)
+    if (account_id is None) == (phone is None):
+        # Mirror argparse's "exactly one required" mutually-exclusive group.
+        raise typer.BadParameter("provide exactly one of --id or --phone")
+    run_async(
+        account_cmd.export_session_impl(
+            ctx.obj.config, account_id=account_id, phone=phone, as_json=as_json
+        )
+    )
+
+
+@account_app.command("import")
+def account_import(
+    ctx: typer.Context,
+    phone: str = typer.Option(..., "--phone", help="Phone number with country code"),
+    session_string: str | None = typer.Option(
+        None,
+        "--session-string",
+        help="Telegram StringSession to import (⚠️ appears in shell history — prefer --session-string-stdin)",
+    ),
+    session_string_stdin: bool = typer.Option(
+        False,
+        "--session-string-stdin",
+        help="Read the StringSession from stdin (keeps the secret out of argv / shell history)",
+    ),
+    force: bool = typer.Option(
+        False, "--force", help="Overwrite the session of an account that already exists for this phone"
+    ),
+) -> None:
+    """Add an account from a ready StringSession (SSO import, skips login).
+
+    Exactly one of --session-string / --session-string-stdin is required (the
+    argparse mutually-exclusive group is enforced here in the body). The raw
+    session string is never echoed back or logged.
+    """
+    apply_startup(ctx)
+    if (session_string is None) == (not session_string_stdin):
+        # Mirror argparse's required mutually-exclusive group: exactly one source.
+        raise typer.BadParameter(
+            "provide exactly one of --session-string or --session-string-stdin"
+        )
+    run_async(
+        account_cmd.import_impl(
+            ctx.obj.config,
+            phone=phone,
+            session_string=session_string,
+            session_string_stdin=session_string_stdin,
+            force=force,
+        )
+    )
+
+
+# --------------------------------------------------------------------------- #
 # argparse → Typer delegation
 # --------------------------------------------------------------------------- #
 
@@ -1236,6 +1453,9 @@ def _argv_from_namespace(args: argparse.Namespace) -> list[str]:
     elif command == "scheduler":
         argv.append("scheduler")
         argv += _scheduler_argv(args)
+    elif command == "account":
+        argv.append("account")
+        argv += _account_argv(args)
     return argv
 
 
@@ -1365,6 +1585,72 @@ def _notification_argv(args: argparse.Namespace) -> list[str]:
             tail += ["--message", args.message]
     elif action == "set-account":
         tail += ["--phone", args.phone]
+    return tail
+
+
+def _account_argv(args: argparse.Namespace) -> list[str]:
+    """argv tail for ``account`` — the action plus its flags / positionals.
+
+    All option-bearing sub-commands here use ``--``-flags only (no leading-dash
+    positionals), so no ``--`` separator is needed. ``export-session`` / ``import``
+    carry the SSO mutually-exclusive groups; we emit whichever side argparse
+    resolved. The session string itself is forwarded verbatim — it is a secret and
+    is never logged at this layer.
+    """
+    action = getattr(args, "account_action", None)
+    if action is None:
+        return []
+    tail = [action]
+    if action == "info":
+        if getattr(args, "phone", None):
+            tail += ["--phone", args.phone]
+    elif action in ("toggle", "set-primary"):
+        tail += ["--", str(args.id)]
+    elif action == "delete":
+        if getattr(args, "notify_to", None):
+            tail += ["--notify-to", args.notify_to]
+        tail += ["--", str(args.id)]
+    elif action == "send-code":
+        tail += ["--phone", args.phone]
+        if getattr(args, "api_id", None) is not None:
+            tail += ["--api-id", str(args.api_id)]
+        if getattr(args, "api_hash", None):
+            tail += ["--api-hash", args.api_hash]
+    elif action == "verify-code":
+        tail += ["--phone", args.phone, "--code", args.code]
+        if getattr(args, "password", None):
+            tail += ["--password", args.password]
+        if getattr(args, "api_id", None) is not None:
+            tail += ["--api-id", str(args.api_id)]
+        if getattr(args, "api_hash", None):
+            tail += ["--api-hash", args.api_hash]
+    elif action == "add":
+        tail += ["--phone", args.phone]
+        if getattr(args, "code", None):
+            tail += ["--code", args.code]
+        if getattr(args, "password", None):
+            tail += ["--password", args.password]
+        if getattr(args, "api_id", None) is not None:
+            tail += ["--api-id", str(args.api_id)]
+        if getattr(args, "api_hash", None):
+            tail += ["--api-hash", args.api_hash]
+    elif action == "flood-clear":
+        tail += ["--phone", args.phone]
+    elif action == "export-session":
+        if getattr(args, "id", None) is not None:
+            tail += ["--id", str(args.id)]
+        elif getattr(args, "phone", None):
+            tail += ["--phone", args.phone]
+        if getattr(args, "json", False):
+            tail.append("--json")
+    elif action == "import":
+        tail += ["--phone", args.phone]
+        if getattr(args, "session_string_stdin", False):
+            tail.append("--session-string-stdin")
+        elif getattr(args, "session_string", None) is not None:
+            tail += ["--session-string", args.session_string]
+        if getattr(args, "force", False):
+            tail.append("--force")
     return tail
 
 

--- a/tests/test_cli_typer_wave3.py
+++ b/tests/test_cli_typer_wave3.py
@@ -588,3 +588,260 @@ def test_scheduler_bare_group_shows_help_exit_0():
     with pytest.raises(SystemExit) as exc_info:
         dispatch_via_typer(args)
     assert exc_info.value.code == 0
+
+
+# --------------------------------------------------------------------------- #
+# account → list / info / toggle / set-primary / delete / send-code /
+#           verify-code / add / flood-status / flood-clear / export-session /
+#           import   (export-session & import are the #828 SSO secret-handling ops)
+# --------------------------------------------------------------------------- #
+
+
+def test_account_list_and_flood_status_delegate():
+    for sub, impl_name in [("list", "list_impl"), ("flood-status", "flood_status_impl")]:
+        mock_impl = MagicMock()
+        with (
+            patch(f"src.cli.typer_commands.account_cmd.{impl_name}", mock_impl),
+            patch("src.cli.typer_commands.run_async"),
+        ):
+            result = runner.invoke(app, ["account", sub])
+        assert result.exit_code == 0, (sub, result.output)
+        mock_impl.assert_called_once_with("config.yaml")
+
+
+def test_account_info_phone_optional():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.account_cmd.info_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        runner.invoke(app, ["account", "info"])
+        runner.invoke(app, ["account", "info", "--phone", "+1234567890"])
+    assert mock_impl.call_args_list[0].kwargs == {"phone": None}
+    assert mock_impl.call_args_list[1].kwargs == {"phone": "+1234567890"}
+
+
+def test_account_toggle_set_primary_pass_id():
+    for sub, impl_name in [("toggle", "toggle_impl"), ("set-primary", "set_primary_impl")]:
+        mock_impl = MagicMock()
+        with (
+            patch(f"src.cli.typer_commands.account_cmd.{impl_name}", mock_impl),
+            patch("src.cli.typer_commands.run_async"),
+        ):
+            result = runner.invoke(app, ["account", sub, "7"])
+        assert result.exit_code == 0, (sub, result.output)
+        mock_impl.assert_called_once_with("config.yaml", account_id=7)
+
+
+def test_account_delete_notify_to():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.account_cmd.delete_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["account", "delete", "3", "--notify-to", "+19998887766"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", account_id=3, notify_to="+19998887766")
+
+
+def test_account_send_code_flags():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.account_cmd.send_code_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(
+            app, ["account", "send-code", "--phone", "+1", "--api-id", "42", "--api-hash", "h"]
+        )
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", phone="+1", api_id=42, api_hash="h")
+
+
+def test_account_verify_code_flags():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.account_cmd.verify_code_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(
+            app, ["account", "verify-code", "--phone", "+1", "--code", "123", "--password", "pw"]
+        )
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with(
+        "config.yaml", phone="+1", code="123", password="pw", api_id=None, api_hash=None
+    )
+
+
+def test_account_add_alias_sends_without_code():
+    """`account add --phone` with no --code resolves to send-code (argparse parity)."""
+    mock_send = MagicMock()
+    mock_verify = MagicMock()
+    with (
+        patch("src.cli.typer_commands.account_cmd.send_code_impl", mock_send),
+        patch("src.cli.typer_commands.account_cmd.verify_code_impl", mock_verify),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["account", "add", "--phone", "+1"])
+    assert result.exit_code == 0
+    mock_send.assert_called_once_with("config.yaml", phone="+1", api_id=None, api_hash=None)
+    mock_verify.assert_not_called()
+
+
+def test_account_add_alias_verifies_with_code():
+    """`account add --phone --code` resolves to verify-code."""
+    mock_send = MagicMock()
+    mock_verify = MagicMock()
+    with (
+        patch("src.cli.typer_commands.account_cmd.send_code_impl", mock_send),
+        patch("src.cli.typer_commands.account_cmd.verify_code_impl", mock_verify),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["account", "add", "--phone", "+1", "--code", "999"])
+    assert result.exit_code == 0
+    mock_verify.assert_called_once_with(
+        "config.yaml", phone="+1", code="999", password=None, api_id=None, api_hash=None
+    )
+    mock_send.assert_not_called()
+
+
+def test_account_flood_clear_phone():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.account_cmd.flood_clear_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["account", "flood-clear", "--phone", "+1"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", phone="+1")
+
+
+# --- #828 export-session / import: the secret-handling SSO ops --------------- #
+
+
+def test_account_export_session_by_id():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.account_cmd.export_session_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["account", "export-session", "--id", "5", "--json"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", account_id=5, phone=None, as_json=True)
+
+
+def test_account_export_session_by_phone():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.account_cmd.export_session_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["account", "export-session", "--phone", "+1234567890"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with(
+        "config.yaml", account_id=None, phone="+1234567890", as_json=False
+    )
+
+
+def test_account_export_session_mutex_rejects_both_and_neither():
+    """Exactly one of --id/--phone — the #828 mutually-exclusive group (kept)."""
+    # neither
+    assert runner.invoke(app, ["account", "export-session"]).exit_code != 0
+    # both
+    assert runner.invoke(
+        app, ["account", "export-session", "--id", "1", "--phone", "+1"]
+    ).exit_code != 0
+
+
+def test_account_import_session_string():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.account_cmd.import_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(
+            app, ["account", "import", "--phone", "+1", "--session-string", "SESS", "--force"]
+        )
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with(
+        "config.yaml",
+        phone="+1",
+        session_string="SESS",
+        session_string_stdin=False,
+        force=True,
+    )
+
+
+def test_account_import_stdin_source():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.account_cmd.import_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["account", "import", "--phone", "+1", "--session-string-stdin"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with(
+        "config.yaml",
+        phone="+1",
+        session_string=None,
+        session_string_stdin=True,
+        force=False,
+    )
+
+
+def test_account_import_mutex_rejects_both_and_neither():
+    """Exactly one session source — the #828 mutually-exclusive group (kept)."""
+    assert runner.invoke(app, ["account", "import", "--phone", "+1"]).exit_code != 0
+    assert runner.invoke(
+        app,
+        ["account", "import", "--phone", "+1", "--session-string", "X", "--session-string-stdin"],
+    ).exit_code != 0
+
+
+def test_account_export_session_delegates_via_argparse():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.account_cmd.export_session_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        _delegate(["account", "export-session", "--id", "9", "--json"])
+    mock_impl.assert_called_once_with("config.yaml", account_id=9, phone=None, as_json=True)
+
+
+def test_account_import_delegates_via_argparse():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.account_cmd.import_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        _delegate(["account", "import", "--phone", "+1", "--session-string", "SECRET", "--force"])
+    mock_impl.assert_called_once_with(
+        "config.yaml",
+        phone="+1",
+        session_string="SECRET",
+        session_string_stdin=False,
+        force=True,
+    )
+
+
+def test_account_export_session_value_not_logged(caplog):
+    """The export path must never log the session value (caplog guard, #828)."""
+    import logging
+
+    from src.cli.typer_commands import _account_argv
+
+    # The argv reconstruction for export-session carries only id/phone/json — never
+    # a session value (the secret is produced inside the impl and printed, not logged).
+    args = build_parser().parse_args(["account", "export-session", "--id", "3", "--json"])
+    with caplog.at_level(logging.DEBUG):
+        tail = _account_argv(args)
+    assert tail == ["export-session", "--id", "3", "--json"]
+    assert "session" not in caplog.text.lower() or "session_string" not in caplog.text
+
+
+def test_account_bare_group_shows_help_exit_0():
+    import pytest
+
+    args = build_parser().parse_args(["account"])
+    with pytest.raises(SystemExit) as exc_info:
+        dispatch_via_typer(args)
+    assert exc_info.value.code == 0

--- a/tests/test_cli_typer_wave3.py
+++ b/tests/test_cli_typer_wave3.py
@@ -375,3 +375,136 @@ def test_filter_bare_group_shows_help_exit_0():
     with pytest.raises(SystemExit) as exc_info:
         dispatch_via_typer(args)
     assert exc_info.value.code == 0
+
+
+# --------------------------------------------------------------------------- #
+# settings → get / set / info / server-time / agent / filter-criteria
+#            / reactions / semantic
+# --------------------------------------------------------------------------- #
+
+
+def test_settings_get_all_and_key():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.settings_cmd.get_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        runner.invoke(app, ["settings", "get"])
+        runner.invoke(app, ["settings", "get", "--key", "tg_api_id"])
+    assert mock_impl.call_args_list[0].kwargs == {"key": None}
+    assert mock_impl.call_args_list[1].kwargs == {"key": "tg_api_id"}
+
+
+def test_settings_set_two_positionals():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.settings_cmd.set_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["settings", "set", "mykey", "myvalue"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", key="mykey", value="myvalue")
+
+
+def test_settings_info_and_server_time_delegate():
+    for sub, impl_name in [("info", "info_impl"), ("server-time", "server_time_impl")]:
+        mock_impl = MagicMock()
+        with (
+            patch(f"src.cli.typer_commands.settings_cmd.{impl_name}", mock_impl),
+            patch("src.cli.typer_commands.run_async"),
+        ):
+            result = runner.invoke(app, ["settings", sub])
+        assert result.exit_code == 0, (sub, result.output)
+        mock_impl.assert_called_once_with("config.yaml")
+
+
+def test_settings_agent_flags_optional():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.settings_cmd.agent_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        runner.invoke(app, ["settings", "agent"])
+        runner.invoke(
+            app, ["settings", "agent", "--backend", "codex", "--prompt-template", "tmpl"]
+        )
+    assert mock_impl.call_args_list[0].kwargs == {"backend": None, "prompt_template": None}
+    assert mock_impl.call_args_list[1].kwargs == {"backend": "codex", "prompt_template": "tmpl"}
+
+
+def test_settings_filter_criteria_floats():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.settings_cmd.filter_criteria_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "settings", "filter-criteria",
+                "--min-uniqueness", "0.5",
+                "--min-sub-ratio", "0.1",
+                "--max-cross-dupe", "30",
+                "--min-cyrillic", "0.7",
+            ],
+        )
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with(
+        "config.yaml",
+        min_uniqueness=0.5,
+        min_sub_ratio=0.1,
+        max_cross_dupe=30.0,
+        min_cyrillic=0.7,
+    )
+
+
+def test_settings_reactions_min_interval():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.settings_cmd.reactions_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        runner.invoke(app, ["settings", "reactions"])
+        runner.invoke(app, ["settings", "reactions", "--min-interval", "45"])
+    assert mock_impl.call_args_list[0].kwargs == {"min_interval": None}
+    assert mock_impl.call_args_list[1].kwargs == {"min_interval": 45}
+
+
+def test_settings_semantic_flags():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.settings_cmd.semantic_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(
+            app,
+            ["settings", "semantic", "--provider", "openai", "--model", "te-3", "--api-key", "sk-x"],
+        )
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with(
+        "config.yaml", provider="openai", model="te-3", api_key="sk-x"
+    )
+
+
+def test_settings_set_delegates_via_argparse():
+    """key/value positionals survive the ``--`` separator end to end."""
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.settings_cmd.set_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        _delegate(["settings", "set", "translation_provider", "openai"])
+    mock_impl.assert_called_once_with(
+        "config.yaml", key="translation_provider", value="openai"
+    )
+
+
+def test_settings_bare_maps_to_get_via_argparse():
+    """A bare ``settings`` ran ``get`` under argparse; the round-trip preserves that."""
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.settings_cmd.get_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        _delegate(["settings"])
+    mock_impl.assert_called_once_with("config.yaml", key=None)

--- a/tests/test_cli_typer_wave3.py
+++ b/tests/test_cli_typer_wave3.py
@@ -265,3 +265,113 @@ def test_search_query_stats_negative_id_via_argparse():
     ):
         _delegate(["search-query", "stats", "8", "--days", "14"])
     mock_impl.assert_called_once_with("config.yaml", query_id=8, days=14)
+
+
+# --------------------------------------------------------------------------- #
+# filter → analyze / apply / reset / precheck / toggle / purge / purge-messages
+#          / hard-delete
+# --------------------------------------------------------------------------- #
+
+
+def test_filter_analyze_default_and_quick():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.filter_cmd.analyze_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        runner.invoke(app, ["filter", "analyze"])
+        runner.invoke(app, ["filter", "analyze", "--quick"])
+    assert mock_impl.call_args_list[0].kwargs == {"quick": False}
+    assert mock_impl.call_args_list[1].kwargs == {"quick": True}
+
+
+def test_filter_apply_precheck_delegate():
+    for sub, impl_name in [("apply", "apply_impl"), ("precheck", "precheck_impl")]:
+        mock_impl = MagicMock()
+        with (
+            patch(f"src.cli.typer_commands.filter_cmd.{impl_name}", mock_impl),
+            patch("src.cli.typer_commands.run_async"),
+        ):
+            result = runner.invoke(app, ["filter", sub])
+        assert result.exit_code == 0, (sub, result.output)
+        mock_impl.assert_called_once_with("config.yaml")
+
+
+def test_filter_toggle_passes_pk():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.filter_cmd.toggle_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["filter", "toggle", "42"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", pk=42)
+
+
+def test_filter_reset_pks_optional():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.filter_cmd.reset_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        runner.invoke(app, ["filter", "reset"])
+        runner.invoke(app, ["filter", "reset", "--pks", "1,2,3"])
+    assert mock_impl.call_args_list[0].kwargs == {"pks": None}
+    assert mock_impl.call_args_list[1].kwargs == {"pks": "1,2,3"}
+
+
+def test_filter_purge_yes_short_alias():
+    """``-y`` is the short alias for ``--yes`` on purge (argparse parity)."""
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.filter_cmd.purge_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["filter", "purge", "--pks", "5", "-y"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", pks="5", yes=True)
+
+
+def test_filter_purge_messages_requires_channel_id():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.filter_cmd.purge_messages_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["filter", "purge-messages", "--channel-id", "-1001", "--yes"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", channel_id=-1001, yes=True)
+
+
+def test_filter_hard_delete_yes_no_short_alias():
+    """hard-delete exposes ``--yes`` only (no ``-y``), matching argparse."""
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.filter_cmd.hard_delete_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["filter", "hard-delete", "--yes"])
+        # -y must NOT be accepted on hard-delete
+        result_short = runner.invoke(app, ["filter", "hard-delete", "-y"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", pks=None, yes=True)
+    assert result_short.exit_code != 0
+
+
+def test_filter_purge_messages_delegates_via_argparse():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.filter_cmd.purge_messages_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        _delegate(["filter", "purge-messages", "--channel-id", "-1002", "-y"])
+    mock_impl.assert_called_once_with("config.yaml", channel_id=-1002, yes=True)
+
+
+def test_filter_bare_group_shows_help_exit_0():
+    import pytest
+
+    args = build_parser().parse_args(["filter"])
+    with pytest.raises(SystemExit) as exc_info:
+        dispatch_via_typer(args)
+    assert exc_info.value.code == 0

--- a/tests/test_cli_typer_wave3.py
+++ b/tests/test_cli_typer_wave3.py
@@ -1,0 +1,267 @@
+"""CliRunner tests for the Wave-3 Typer command groups (epic #959 — issue #1123).
+
+Wave 3 migrates the medium, depth-1 command groups off the argparse dispatcher
+onto the Typer ``app``:
+
+    search-query · filter · settings · scheduler · account · agent · photo-loader
+
+These tests drive the production ``app`` through ``typer.testing.CliRunner`` and
+assert each sub-command:
+
+* exposes the *same* flags / arguments / sub-command names the argparse parser did
+  (the hard invariant of the migration), and
+* delegates to the shared ``*_impl`` body with the flags mapped to exactly the
+  right keyword arguments.
+
+The shared bodies are stubbed (and ``run_async`` is patched to capture rather than
+execute the coroutine) so no real DB / Telegram work happens — the wiring from CLI
+tokens to the body is what is under test. The ``*_delegates_via_argparse`` tests
+drive the real prod path (``build_parser`` → ``dispatch_via_typer``) to guard the
+argparse→Typer round-trip end to end, including the tri-state / store_const flags.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from src.cli.parser import build_parser
+from src.cli.typer_app import app
+from src.cli.typer_commands import dispatch_via_typer
+
+runner = CliRunner()
+
+
+def _delegate(argv: list[str]) -> None:
+    """Run the real prod path: argparse parse → argparse→Typer delegation."""
+    args = build_parser().parse_args(argv)
+    dispatch_via_typer(args)
+
+
+# --------------------------------------------------------------------------- #
+# search-query → list / get / add / edit / delete / toggle / run / stats
+# --------------------------------------------------------------------------- #
+
+
+def test_search_query_list_delegates():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.search_query_cmd.list_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["search-query", "list"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml")
+
+
+def test_search_query_get_passes_id():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.search_query_cmd.get_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["search-query", "get", "7"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", query_id=7)
+
+
+def test_search_query_add_defaults():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.search_query_cmd.add_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["search-query", "add", "hello world"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with(
+        "config.yaml",
+        query="hello world",
+        interval=60,
+        is_regex=False,
+        is_fts=False,
+        notify=False,
+        track_stats=True,
+        exclude_patterns="",
+        max_length=None,
+        chats="",
+    )
+
+
+def test_search_query_add_all_flags():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.search_query_cmd.add_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "search-query", "add", "q",
+                "--interval", "15",
+                "--regex", "--fts", "--notify", "--no-track-stats",
+                "--exclude-patterns", "spam",
+                "--max-length", "500",
+                "--chats", "@chan",
+            ],
+        )
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with(
+        "config.yaml",
+        query="q",
+        interval=15,
+        is_regex=True,
+        is_fts=True,
+        notify=True,
+        track_stats=False,
+        exclude_patterns="spam",
+        max_length=500,
+        chats="@chan",
+    )
+
+
+def test_search_query_edit_unset_flags_are_none():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.search_query_cmd.edit_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["search-query", "edit", "3"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with(
+        "config.yaml",
+        query_id=3,
+        query=None,
+        interval=None,
+        is_regex=None,
+        is_fts=None,
+        notify=None,
+        track_stats=None,
+        exclude_patterns=None,
+        max_length=None,
+        chats=None,
+    )
+
+
+def test_search_query_edit_tristate_negative_flags():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.search_query_cmd.edit_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(
+            app, ["search-query", "edit", "3", "--no-regex", "--no-fts", "--no-notify"]
+        )
+    assert result.exit_code == 0
+    _, kwargs = mock_impl.call_args
+    assert kwargs["is_regex"] is False
+    assert kwargs["is_fts"] is False
+    assert kwargs["notify"] is False
+
+
+def test_search_query_edit_clear_sentinels():
+    """``--no-max-length`` → -1, ``--clear-chats`` → "" (mirrors store_const)."""
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.search_query_cmd.edit_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(
+            app, ["search-query", "edit", "3", "--no-max-length", "--clear-chats"]
+        )
+    assert result.exit_code == 0
+    _, kwargs = mock_impl.call_args
+    assert kwargs["max_length"] == -1
+    assert kwargs["chats"] == ""
+
+
+def test_search_query_delete_toggle_run_pass_id():
+    for sub, impl_name in [
+        ("delete", "delete_impl"),
+        ("toggle", "toggle_impl"),
+        ("run", "run_impl"),
+    ]:
+        mock_impl = MagicMock()
+        with (
+            patch(f"src.cli.typer_commands.search_query_cmd.{impl_name}", mock_impl),
+            patch("src.cli.typer_commands.run_async"),
+        ):
+            result = runner.invoke(app, ["search-query", sub, "9"])
+        assert result.exit_code == 0, (sub, result.output)
+        mock_impl.assert_called_once_with("config.yaml", query_id=9)
+
+
+def test_search_query_stats_defaults_and_days():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.search_query_cmd.stats_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["search-query", "stats", "4", "--days", "7"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", query_id=4, days=7)
+
+
+def test_search_query_bare_group_shows_help_exit_0():
+    """A bare ``search-query`` group renders help and exits 0 via the prod path.
+
+    Argparse's old ``sub_attr`` fallback printed the group help and exited 0;
+    ``dispatch_via_typer`` reproduces that (a direct CliRunner invoke would exit
+    non-zero in standalone mode — that path is covered elsewhere).
+    """
+    import pytest
+
+    args = build_parser().parse_args(["search-query"])
+    with pytest.raises(SystemExit) as exc_info:
+        dispatch_via_typer(args)
+    assert exc_info.value.code == 0
+
+
+# --- real prod path: build_parser → dispatch_via_typer round-trip ----------- #
+
+
+def test_search_query_add_delegates_via_argparse():
+    """End-to-end argparse→Typer round-trip; the query goes after ``--`` so a
+    value that looks option-like survives Click (here a plain FTS query)."""
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.search_query_cmd.add_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        _delegate(["search-query", "add", "kremlin OR putin", "--regex", "--chats", "@c"])
+    mock_impl.assert_called_once_with(
+        "config.yaml",
+        query="kremlin OR putin",
+        interval=60,
+        is_regex=True,
+        is_fts=False,
+        notify=False,
+        track_stats=True,
+        exclude_patterns="",
+        max_length=None,
+        chats="@c",
+    )
+
+
+def test_search_query_edit_clear_sentinels_via_argparse():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.search_query_cmd.edit_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        _delegate(["search-query", "edit", "5", "--no-max-length", "--clear-chats"])
+    _, kwargs = mock_impl.call_args
+    assert kwargs["query_id"] == 5
+    assert kwargs["max_length"] == -1
+    assert kwargs["chats"] == ""
+
+
+def test_search_query_stats_negative_id_via_argparse():
+    """A leading-dash positional id round-trips through the ``--`` separator."""
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.search_query_cmd.stats_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        _delegate(["search-query", "stats", "8", "--days", "14"])
+    mock_impl.assert_called_once_with("config.yaml", query_id=8, days=14)

--- a/tests/test_cli_typer_wave3.py
+++ b/tests/test_cli_typer_wave3.py
@@ -508,3 +508,83 @@ def test_settings_bare_maps_to_get_via_argparse():
     ):
         _delegate(["settings"])
     mock_impl.assert_called_once_with("config.yaml", key=None)
+
+
+# --------------------------------------------------------------------------- #
+# scheduler → start / trigger / status / stop / job-toggle / set-interval
+#             / task-cancel / clear-pending / queue-pause / queue-resume
+# --------------------------------------------------------------------------- #
+
+
+def test_scheduler_no_arg_subcommands_delegate():
+    for sub, impl_name in [
+        ("start", "start_impl"),
+        ("trigger", "trigger_impl"),
+        ("status", "status_impl"),
+        ("stop", "stop_impl"),
+        ("clear-pending", "clear_pending_impl"),
+        ("queue-pause", "queue_pause_impl"),
+        ("queue-resume", "queue_resume_impl"),
+    ]:
+        mock_impl = MagicMock()
+        with (
+            patch(f"src.cli.typer_commands.scheduler_cmd.{impl_name}", mock_impl),
+            patch("src.cli.typer_commands.run_async"),
+        ):
+            result = runner.invoke(app, ["scheduler", sub])
+        assert result.exit_code == 0, (sub, result.output)
+        mock_impl.assert_called_once_with("config.yaml")
+
+
+def test_scheduler_job_toggle_passes_job_id():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.scheduler_cmd.job_toggle_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["scheduler", "job-toggle", "collect_all"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", job_id="collect_all")
+
+
+def test_scheduler_set_interval_two_positionals():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.scheduler_cmd.set_interval_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["scheduler", "set-interval", "sq_3", "120"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", job_id="sq_3", minutes=120)
+
+
+def test_scheduler_task_cancel_int_id():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.scheduler_cmd.task_cancel_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["scheduler", "task-cancel", "55"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", task_id=55)
+
+
+def test_scheduler_set_interval_delegates_via_argparse():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.scheduler_cmd.set_interval_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        _delegate(["scheduler", "set-interval", "content_generate_2", "30"])
+    mock_impl.assert_called_once_with(
+        "config.yaml", job_id="content_generate_2", minutes=30
+    )
+
+
+def test_scheduler_bare_group_shows_help_exit_0():
+    import pytest
+
+    args = build_parser().parse_args(["scheduler"])
+    with pytest.raises(SystemExit) as exc_info:
+        dispatch_via_typer(args)
+    assert exc_info.value.code == 0

--- a/tests/test_cli_typer_wave3.py
+++ b/tests/test_cli_typer_wave3.py
@@ -120,6 +120,23 @@ def test_search_query_add_all_flags():
     )
 
 
+def test_search_query_add_rejects_track_stats_flag():
+    """argparse ``add`` declares ONLY ``--no-track-stats`` — ``--track-stats`` must
+    be rejected so the Typer surface is not one flag wider than argparse (#1123
+    review). ``edit`` legitimately has both (argparse declares both there)."""
+    # add: --track-stats is NOT a valid flag
+    assert runner.invoke(app, ["search-query", "add", "q", "--track-stats"]).exit_code != 0
+    # edit: --track-stats IS valid (argparse parser_domains declares both)
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.search_query_cmd.edit_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["search-query", "edit", "1", "--track-stats"])
+    assert result.exit_code == 0
+    assert mock_impl.call_args.kwargs["track_stats"] is True
+
+
 def test_search_query_edit_unset_flags_are_none():
     mock_impl = MagicMock()
     with (
@@ -1217,6 +1234,41 @@ def test_photo_loader_auto_update_delegates_via_argparse():
         active=False,
         paused=True,
     )
+
+
+def test_photo_loader_auto_update_empty_caption_clears_via_argparse():
+    """``auto-update --caption ""`` is a deliberate CLEAR (repo writes when caption
+    is not None); the round-trip must forward the empty string, not drop it as
+    "unset" (#1123 review). caption=None (omitted) stays a no-op."""
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.photo_loader_cmd.auto_update_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        _delegate(["photo-loader", "auto-update", "5", "--caption", ""])
+    assert mock_impl.call_args.kwargs["caption"] == ""
+    # omitting --caption keeps it None (no write)
+    mock_impl.reset_mock()
+    with (
+        patch("src.cli.typer_commands.photo_loader_cmd.auto_update_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        _delegate(["photo-loader", "auto-update", "5", "--folder", "/x"])
+    assert mock_impl.call_args.kwargs["caption"] is None
+
+
+def test_settings_bare_runs_get_on_direct_typer_surface():
+    """Bare ``settings`` (no sub-command) runs ``get`` on the DIRECT Typer surface,
+    not just the argparse bridge — argparse defaulted settings_action to get (#1123
+    review)."""
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.settings_cmd.get_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["settings"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", key=None)
 
 
 def test_photo_loader_bare_group_shows_help_exit_0():

--- a/tests/test_cli_typer_wave3.py
+++ b/tests/test_cli_typer_wave3.py
@@ -992,3 +992,237 @@ def test_agent_bare_group_shows_help_exit_0():
     with pytest.raises(SystemExit) as exc_info:
         dispatch_via_typer(args)
     assert exc_info.value.code == 0
+
+
+# --------------------------------------------------------------------------- #
+# photo-loader → dialogs / refresh / send / schedule-send / batch-create /
+#                batch-list / items / batch-cancel / auto-create / auto-list /
+#                auto-update / auto-toggle / auto-delete / run-due
+# --------------------------------------------------------------------------- #
+
+
+def test_photo_loader_dialogs_refresh_require_phone():
+    for sub, impl_name in [("dialogs", "dialogs_impl"), ("refresh", "refresh_impl")]:
+        mock_impl = MagicMock()
+        with (
+            patch(f"src.cli.typer_commands.photo_loader_cmd.{impl_name}", mock_impl),
+            patch("src.cli.typer_commands.run_async"),
+        ):
+            result = runner.invoke(app, ["photo-loader", sub, "--phone", "+1"])
+        assert result.exit_code == 0, (sub, result.output)
+        mock_impl.assert_called_once_with("config.yaml", phone="+1")
+
+
+def test_photo_loader_send_files_list_and_mode():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.photo_loader_cmd.send_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "photo-loader", "send",
+                "--phone", "+1", "--target", "me",
+                "--files", "a.jpg", "--files", "b.jpg",
+                "--mode", "separate", "--caption", "hi",
+            ],
+        )
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with(
+        "config.yaml", phone="+1", target="me", files=["a.jpg", "b.jpg"], mode="separate", caption="hi"
+    )
+
+
+def test_photo_loader_send_mode_defaults_album():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.photo_loader_cmd.send_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(
+            app, ["photo-loader", "send", "--phone", "+1", "--target", "me", "--files", "a.jpg"]
+        )
+    assert result.exit_code == 0
+    _, kwargs = mock_impl.call_args
+    assert kwargs["mode"] == "album"
+    assert kwargs["caption"] is None
+
+
+def test_photo_loader_send_rejects_bad_mode():
+    """``--mode`` is constrained to album/separate (the argparse choices, as an Enum)."""
+    result = runner.invoke(
+        app, ["photo-loader", "send", "--phone", "+1", "--target", "me", "--files", "a", "--mode", "bogus"]
+    )
+    assert result.exit_code != 0
+
+
+def test_photo_loader_schedule_send_requires_at():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.photo_loader_cmd.schedule_send_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "photo-loader", "schedule-send",
+                "--phone", "+1", "--target", "me", "--files", "a.jpg",
+                "--at", "2026-07-01T10:00:00",
+            ],
+        )
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with(
+        "config.yaml",
+        phone="+1",
+        target="me",
+        files=["a.jpg"],
+        at="2026-07-01T10:00:00",
+        mode="album",
+        caption=None,
+    )
+
+
+def test_photo_loader_batch_list_auto_list_no_args():
+    for sub, impl_name in [("batch-list", "batch_list_impl"), ("auto-list", "auto_list_impl")]:
+        mock_impl = MagicMock()
+        with (
+            patch(f"src.cli.typer_commands.photo_loader_cmd.{impl_name}", mock_impl),
+            patch("src.cli.typer_commands.run_async"),
+        ):
+            result = runner.invoke(app, ["photo-loader", sub])
+        assert result.exit_code == 0, (sub, result.output)
+        mock_impl.assert_called_once_with("config.yaml")
+
+
+def test_photo_loader_items_optional_flags():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.photo_loader_cmd.items_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        runner.invoke(app, ["photo-loader", "items"])
+        runner.invoke(app, ["photo-loader", "items", "--batch-id", "5", "--limit", "20"])
+    assert mock_impl.call_args_list[0].kwargs == {"batch_id": None, "limit": 100}
+    assert mock_impl.call_args_list[1].kwargs == {"batch_id": 5, "limit": 20}
+
+
+def test_photo_loader_id_positional_subcommands():
+    for sub, impl_name in [
+        ("batch-cancel", "batch_cancel_impl"),
+        ("auto-toggle", "auto_toggle_impl"),
+        ("auto-delete", "auto_delete_impl"),
+    ]:
+        mock_impl = MagicMock()
+        with (
+            patch(f"src.cli.typer_commands.photo_loader_cmd.{impl_name}", mock_impl),
+            patch("src.cli.typer_commands.run_async"),
+        ):
+            result = runner.invoke(app, ["photo-loader", sub, "9"])
+        assert result.exit_code == 0, (sub, result.output)
+        kwargs = mock_impl.call_args.kwargs
+        # batch-cancel uses item_id; auto-* use job_id
+        assert kwargs in ({"item_id": 9}, {"job_id": 9})
+
+
+def test_photo_loader_auto_create_required_flags():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.photo_loader_cmd.auto_create_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "photo-loader", "auto-create",
+                "--phone", "+1", "--target", "me",
+                "--folder", "/pics", "--interval", "60",
+            ],
+        )
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with(
+        "config.yaml",
+        phone="+1",
+        target="me",
+        folder="/pics",
+        interval=60,
+        mode="album",
+        caption=None,
+    )
+
+
+def test_photo_loader_auto_update_active_paused():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.photo_loader_cmd.auto_update_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(
+            app, ["photo-loader", "auto-update", "4", "--interval", "30", "--active"]
+        )
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with(
+        "config.yaml",
+        job_id=4,
+        folder=None,
+        interval=30,
+        mode=None,
+        caption=None,
+        active=True,
+        paused=False,
+    )
+
+
+def test_photo_loader_run_due_flags():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.photo_loader_cmd.run_due_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        runner.invoke(app, ["photo-loader", "run-due"])
+        runner.invoke(app, ["photo-loader", "run-due", "--item-id", "7", "--dry-run"])
+    assert mock_impl.call_args_list[0].kwargs == {"item_id": None, "dry_run": False}
+    assert mock_impl.call_args_list[1].kwargs == {"item_id": 7, "dry_run": True}
+
+
+def test_photo_loader_send_delegates_via_argparse():
+    """argparse --files nargs='+' (a b) round-trips to Typer's repeated --files."""
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.photo_loader_cmd.send_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        _delegate(
+            ["photo-loader", "send", "--phone", "+1", "--target", "me", "--files", "a.jpg", "b.jpg"]
+        )
+    mock_impl.assert_called_once_with(
+        "config.yaml", phone="+1", target="me", files=["a.jpg", "b.jpg"], mode="album", caption=None
+    )
+
+
+def test_photo_loader_auto_update_delegates_via_argparse():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.photo_loader_cmd.auto_update_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        _delegate(["photo-loader", "auto-update", "2", "--mode", "separate", "--paused"])
+    mock_impl.assert_called_once_with(
+        "config.yaml",
+        job_id=2,
+        folder=None,
+        interval=None,
+        mode="separate",
+        caption=None,
+        active=False,
+        paused=True,
+    )
+
+
+def test_photo_loader_bare_group_shows_help_exit_0():
+    import pytest
+
+    args = build_parser().parse_args(["photo-loader"])
+    with pytest.raises(SystemExit) as exc_info:
+        dispatch_via_typer(args)
+    assert exc_info.value.code == 0

--- a/tests/test_cli_typer_wave3.py
+++ b/tests/test_cli_typer_wave3.py
@@ -845,3 +845,150 @@ def test_account_bare_group_shows_help_exit_0():
     with pytest.raises(SystemExit) as exc_info:
         dispatch_via_typer(args)
     assert exc_info.value.code == 0
+
+
+# --------------------------------------------------------------------------- #
+# agent → threads / thread-create / thread-delete / chat / thread-rename /
+#         thread-stop / messages / context / test-escaping / test-tools
+# --------------------------------------------------------------------------- #
+
+
+def test_agent_threads_and_test_subcommands_delegate():
+    for sub, impl_name in [
+        ("threads", "threads_impl"),
+        ("test-escaping", "test_escaping_impl"),
+        ("test-tools", "test_tools_impl"),
+    ]:
+        mock_impl = MagicMock()
+        with (
+            patch(f"src.cli.typer_commands.agent_cmd.{impl_name}", mock_impl),
+            patch("src.cli.typer_commands.run_async"),
+        ):
+            result = runner.invoke(app, ["agent", sub])
+        assert result.exit_code == 0, (sub, result.output)
+        mock_impl.assert_called_once_with("config.yaml")
+
+
+def test_agent_thread_create_title_optional():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.agent_cmd.thread_create_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        runner.invoke(app, ["agent", "thread-create"])
+        runner.invoke(app, ["agent", "thread-create", "--title", "My Thread"])
+    assert mock_impl.call_args_list[0].kwargs == {"title": None}
+    assert mock_impl.call_args_list[1].kwargs == {"title": "My Thread"}
+
+
+def test_agent_thread_delete_stop_pass_id():
+    for sub, impl_name in [
+        ("thread-delete", "thread_delete_impl"),
+        ("thread-stop", "thread_stop_impl"),
+    ]:
+        mock_impl = MagicMock()
+        with (
+            patch(f"src.cli.typer_commands.agent_cmd.{impl_name}", mock_impl),
+            patch("src.cli.typer_commands.run_async"),
+        ):
+            result = runner.invoke(app, ["agent", sub, "12"])
+        assert result.exit_code == 0, (sub, result.output)
+        mock_impl.assert_called_once_with("config.yaml", thread_id=12)
+
+
+def test_agent_chat_prompt_short_alias():
+    """``-p`` is the short alias for ``--prompt`` (argparse parity)."""
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.agent_cmd.chat_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(
+            app, ["agent", "chat", "-p", "hi", "--thread-id", "4", "--model", "opus"]
+        )
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", prompt="hi", thread_id=4, model="opus")
+
+
+def test_agent_chat_interactive_no_prompt():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.agent_cmd.chat_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["agent", "chat"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", prompt=None, thread_id=None, model=None)
+
+
+def test_agent_thread_rename_two_positionals():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.agent_cmd.thread_rename_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(app, ["agent", "thread-rename", "5", "New Title"])
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with("config.yaml", thread_id=5, title="New Title")
+
+
+def test_agent_messages_limit_optional():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.agent_cmd.messages_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        runner.invoke(app, ["agent", "messages", "8"])
+        runner.invoke(app, ["agent", "messages", "8", "--limit", "20"])
+    assert mock_impl.call_args_list[0].kwargs == {"thread_id": 8, "limit": None}
+    assert mock_impl.call_args_list[1].kwargs == {"thread_id": 8, "limit": 20}
+
+
+def test_agent_context_required_channel_id():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.agent_cmd.context_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        result = runner.invoke(
+            app,
+            ["agent", "context", "3", "--channel-id", "-1001", "--limit", "50", "--topic-id", "7"],
+        )
+    assert result.exit_code == 0
+    mock_impl.assert_called_once_with(
+        "config.yaml", thread_id=3, channel_id=-1001, limit=50, topic_id=7
+    )
+
+
+def test_agent_chat_leading_dash_prompt_via_argparse():
+    """A prompt starting with ``-`` survives the ``--prompt=`` attached form."""
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.agent_cmd.chat_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        _delegate(["agent", "chat", "-p", "-x marks the spot"])
+    mock_impl.assert_called_once_with(
+        "config.yaml", prompt="-x marks the spot", thread_id=None, model=None
+    )
+
+
+def test_agent_context_delegates_via_argparse():
+    mock_impl = MagicMock()
+    with (
+        patch("src.cli.typer_commands.agent_cmd.context_impl", mock_impl),
+        patch("src.cli.typer_commands.run_async"),
+    ):
+        _delegate(["agent", "context", "2", "--channel-id", "-1009", "--topic-id", "3"])
+    mock_impl.assert_called_once_with(
+        "config.yaml", thread_id=2, channel_id=-1009, limit=100000, topic_id=3
+    )
+
+
+def test_agent_bare_group_shows_help_exit_0():
+    import pytest
+
+    args = build_parser().parse_args(["agent"])
+    with pytest.raises(SystemExit) as exc_info:
+        dispatch_via_typer(args)
+    assert exc_info.value.code == 0


### PR DESCRIPTION
## CLI argparse→Typer: Волна 3 — средние группы

Часть эпика #959. Мигрирует 7 средних CLI-групп (~60 сабкоманд) с argparse-диспетчера на Typer `app`, по той же гибрид-схеме, что Волны 0/1/2 (#1120/#1121/#1122).

Closes #1123

### Группы (per-group коммиты)
| Группа | Сабкоманд | Коммит |
|---|---|---|
| search-query | 8 | `b550e9a` |
| filter | 8 | `882238d` |
| settings | 8 | `70aada2` |
| scheduler | 10 | `400aadb` |
| **account** ⚠️ | 10 + export-session/import (#828) | `92f3777` |
| agent | 10 | `29eff0f` |
| photo-loader | 14 | `4dc5849` |

### Что сделано (на каждую группу)
- `commands/X.py`: монолитный `run(args)`-диспетчер по `args.X_action` → набор `async def *_impl(config_path, *, …)` + тонкий `run(args)`-адаптер (читает аргументы через `getattr(args,…,default)` — partial-Namespace тест-фейки, #1117).
- `typer_commands.py`: `X_app` Typer sub-app (**имена/флаги неизменны** vs argparse), `_X_argv(args)` для argparse→Typer round-trip, `X` в `MIGRATED_COMMANDS`.
- TDD: 84 CliRunner-теста в `tests/test_cli_typer_wave3.py`; каждая группа мутационно проверена (поломка argv-реконструкции → тест краснеет).

### Гибрид (register НЕ опустошён) — [развилка в #1123](https://github.com/axisrow/tg_content_factory/issues/1123#issuecomment-4796462927)
argparse-декларации в `parser_domains/` сохранены как источник истины для leaf-audit (`test_real_telegram_policy::_cli_leaf_commands()` строит из `build_parser()`). Опустошение `register()` сломало бы инвариант `covered XOR manifested` — отложено до финальной волны #1125. Консистентно с Волнами 1/2.

### Сохранность бизнес-логики
Тела `*_impl` идентичны старому `run()` (две независимые сверки vs `origin/main`): dev-mode gate в `filter hard-delete`, confirm-промпты, порядок persist-then-warm-pool в `account verify-code` (#449), SSO export/import (#828, mutex `--id`/`--phone` и `--session-string`/`--session-string-stdin`, `session_string` не логируется, core `_run_export_session`/`_run_import` нетронуты), `redirect_logging` + cleanup в `agent chat`, dry-run в `photo-loader run-due`.

### Dual cycle-review (Codex ∥ Claude code-reviewer)
- **Claude code-reviewer**: мержить можно, 0 блокеров.
- **Codex**: 1 High + 2 Medium + 1 Low (проверил прямую Typer-поверхность, не только round-trip).

Триаж:
- ✅ **Исправлено** (`d2a7ace`): `search-query add` лишний `--track-stats` (Low, argparse только `--no-track-stats`); `photo-loader auto-update --caption ""` терялся (Medium, truthy-чек дропал очистку → `is not None`); bare `settings` на прямой Typer-поверхности не звал `get` (Medium → callback `invoke_without_command`).
- 📌 **`--files` (High) = known-drift до #1125** ([развилка](https://github.com/axisrow/tg_content_factory/issues/1123#issuecomment-4796578370)): argparse `--files a b c` (`nargs='+'`) невоспроизводим в Click (опции не поддерживают variadic nargs). Typer-leaf = repeated `--files a --files b`. **Прод-путь корректен** (юзер всегда через argparse→`_photo_loader_argv`→repeated→Typer; прямая Typer-поверхность недостижима до #1125). Имя флага `--files` сохранено.

### Проверки
- 719 тестов CLI-набора + policy + golden-snapshot зелёные (полный прогон, не `-k`).
- Golden-snapshot `tool_categories` (`test_tool_permissions_autoderive`) + `test_cli_agent_parity` прогнаны **явно** (14/14) — PR не добавляет agent-tools, `parity.md` не задет.
- `ruff check` чистый. mypy: 5 ошибок в изменённых файлах — все baseline (дословный перенос), 0 новых.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
