### PR TITLE
fix(photo): release client lease in resolve_photo_target

### DIFF
--- a/src/agent/tools/_photo_loader_runtime.py
+++ b/src/agent/tools/_photo_loader_runtime.py
@@ -46,9 +46,12 @@ async def resolve_photo_target(client_pool: Any, phone: str, target: str) -> Any
     client_result = await client_pool.get_client_by_phone(phone)
     if not client_result:
         raise LookupError(f"Клиент для {phone} не найден.")
-    session, _ = client_result
-    me = await session.fetch_me()
-    return photo_task_module.PhotoTarget(dialog_id=int(me.id), title="Saved Messages", target_type="saved")
+    session, acquired_phone = client_result
+    try:
+        me = await session.fetch_me()
+        return photo_task_module.PhotoTarget(dialog_id=int(me.id), title="Saved Messages", target_type="saved")
+    finally:
+        await client_pool.release_client(acquired_phone)
 
 
 async def resolve_photo_target_id(client_pool: Any, phone: str, target: str) -> int:

--- a/tests/test_agent_tools_photo_loader.py
+++ b/tests/test_agent_tools_photo_loader.py
@@ -41,6 +41,7 @@ def _make_mock_pool():
     mock_pool = MagicMock()
     mock_pool.get_native_client_by_phone = AsyncMock(return_value=(mock_client, None))
     mock_pool.get_client_by_phone = AsyncMock(return_value=(mock_session, None))
+    mock_pool.release_client = AsyncMock()
     mock_pool.resolve_dialog_entity = AsyncMock(return_value=MagicMock(id=123456))
     return mock_pool, mock_client
 
@@ -82,6 +83,61 @@ def _photo_ctx(photo_task_svc, auto_upload_svc):
         patch("src.services.photo_publish_service.PhotoPublishService"),
     ):
         yield
+
+
+class TestResolvePhotoTargetLease:
+    @pytest.mark.anyio
+    async def test_self_target_releases_client_lease(self):
+        """resolve_photo_target must release the acquired client lease so the account
+        stays in exclusive collector rotation (#1179). Mirror of
+        PhotoPublishService._acquire_client_and_resolve's try/finally release."""
+        from src.agent.tools._photo_loader_runtime import resolve_photo_target
+
+        session = MagicMock()
+        session.fetch_me = AsyncMock(return_value=MagicMock(id=555))
+
+        class _LeaseTrackingPool:
+            def __init__(self):
+                self.acquired = 0
+                self.released: list[str] = []
+
+            async def get_client_by_phone(self, phone: str):
+                self.acquired += 1
+                return session, phone
+
+            async def release_client(self, phone: str) -> None:
+                self.released.append(phone)
+
+        pool = _LeaseTrackingPool()
+        target = await resolve_photo_target(pool, "+79001234567", "me")
+        assert target.dialog_id == 555
+        assert target.target_type == "saved"
+        assert pool.acquired == 1
+        assert pool.released == ["+79001234567"]
+
+    @pytest.mark.anyio
+    async def test_self_target_releases_even_on_fetch_error(self):
+        """If fetch_me raises, the lease must still be released (try/finally) (#1179)."""
+        from src.agent.tools._photo_loader_runtime import resolve_photo_target
+
+        class _BoomSession:
+            async def fetch_me(self):
+                raise RuntimeError("network down")
+
+        class _LeaseTrackingPool:
+            def __init__(self):
+                self.released: list[str] = []
+
+            async def get_client_by_phone(self, phone: str):
+                return _BoomSession(), phone
+
+            async def release_client(self, phone: str) -> None:
+                self.released.append(phone)
+
+        pool = _LeaseTrackingPool()
+        with pytest.raises(RuntimeError, match="network down"):
+            await resolve_photo_target(pool, "+79001234567", "me")
+        assert pool.released == ["+79001234567"]
 
 
 class TestListPhotoBatches:


### PR DESCRIPTION
## Summary

`resolve_photo_target` (`src/agent/tools/_photo_loader_runtime.py`) acquired a client lease via `get_client_by_phone` but **never released it** — no `release_client`, no `try/finally`.

A single `target="me"`/`"self"` call permanently marked the account as `_in_use`, dropping it out of the exclusive collector rotation (`AccountLeasePool.acquire_available` skips `phone in _in_use`). `_active_leases[phone]` grew unbounded.

## Fix

Wrap acquire→`fetch_me` in `try/finally` and release the **acquired** phone (the one returned by `get_client_by_phone`), mirroring the reference `PhotoPublishService._acquire_client_and_resolve` (`photo_publish_service.py:39-47`):

```python
session, acquired_phone = client_result
try:
    me = await session.fetch_me()
    return PhotoTarget(...)
finally:
    await client_pool.release_client(acquired_phone)
```

## Affected paths
All callers of `resolve_photo_target` now release correctly: `send_photos_now`, `schedule_photos`, `create_photo_batch`, `create_auto_upload`.

## Tests
Added `TestResolvePhotoTargetLease` with a **lease-tracking fake-pool** (counts acquire/release):
- `test_self_target_releases_client_lease` — assert `released == [phone]` after a normal resolve (RED on main: `released == []`).
- `test_self_target_releases_even_on_fetch_error` — assert the lease is released even when `fetch_me` raises (try/finally).

Also added `release_client = AsyncMock()` to `_make_mock_pool()` so the existing "me"/"self" tool tests exercise the release path.

Closes #1179