### PR TITLE
feat(debug): surface ErrorRecoveryService stats via cross-instance aggregate (#1055)

### DIFF
--- a/src/cli/commands/debug.py
+++ b/src/cli/commands/debug.py
@@ -66,6 +66,50 @@ async def timing_impl(config_path: str) -> None:
         await db.close()
 
 
+async def errors_impl(config_path: str, *, as_json: bool = False) -> None:
+    """Print aggregated provider error-recovery stats (#1055).
+
+    Folds the error histories of every live ``ErrorRecoveryService`` instance
+    (the per-service LLM/embedding recovery wrappers) into one process-wide
+    view. In a short-lived CLI invocation no provider call has run, so the
+    aggregate is usually empty — the stats are meaningful in a long-running
+    ``serve``/``worker`` process (or the Web debug page) where provider calls
+    have actually happened.
+    """
+    from src.services.error_recovery_service import ErrorRecoveryService
+
+    _, db = await runtime.init_db(config_path)
+    try:
+        stats = ErrorRecoveryService.aggregate_error_stats()
+        if as_json:
+            import json
+
+            print(json.dumps(stats, indent=2, ensure_ascii=False))
+            return
+
+        print("Provider error-recovery stats (aggregated across live instances):")
+        print(f"  Live recovery instances: {stats['instances']}")
+        print(f"  Total errors recorded:   {stats['total_errors']}")
+        print(f"  Open circuit breakers:   {stats['open_circuits']}")
+
+        by_category = stats.get("by_category") or {}
+        if by_category:
+            print("  By category:")
+            for cat, count in sorted(by_category.items()):
+                print(f"    {cat}: {count}")
+
+        recent = stats.get("recent") or []
+        if recent:
+            print("  Recent errors (newest first):")
+            for r in recent:
+                print(f"    [{r.get('category')}] {r.get('type')}: {r.get('message')}")
+
+        if stats["total_errors"] == 0:
+            print("  (no provider errors recorded in this process)")
+    finally:
+        await db.close()
+
+
 def run(args: argparse.Namespace) -> None:
     """Thin argparse-Namespace adapter over the ``*_impl`` bodies.
 
@@ -80,3 +124,5 @@ def run(args: argparse.Namespace) -> None:
         asyncio.run(memory_impl(args.config))
     elif action == "timing":
         asyncio.run(timing_impl(args.config))
+    elif action == "errors":
+        asyncio.run(errors_impl(args.config, as_json=getattr(args, "json", False)))

--- a/src/cli/typer_commands.py
+++ b/src/cli/typer_commands.py
@@ -435,6 +435,16 @@ def debug_timing(ctx: typer.Context) -> None:
     run_async(debug_cmd.timing_impl(ctx.obj.config))
 
 
+@debug_app.command("errors")
+def debug_errors(
+    ctx: typer.Context,
+    as_json: bool = typer.Option(False, "--json", help="Emit raw JSON instead of text"),
+) -> None:
+    """Show aggregated provider error-recovery stats (#1055)."""
+    apply_startup(ctx)
+    run_async(debug_cmd.errors_impl(ctx.obj.config, as_json=as_json))
+
+
 # --------------------------------------------------------------------------- #
 # export → json / csv / rss / telegram
 # --------------------------------------------------------------------------- #

--- a/src/services/error_recovery_service.py
+++ b/src/services/error_recovery_service.py
@@ -4,6 +4,7 @@ import asyncio
 import inspect
 import logging
 import time
+import weakref
 from dataclasses import dataclass
 from enum import Enum
 from typing import Awaitable, Callable, TypeVar
@@ -172,6 +173,22 @@ class CircuitBreaker:
 class ErrorRecoveryService:
     """Service for error recovery with retry policies and circuit breakers."""
 
+    # Process-wide weak registry of every live recovery service. Each instance
+    # keeps its OWN ``_error_history`` (the stats live in the instance), but the
+    # five LLM/embedding services build a *fresh* instance per pipeline-run /
+    # request / task via ``for_llm()`` / ``for_embeddings()`` — there is no
+    # single long-lived instance to query. The registry lets a debug surface
+    # aggregate the histories of all instances that are still alive without
+    # threading a shared instance through every constructor and call site.
+    #
+    # WeakSet => an instance is dropped automatically once its owning service is
+    # garbage-collected, so the registry never keeps an otherwise-dead service
+    # alive and never leaks. The trade-off is that an ephemeral instance's
+    # history is only visible while it (and its owner) are still referenced —
+    # i.e. the aggregate is a live snapshot of in-flight/recent work, not a
+    # durable error log. See ``aggregate_error_stats``.
+    _instances: "weakref.WeakSet[ErrorRecoveryService]" = weakref.WeakSet()
+
     def __init__(
         self,
         retry_policy: RetryPolicy | None = None,
@@ -181,6 +198,8 @@ class ErrorRecoveryService:
         self._circuit_breaker = CircuitBreaker(circuit_config)
         self._error_history: list[ErrorRecord] = []
         self._max_history = 100
+        # Self-register so ``aggregate_error_stats`` can find this instance.
+        ErrorRecoveryService._instances.add(self)
 
     def _calculate_delay(self, attempt: int) -> float:
         """Calculate delay for retry attempt."""
@@ -369,6 +388,61 @@ class ErrorRecoveryService:
             "by_category": by_category,
             "recent": recent,
             "circuit_breaker": self._circuit_breaker.get_state(),
+        }
+
+    @classmethod
+    def aggregate_error_stats(cls) -> dict:
+        """Aggregate error stats across every live recovery instance.
+
+        The five idempotent LLM/embedding services each build their own
+        ``ErrorRecoveryService`` (via ``for_llm()`` / ``for_embeddings()``), and
+        those instances are short-lived (one per pipeline-run / request / task).
+        Querying any single instance would only ever show one service's slice, so
+        this walks the weak registry (``cls._instances``) and folds every live
+        instance's :meth:`get_error_stats` into one process-wide view.
+
+        Returns a dict shaped like :meth:`get_error_stats` plus:
+          - ``instances``: number of live recovery instances folded in;
+          - ``open_circuits``: how many of them have a tripped (open/half_open)
+            circuit breaker right now.
+
+        ``recent`` is the 10 most-recent error records across all instances
+        (sorted by timestamp), so the snapshot reads chronologically regardless
+        of which service produced each error. Because the registry holds only
+        *live* instances, this is a snapshot of in-flight/recent activity — it is
+        intentionally not a durable error log (see the ``_instances`` note).
+        """
+        # Snapshot to a list first: the WeakSet can mutate mid-iteration as
+        # instances are collected, and we want a stable count.
+        live = list(cls._instances)
+
+        total = 0
+        by_category: dict[str, int] = {}
+        all_recent: list[dict] = []
+        open_circuits = 0
+
+        for inst in live:
+            stats = inst.get_error_stats()
+            total += stats.get("total_errors", 0)
+            for cat, count in stats.get("by_category", {}).items():
+                by_category[cat] = by_category.get(cat, 0) + count
+            all_recent.extend(stats.get("recent", []))
+            # Read the breaker state straight from the instance: get_error_stats
+            # omits the ``circuit_breaker`` key on an empty history, but a breaker
+            # can be open with no recorded errors (it counts failures, not stored
+            # records), so we must not infer "closed" from a missing key.
+            cb_state = inst._circuit_breaker.get_state().get("state", "closed")
+            if cb_state != "closed":
+                open_circuits += 1
+
+        all_recent.sort(key=lambda r: r.get("timestamp", 0.0), reverse=True)
+
+        return {
+            "instances": len(live),
+            "total_errors": total,
+            "by_category": by_category,
+            "recent": all_recent[:10],
+            "open_circuits": open_circuits,
         }
 
 

--- a/src/services/error_recovery_service.py
+++ b/src/services/error_recovery_service.py
@@ -412,8 +412,11 @@ class ErrorRecoveryService:
         *live* instances, this is a snapshot of in-flight/recent activity — it is
         intentionally not a durable error log (see the ``_instances`` note).
         """
-        # Snapshot to a list first: the WeakSet can mutate mid-iteration as
-        # instances are collected, and we want a stable count.
+        # Materialize to a list first. WeakSet.__iter__ already guards against
+        # "set changed size during iteration" (it defers referent removal while
+        # iterating), so this is not about avoiding a crash — it pins a stable
+        # set for the whole aggregation: a fixed len() for the ``instances``
+        # count, and strong refs so no instance is collected mid-loop.
         live = list(cls._instances)
 
         total = 0

--- a/src/web/routes/debug.py
+++ b/src/web/routes/debug.py
@@ -80,6 +80,25 @@ async def debug_timing_rows(request: Request):
     )
 
 
+@router.get("/errors", response_class=HTMLResponse)
+async def debug_errors(request: Request):
+    """HTMX partial: aggregated provider error-recovery stats (#1055)."""
+    from src.services.error_recovery_service import ErrorRecoveryService
+
+    stats = ErrorRecoveryService.aggregate_error_stats()
+    return deps.get_templates(request).TemplateResponse(
+        request, "_debug_errors.html", {"stats": stats}
+    )
+
+
+@router.get("/errors.json", response_class=JSONResponse)
+async def debug_errors_json(request: Request):
+    """REST JSON: aggregated provider error-recovery stats (#1055)."""
+    from src.services.error_recovery_service import ErrorRecoveryService
+
+    return ErrorRecoveryService.aggregate_error_stats()
+
+
 @router.get("/memory", response_class=JSONResponse)
 async def debug_memory(request: Request):
     gc.collect()

--- a/src/web/templates/_debug_errors.html
+++ b/src/web/templates/_debug_errors.html
@@ -1,0 +1,34 @@
+<div class="row g-3 mb-2">
+  <div class="col-auto"><span class="text-muted">Живых инстансов:</span> <strong>{{ stats.instances }}</strong></div>
+  <div class="col-auto"><span class="text-muted">Всего ошибок:</span> <strong>{{ stats.total_errors }}</strong></div>
+  <div class="col-auto"><span class="text-muted">Открытых circuit breaker:</span> <strong>{{ stats.open_circuits }}</strong></div>
+</div>
+
+{% if stats.by_category %}
+<div class="mb-2">
+  {% for cat, count in stats.by_category.items()|sort %}
+  <span class="badge bg-secondary me-1">{{ cat }}: {{ count }}</span>
+  {% endfor %}
+</div>
+{% endif %}
+
+{% if stats.recent %}
+<div class="table-responsive" style="font-size:0.85rem">
+  <table class="tga-table-striped">
+    <thead>
+      <tr><th>Категория</th><th>Тип</th><th>Сообщение</th></tr>
+    </thead>
+    <tbody>
+      {% for r in stats.recent %}
+      <tr>
+        <td><span class="badge bg-light text-dark">{{ r.category }}</span></td>
+        <td><code>{{ r.type }}</code></td>
+        <td><code>{{ r.message }}</code></td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% else %}
+<p class="mb-0"><small class="text-muted">Ошибок провайдеров в этом процессе не зафиксировано.</small></p>
+{% endif %}

--- a/src/web/templates/debug.html
+++ b/src/web/templates/debug.html
@@ -5,6 +5,21 @@
   <h1 class="mb-0">Консоль сервера</h1>
   <a href="/debug/timing" class="btn btn-sm btn-outline-secondary">Тайминг запросов →</a>
 </div>
+
+<div class="card mb-4">
+  <div class="card-header d-flex align-items-center justify-content-between">
+    <span>Ошибки провайдеров (восстановление)</span>
+    <button class="btn btn-sm btn-outline-secondary"
+            hx-get="/debug/errors" hx-target="#debug-errors" hx-swap="innerHTML">
+      Обновить
+    </button>
+  </div>
+  <div class="card-body" id="debug-errors"
+       hx-get="/debug/errors" hx-trigger="load" hx-swap="innerHTML">
+    <small class="text-muted">Загрузка…</small>
+  </div>
+</div>
+
 <p><small class="text-muted">Последние 500 записей.</small></p>
 <div class="table-responsive" style="font-size:0.85rem">
   <table class="tga-table-striped">

--- a/tests/cli_real_tg_integration/command_manifest.py
+++ b/tests/cli_real_tg_integration/command_manifest.py
@@ -26,6 +26,7 @@ CLI_REAL_TG_COMMAND_CASES_BY_CATEGORY: dict[str, set[tuple[str, ...]]] = {
         ("channel", "tag", "get"),
         ("channel", "tag", "list"),
         ("collect", "sample"),
+        ("debug", "errors"),
         ("debug", "logs"),
         ("debug", "memory"),
         ("debug", "timing"),

--- a/tests/cli_real_tg_integration/safe_ro/test_debug_errors.py
+++ b/tests/cli_real_tg_integration/safe_ro/test_debug_errors.py
@@ -1,0 +1,10 @@
+import pytest
+
+pytestmark = pytest.mark.real_tg_safe
+
+
+def test_debug_errors(run_cli, assert_cli_ok):
+    result = run_cli("debug", "errors")
+    assert_cli_ok(result)
+    assert result.stdout.strip(), "`debug errors` produced empty stdout"
+    assert "recovery instances" in result.stdout.lower()

--- a/tests/routes/test_debug_routes.py
+++ b/tests/routes/test_debug_routes.py
@@ -350,6 +350,8 @@ async def test_debug_errors_partial(client, monkeypatch):
     assert "transient" in body
     assert "rate_limit" in body
     del a, b  # keep strong refs alive until here (WeakSet)
+
+
 @pytest.mark.anyio
 async def test_debug_errors_json(client, monkeypatch):
     """REST JSON endpoint returns the aggregate payload."""
@@ -370,6 +372,8 @@ async def test_debug_errors_json(client, monkeypatch):
     assert payload["total_errors"] == 1
     assert payload["by_category"] == {"fatal": 1}
     del a  # keep strong refs alive until here (WeakSet)
+
+
 @pytest.mark.anyio
 async def test_debug_errors_json_empty(client, monkeypatch):
     """Empty registry → zeroed payload, not an error."""

--- a/tests/routes/test_debug_routes.py
+++ b/tests/routes/test_debug_routes.py
@@ -322,3 +322,66 @@ async def test_debug_memory_live_counters_in_worker_mode(client, base_app):
     assert body["runtime_mode"] == "worker"
     assert body["pool"]["source"] == "live"
     assert body["pool"]["dialogs_cache_entries"] == 2
+
+
+# ─── error-recovery stats routes (#1055) ─────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_debug_errors_partial(client, monkeypatch):
+    """HTMX partial renders aggregated stats across live instances."""
+    import weakref
+
+    from src.services.error_recovery_service import ErrorCategory, ErrorRecoveryService
+
+    fresh: weakref.WeakSet = weakref.WeakSet()
+    a = ErrorRecoveryService()
+    b = ErrorRecoveryService()
+    a._record_error(RuntimeError("boom"), ErrorCategory.TRANSIENT)
+    b._record_error(RuntimeError("boom"), ErrorCategory.RATE_LIMIT)
+    fresh.add(a)
+    fresh.add(b)
+    monkeypatch.setattr(ErrorRecoveryService, "_instances", fresh)
+
+    resp = await client.get("/debug/errors")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "2" in body  # 2 live instances / 2 errors
+    assert "transient" in body
+    assert "rate_limit" in body
+    del a, b  # keep strong refs alive until here (WeakSet)
+@pytest.mark.anyio
+async def test_debug_errors_json(client, monkeypatch):
+    """REST JSON endpoint returns the aggregate payload."""
+    import weakref
+
+    from src.services.error_recovery_service import ErrorCategory, ErrorRecoveryService
+
+    fresh: weakref.WeakSet = weakref.WeakSet()
+    a = ErrorRecoveryService()
+    a._record_error(RuntimeError("boom"), ErrorCategory.FATAL)
+    fresh.add(a)
+    monkeypatch.setattr(ErrorRecoveryService, "_instances", fresh)
+
+    resp = await client.get("/debug/errors.json")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["instances"] == 1
+    assert payload["total_errors"] == 1
+    assert payload["by_category"] == {"fatal": 1}
+    del a  # keep strong refs alive until here (WeakSet)
+@pytest.mark.anyio
+async def test_debug_errors_json_empty(client, monkeypatch):
+    """Empty registry → zeroed payload, not an error."""
+    import weakref
+
+    from src.services.error_recovery_service import ErrorRecoveryService
+
+    fresh: weakref.WeakSet = weakref.WeakSet()
+    monkeypatch.setattr(ErrorRecoveryService, "_instances", fresh)
+
+    resp = await client.get("/debug/errors.json")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["instances"] == 0
+    assert payload["total_errors"] == 0

--- a/tests/test_cli_debug_commands.py
+++ b/tests/test_cli_debug_commands.py
@@ -94,3 +94,74 @@ def test_timing(capsys):
         run(_args(debug_action="timing"))
     out = capsys.readouterr().out
     assert "timing" in out.lower() or "benchmark" in out.lower()
+
+
+# ---------------------------------------------------------------------------
+# errors (#1055) — aggregated provider error-recovery stats
+# ---------------------------------------------------------------------------
+
+
+def test_errors_aggregates_live_instances(capsys):
+    import weakref
+
+    from src.services.error_recovery_service import ErrorCategory, ErrorRecoveryService
+
+    fresh: weakref.WeakSet = weakref.WeakSet()
+    a = ErrorRecoveryService()
+    b = ErrorRecoveryService()
+    a._record_error(RuntimeError("boom"), ErrorCategory.TRANSIENT)
+    b._record_error(RuntimeError("boom"), ErrorCategory.RATE_LIMIT)
+    fresh.add(a)
+    fresh.add(b)
+
+    db = make_debug_db()
+    config = make_cli_config()
+    with patch("src.cli.commands.debug.runtime.init_db", AsyncMock(return_value=(config, db))), \
+         patch.object(ErrorRecoveryService, "_instances", fresh), \
+         patch("asyncio.run", fake_asyncio_run):
+        run(_args(debug_action="errors", json=False))
+    out = capsys.readouterr().out
+    assert "Live recovery instances: 2" in out
+    assert "Total errors recorded:   2" in out
+    del a, b  # keep strong refs alive until here (WeakSet)
+
+
+def test_errors_empty_process(capsys):
+    import weakref
+
+    from src.services.error_recovery_service import ErrorRecoveryService
+
+    fresh: weakref.WeakSet = weakref.WeakSet()
+    db = make_debug_db()
+    config = make_cli_config()
+    with patch("src.cli.commands.debug.runtime.init_db", AsyncMock(return_value=(config, db))), \
+         patch.object(ErrorRecoveryService, "_instances", fresh), \
+         patch("asyncio.run", fake_asyncio_run):
+        run(_args(debug_action="errors", json=False))
+    out = capsys.readouterr().out
+    assert "Live recovery instances: 0" in out
+    assert "no provider errors recorded" in out
+
+
+def test_errors_json_output(capsys):
+    import json as json_mod
+    import weakref
+
+    from src.services.error_recovery_service import ErrorCategory, ErrorRecoveryService
+
+    fresh: weakref.WeakSet = weakref.WeakSet()
+    a = ErrorRecoveryService()
+    a._record_error(RuntimeError("boom"), ErrorCategory.TRANSIENT)
+    fresh.add(a)
+
+    db = make_debug_db()
+    config = make_cli_config()
+    with patch("src.cli.commands.debug.runtime.init_db", AsyncMock(return_value=(config, db))), \
+         patch.object(ErrorRecoveryService, "_instances", fresh), \
+         patch("asyncio.run", fake_asyncio_run):
+        run(_args(debug_action="errors", json=True))
+    out = capsys.readouterr().out
+    payload = json_mod.loads(out)
+    assert payload["instances"] == 1
+    assert payload["total_errors"] == 1
+    del a  # keep strong refs alive until here (WeakSet)

--- a/tests/test_error_recovery_service.py
+++ b/tests/test_error_recovery_service.py
@@ -390,6 +390,8 @@ def test_aggregate_sums_across_instances(isolated_registry):
     assert stats["by_category"] == {"transient": 3, "rate_limit": 3}
     # keep strong refs alive past the assertion so the WeakSet doesn't drop them
     del a, b, c  # keep strong refs alive until here (WeakSet)
+
+
 def test_aggregate_empty_registry(isolated_registry):
     stats = ErrorRecoveryService.aggregate_error_stats()
     assert stats == {
@@ -416,6 +418,8 @@ def test_aggregate_recent_is_global_and_capped(isolated_registry):
     timestamps = [r["timestamp"] for r in stats["recent"]]
     assert timestamps == sorted(timestamps, reverse=True)
     del a, b  # keep strong refs alive until here (WeakSet)
+
+
 @pytest.mark.anyio
 async def test_aggregate_counts_open_circuits(isolated_registry):
     a = ErrorRecoveryService(circuit_config=CircuitBreakerConfig(failure_threshold=1))
@@ -427,6 +431,8 @@ async def test_aggregate_counts_open_circuits(isolated_registry):
 
     assert stats["open_circuits"] == 1
     del a, b  # keep strong refs alive until here (WeakSet)
+
+
 def test_new_instance_self_registers(isolated_registry):
     assert len(list(isolated_registry)) == 0
     svc = ErrorRecoveryService()

--- a/tests/test_error_recovery_service.py
+++ b/tests/test_error_recovery_service.py
@@ -346,3 +346,109 @@ async def test_circuit_breaker_half_open_failure_reopens(monkeypatch):
     allowed, state = await breaker.can_execute()
     assert allowed is False
     assert state == "open"
+
+
+# ---------------------------------------------------------------------------
+# aggregate_error_stats — cross-instance aggregation (#1055)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_registry(monkeypatch):
+    """Give each test a fresh, empty instance registry.
+
+    ``ErrorRecoveryService._instances`` is a process-wide WeakSet, so without
+    isolation a test would see instances created by other tests / at import
+    time. Swapping in a fresh WeakSet makes the aggregate deterministic.
+    """
+    import weakref
+
+    fresh: weakref.WeakSet = weakref.WeakSet()
+    monkeypatch.setattr(ErrorRecoveryService, "_instances", fresh)
+    return fresh
+
+
+def _seed_errors(service: ErrorRecoveryService, n: int, category: ErrorCategory) -> None:
+    for _ in range(n):
+        service._record_error(RuntimeError("boom"), category)
+
+
+def test_aggregate_sums_across_instances(isolated_registry):
+    # Three independent services, each with its own history — exactly the shape
+    # the five LLM/embedding services produce in production.
+    a = ErrorRecoveryService()
+    b = ErrorRecoveryService()
+    c = ErrorRecoveryService()
+    _seed_errors(a, 2, ErrorCategory.TRANSIENT)
+    _seed_errors(b, 3, ErrorCategory.RATE_LIMIT)
+    _seed_errors(c, 1, ErrorCategory.TRANSIENT)
+
+    stats = ErrorRecoveryService.aggregate_error_stats()
+
+    assert stats["instances"] == 3
+    assert stats["total_errors"] == 6
+    assert stats["by_category"] == {"transient": 3, "rate_limit": 3}
+    # keep strong refs alive past the assertion so the WeakSet doesn't drop them
+    del a, b, c  # keep strong refs alive until here (WeakSet)
+def test_aggregate_empty_registry(isolated_registry):
+    stats = ErrorRecoveryService.aggregate_error_stats()
+    assert stats == {
+        "instances": 0,
+        "total_errors": 0,
+        "by_category": {},
+        "recent": [],
+        "open_circuits": 0,
+    }
+
+
+def test_aggregate_recent_is_global_and_capped(isolated_registry):
+    a = ErrorRecoveryService()
+    b = ErrorRecoveryService()
+    # 8 errors on each → 16 total, but recent is capped at 10.
+    _seed_errors(a, 8, ErrorCategory.TRANSIENT)
+    _seed_errors(b, 8, ErrorCategory.FATAL)
+
+    stats = ErrorRecoveryService.aggregate_error_stats()
+
+    assert stats["total_errors"] == 16
+    assert len(stats["recent"]) == 10
+    # recent sorted newest-first across BOTH instances
+    timestamps = [r["timestamp"] for r in stats["recent"]]
+    assert timestamps == sorted(timestamps, reverse=True)
+    del a, b  # keep strong refs alive until here (WeakSet)
+@pytest.mark.anyio
+async def test_aggregate_counts_open_circuits(isolated_registry):
+    a = ErrorRecoveryService(circuit_config=CircuitBreakerConfig(failure_threshold=1))
+    b = ErrorRecoveryService()
+    # Trip a's breaker; b stays closed.
+    await a._circuit_breaker.record_failure()
+
+    stats = ErrorRecoveryService.aggregate_error_stats()
+
+    assert stats["open_circuits"] == 1
+    del a, b  # keep strong refs alive until here (WeakSet)
+def test_new_instance_self_registers(isolated_registry):
+    assert len(list(isolated_registry)) == 0
+    svc = ErrorRecoveryService()
+    assert svc in isolated_registry
+    assert len(list(isolated_registry)) == 1
+
+
+def test_aggregate_drops_collected_instances(isolated_registry):
+    import gc
+
+    a = ErrorRecoveryService()
+    _seed_errors(a, 5, ErrorCategory.TRANSIENT)
+    # A transient throwaway instance whose only ref we drop.
+    throwaway = ErrorRecoveryService()
+    _seed_errors(throwaway, 99, ErrorCategory.FATAL)
+    assert ErrorRecoveryService.aggregate_error_stats()["instances"] == 2
+
+    del throwaway
+    gc.collect()
+
+    stats = ErrorRecoveryService.aggregate_error_stats()
+    # Only the live instance survives — the weak registry self-prunes.
+    assert stats["instances"] == 1
+    assert stats["total_errors"] == 5
+    del a  # keep strong refs alive until here (WeakSet)


### PR DESCRIPTION
## Что

Хвост эпика #1055 (зонтик «написано, но не подключено»): метод `ErrorRecoveryService.get_error_stats()` (`error_recovery_service.py`) собирал статистику ошибок провайдеров, но **никуда не выводился**. Подключаю его в `debug` CLI + Web с REST JSON.

`execute_with_recovery` и `guard_not_image` (#958 анти-дубль-биллинг) **не тронуты**.

## Подвох агрегации и его решение

Статистика живёт **в инстансе** (`_error_history`). Но пять идемпотентных LLM/embedding-служб (`content_generation`, `generation`, `embedding`, `quality_scoring`, `ab_testing`) создают **свой** `ErrorRecoveryService` через `for_llm()`/`for_embeddings()`, и эти инстансы **эфемерны** — по одному на pipeline-run / HTTP-запрос / task / agent-tool. Шестая точка — замыкание `_recovered` в `provider_service.py`, создающее инстанс на лету. Дёрнешь один — увидишь срез одной службы.

Рассмотренные варианты:
- **Сбор через AppContainer** — невозможен: эти службы в контейнере не живут (создаются по запросу), увидели бы 0.
- **Один долгоживущий инстанс, прокинутый везде через DI** — переписать конструкторы + все call-sites 6 служб (web/CLI/agent/task_handlers) = «пол-проекта». Чрезмерно.
- **WeakSet-реестр на уровне класса + `classmethod aggregate_error_stats()`** ← выбрано.

### Механизм
- Классовый `weakref.WeakSet` `_instances`; каждый инстанс саморегистрируется в `__init__`.
- `aggregate_error_stats()` обходит **живые** инстансы и складывает: `instances`, `total_errors`, `by_category`, `recent` (top-10 по всем, отсортировано newest-first), `open_circuits`.
- Состояние circuit breaker читается **напрямую из инстанса**, а не через `get_error_stats()` — тот опускает ключ `circuit_breaker` при пустой истории, но breaker может быть открыт без записанных ошибок (он считает failures, а не записи). Без этого открытый breaker терялся (поймано тестом).

### Риски / трейд-оффы
- **Снимок, не журнал.** WeakSet держит только живые инстансы → видна история in-flight/недавней работы, не персистентная. Для долговременной статистики нужна персистентность в БД — вне scope хвоста.
- **Эфемерный CLI** почти всегда покажет 0 (службы в коротком процессе не создаются). Это честно отражено в выводе и docstring; реальная ценность — в долгоживущем `serve`/`worker` и на Web debug-странице.
- WeakSet не течёт: мёртвые службы self-prune (проверено тестом с `gc.collect()`).

## Подключение (CLI/Web parity)

- **CLI:** `debug errors [--json]` — Typer-команда + `errors_impl`, рядом с `logs`/`memory`/`timing`.
- **Web:** HTMX-партиал на странице `/debug` (server-driven swap, как `/debug/logs`) + REST `GET /debug/errors.json`. По frontend-policy: HTML-фрагмент через HTMX для UI, чистый JSON для REST.

## Тесты

- **Агрегация:** N инстансов суммируются; `recent` глобален и обрезан до 10 (newest-first); подсчёт открытых breaker; саморегистрация; weak-prune после GC; пустой реестр.
- **CLI:** text + `--json` + пустой процесс.
- **Web:** HTMX-партиал + JSON + пустой реестр.
- **Мутационно проверено** (каждый тест краснеет без фикса): (A) `live[:1]` вместо всех инстансов, (B) убрана саморегистрация, (C) откат `open_circuits` на путь через `get_error_stats()`.
- Real-TG policy parity: `debug errors` добавлена в safe_ro manifest + smoke-тест.

126 затронутых тестов зелёные, ruff чист, import-linter контракты соблюдены, без warnings.

Closes #1055

🤖 Generated with [Claude Code](https://claude.com/claude-code)