### PR TITLE
fix(agent): resolve 'me'/'self' target in create_photo_batch/create_auto_upload

### DIFF
--- a/src/agent/tools/photo_loader_schemas.py
+++ b/src/agent/tools/photo_loader_schemas.py
@@ -4,7 +4,7 @@ from typing import Annotated
 
 PHONE_ARG = Annotated[str, "Номер телефона аккаунта (например +79001234567)"]
 CONFIRM_ARG = Annotated[bool, "Установите true для подтверждения действия"]
-PHOTO_TARGET_ARG = Annotated[str, "ID диалога-получателя (из list_photo_dialogs или me)"]
+PHOTO_TARGET_ARG = Annotated[str, "ID диалога-получателя (из list_photo_dialogs) или 'me'/'self' для Saved Messages"]
 FILE_PATHS_ARG = Annotated[str, "Пути к файлам через запятую (серверные пути)"]
 MODE_ARG = Annotated[str, "Режим отправки: album или separate"]
 CAPTION_ARG = Annotated[str, "Подпись к фото"]

--- a/src/agent/tools/photo_loader_write.py
+++ b/src/agent/tools/photo_loader_write.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Any
 
 from claude_agent_sdk import tool
@@ -186,7 +187,14 @@ def register_batch_write_tools(db: Any, ctx: Any, client_pool: Any) -> list[Any]
             return gate
         try:
             svc = photo_task_service(db, client_pool)
-            entries = [{"file_path": file_path} for file_path in files]
+            # Entry contract matches PhotoTaskService.create_batch (reads entry["files"],
+            # a list) and the web manifest shape {"files": [...]} — a bare "file_path"
+            # key made the service see files=[] → "No files provided" (#1126). One file
+            # per entry → one item per file; send_mode is normalized by len(files).
+            # create_batch also requires "at" (schedule) per entry; default to now so the
+            # items are immediately due for run_photo_due.
+            now_iso = datetime.now(timezone.utc).isoformat()
+            entries = [{"files": [file_path], "at": now_iso} for file_path in files]
             # Resolve 'me'/'self'/dialog-name targets like send/schedule do — a raw
             # int(target) crashes on the documented 'me' literal (#1126), and a bare
             # id loses target_type="saved" so Saved Messages mis-resolves to a channel.

--- a/src/agent/tools/photo_loader_write.py
+++ b/src/agent/tools/photo_loader_write.py
@@ -31,7 +31,6 @@ from src.agent.tools.photo_loader_schemas import (
     UPDATE_AUTO_UPLOAD_SCHEMA,
 )
 from src.models import PhotoAutoUploadJob, PhotoSendMode
-from src.services import photo_task_service as photo_task_module
 from src.utils.datetime import parse_required_schedule_datetime
 
 
@@ -188,9 +187,13 @@ def register_batch_write_tools(db: Any, ctx: Any, client_pool: Any) -> list[Any]
         try:
             svc = photo_task_service(db, client_pool)
             entries = [{"file_path": file_path} for file_path in files]
+            # Resolve 'me'/'self'/dialog-name targets like send/schedule do — a raw
+            # int(target) crashes on the documented 'me' literal (#1126), and a bare
+            # id loses target_type="saved" so Saved Messages mis-resolves to a channel.
+            photo_target = await resolve_photo_target(client_pool, phone, target)
             batch_id = await svc.create_batch(
                 phone=phone,
-                target=photo_task_module.PhotoTarget(dialog_id=int(target)),
+                target=photo_target,
                 entries=entries,
                 caption=caption,
             )
@@ -330,10 +333,16 @@ def register_auto_write_tools(db: Any, ctx: Any, client_pool: Any) -> list[Any]:
             return gate
         try:
             svc = photo_auto_upload_service(db, client_pool)
+            # Resolve 'me'/'self'/dialog-name targets like send/schedule do — a raw
+            # int(target) crashes on the documented 'me' literal (#1126), and a bare
+            # id loses target_type="saved" so Saved Messages mis-resolves to a channel.
+            pt = await resolve_photo_target(client_pool, phone, target)
             job_id = await svc.create_job(
                 PhotoAutoUploadJob(
                     phone=phone,
-                    target_dialog_id=int(target),
+                    target_dialog_id=pt.dialog_id,
+                    target_title=pt.title,
+                    target_type=pt.target_type,
                     folder_path=folder_path,
                     send_mode=PhotoSendMode(mode),
                     caption=caption,

--- a/tests/test_agent_tools_photo_loader.py
+++ b/tests/test_agent_tools_photo_loader.py
@@ -528,6 +528,48 @@ class TestCreatePhotoBatch:
         assert target.dialog_id == 555
         assert target.target_type == "saved"
 
+    @pytest.mark.anyio
+    @pytest.mark.parametrize("target", ["me", "12345"])
+    async def test_create_batch_real_service_persists_files(self, db, tmp_path, target):
+        """End-to-end against the REAL PhotoTaskService.create_batch (no service mock):
+        the handler-built entries must satisfy the service's entry['files'] contract so a
+        real .jpg is persisted with non-empty item.file_paths. Regression — an entry-key
+        mismatch made the service raise 'No files provided', which the mocked-service
+        tests silently missed (#1126)."""
+        jpg = tmp_path / "photo.jpg"
+        jpg.write_bytes(b"\xff\xd8\xff\xe0")  # JPEG SOI + APP0 magic bytes
+
+        mock_pool, _ = _make_mock_pool()
+        session = MagicMock()
+        session.fetch_me = AsyncMock(return_value=MagicMock(id=555))
+        mock_pool.get_client_by_phone = AsyncMock(return_value=(session, None))
+
+        # No _photo_ctx: the REAL PhotoTaskService + PhotoLoaderBundle back the tool.
+        handlers = _get_tool_handlers(db, client_pool=mock_pool)
+        result = await handlers["create_photo_batch"](
+            {
+                "phone": "+79001234567",
+                "target": target,
+                "file_paths": str(jpg),
+                "confirm": True,
+            }
+        )
+        text = _text(result)
+        assert "Батч создан" in text
+        assert "No files provided" not in text
+
+        # Read back through the real bundle and confirm the file was persisted.
+        from src.database.bundles import PhotoLoaderBundle
+        from src.services.photo_publish_service import PhotoPublishService
+        from src.services.photo_task_service import PhotoTaskService
+
+        readback = PhotoTaskService(
+            PhotoLoaderBundle.from_database(db), PhotoPublishService(mock_pool)
+        )
+        items = await readback.list_items(limit=10)
+        assert len(items) == 1
+        assert items[0].file_paths == [str(jpg)]
+
 
 class TestRunPhotoDue:
     @pytest.mark.anyio

--- a/tests/test_agent_tools_photo_loader.py
+++ b/tests/test_agent_tools_photo_loader.py
@@ -499,6 +499,35 @@ class TestCreatePhotoBatch:
         text = _text(result)
         assert "Батч создан" in text
 
+    @pytest.mark.anyio
+    @pytest.mark.parametrize("alias", ["me", "self"])
+    async def test_create_batch_self_target_carries_saved_type(self, mock_db, alias):
+        """target='me'/'self' must not crash int('me'); it resolves to Saved Messages
+        with target_type='saved' so it doesn't mis-resolve to a channel (#1126)."""
+        photo_task_svc, auto_upload_svc = _make_photo_services()
+        mock_pool, _ = _make_mock_pool()
+        session = MagicMock()
+        session.fetch_me = AsyncMock(return_value=MagicMock(id=555))
+        mock_pool.get_client_by_phone = AsyncMock(return_value=(session, None))
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+
+        # Do NOT patch PhotoTarget — we want to inspect the real target fields.
+        with _photo_ctx(photo_task_svc, auto_upload_svc):
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["create_photo_batch"](
+                {
+                    "phone": "+79001234567",
+                    "target": alias,
+                    "file_paths": "a.jpg",
+                    "confirm": True,
+                }
+            )
+        assert "Батч создан" in _text(result)
+        photo_task_svc.create_batch.assert_awaited_once()
+        target = photo_task_svc.create_batch.await_args.kwargs["target"]
+        assert target.dialog_id == 555
+        assert target.target_type == "saved"
+
 
 class TestRunPhotoDue:
     @pytest.mark.anyio
@@ -622,6 +651,36 @@ class TestCreateAutoUpload:
             )
         text = _text(result)
         assert "Автозагрузка создана" in text
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize("alias", ["me", "self"])
+    async def test_create_auto_upload_self_target_carries_saved_type(self, mock_db, alias):
+        """target='me'/'self' must not crash int('me'); the PhotoAutoUploadJob carries
+        target_type='saved' and target_dialog_id==own user-id (#1126)."""
+        photo_task_svc, auto_upload_svc = _make_photo_services()
+        mock_pool, _ = _make_mock_pool()
+        session = MagicMock()
+        session.fetch_me = AsyncMock(return_value=MagicMock(id=555))
+        mock_pool.get_client_by_phone = AsyncMock(return_value=(session, None))
+        mock_db.get_accounts = AsyncMock(return_value=[_make_account()])
+
+        with _photo_ctx(photo_task_svc, auto_upload_svc):
+            handlers = _get_tool_handlers(mock_db, client_pool=mock_pool)
+            result = await handlers["create_auto_upload"](
+                {
+                    "phone": "+79001234567",
+                    "target": alias,
+                    "folder_path": "/photos",
+                    "interval_minutes": 30,
+                    "mode": "album",
+                    "confirm": True,
+                }
+            )
+        assert "Автозагрузка создана" in _text(result)
+        auto_upload_svc.create_job.assert_awaited_once()
+        job = auto_upload_svc.create_job.await_args.args[0]
+        assert job.target_type == "saved"
+        assert job.target_dialog_id == 555
 
 
 class TestUpdateAutoUpload:


### PR DESCRIPTION
## Summary

The agent-tool schema promises `target="me"` (Saved Messages), but `create_photo_batch` and `create_auto_upload` did a raw `int(target)` that crashed on `int("me")`. This brings them to parity with the already-working `send_photos_now` / `schedule_photos` by routing through `resolve_photo_target`.

Beyond the crash, `target_type="saved"` is critical: `pool_dialogs.resolve_dialog_entity` with `target_type=None` and an empty cache falls through to `PeerChannel(abs(dialog_id))`, so the account's own user-id gets mis-resolved as an unrelated channel.

Closes #1126

## Changes
- `create_photo_batch`: replace `PhotoTarget(dialog_id=int(target))` with `await resolve_photo_target(client_pool, phone, target)` and pass the result to `svc.create_batch(target=...)` (same pattern as `schedule_photos`, audit #838/10).
- `create_auto_upload`: resolve via `resolve_photo_target`, then fill `PhotoAutoUploadJob` fields from the resolved `PhotoTarget` (`target_dialog_id`, `target_title`, `target_type`).
- `PHOTO_TARGET_ARG`: updated description to mention `'me'`/`'self'` for Saved Messages. Tool names and argument formats are unchanged.
- Removed the now-unused `photo_task_module` import.

## Tests
Added parametrized (`me`/`self`) regression tests mirroring the existing `test_self_target_carries_saved_type` / `test_send_now_self_target_carries_saved_type`:
- `create_photo_batch` → does not crash, `create_batch` called, `target.target_type=="saved"`, `dialog_id==555`.
- `create_auto_upload` → does not crash, `create_job` called, `PhotoAutoUploadJob.target_type=="saved"`, `target_dialog_id==555`.

## Verification
- `pytest tests/test_agent_tools_photo_loader.py -q` → 49 passed
- `pytest tests/test_agent_tool_smoke_contract.py -q` → 7 passed
- `ruff check src/ tests/ conftest.py` → clean

No schema/config impact; `ci.yml` untouched.