### PR TITLE
fix(photo): keep album mode in create_photo_batch

### DIFF
--- a/src/agent/tools/photo_loader_write.py
+++ b/src/agent/tools/photo_loader_write.py
@@ -187,14 +187,14 @@ def register_batch_write_tools(db: Any, ctx: Any, client_pool: Any) -> list[Any]
             return gate
         try:
             svc = photo_task_service(db, client_pool)
-            # Entry contract matches PhotoTaskService.create_batch (reads entry["files"],
-            # a list) and the web manifest shape {"files": [...]} — a bare "file_path"
-            # key made the service see files=[] → "No files provided" (#1126). One file
-            # per entry → one item per file; send_mode is normalized by len(files).
-            # create_batch also requires "at" (schedule) per entry; default to now so the
-            # items are immediately due for run_photo_due.
+            # All files in ONE entry so normalize_mode sees len(files)>1 and keeps
+            # ALBUM. Splitting one-entry-per-file downgrades ALBUM→SEPARATE because
+            # each entry has len==1 (#1180). The entry contract matches
+            # PhotoTaskService.create_batch (reads entry["files"], a list) and the
+            # web manifest shape {"files": [...]} (#1126). "at" (schedule) defaults
+            # to now so the items are immediately due for run_photo_due.
             now_iso = datetime.now(timezone.utc).isoformat()
-            entries = [{"files": [file_path], "at": now_iso} for file_path in files]
+            entries = [{"files": files, "at": now_iso}]
             # Resolve 'me'/'self'/dialog-name targets like send/schedule do — a raw
             # int(target) crashes on the documented 'me' literal (#1126), and a bare
             # id loses target_type="saved" so Saved Messages mis-resolves to a channel.

--- a/tests/test_agent_tools_photo_loader.py
+++ b/tests/test_agent_tools_photo_loader.py
@@ -570,6 +570,44 @@ class TestCreatePhotoBatch:
         assert len(items) == 1
         assert items[0].file_paths == [str(jpg)]
 
+    @pytest.mark.anyio
+    async def test_create_batch_album_keeps_single_item(self, db, tmp_path):
+        """create_photo_batch must put all files in ONE entry so normalize_mode sees
+        len(files)>1 and keeps ALBUM. Splitting one-entry-per-file makes each entry
+        have len==1 → normalize downgrades ALBUM→SEPARATE, silently degrading an
+        album into N separate single-photo messages (#1180)."""
+        from src.models import PhotoSendMode
+
+        files = []
+        for name in ("a.jpg", "b.jpg", "c.jpg"):
+            fp = tmp_path / name
+            fp.write_bytes(b"\xff\xd8\xff\xe0")
+            files.append(str(fp))
+
+        mock_pool, _ = _make_mock_pool()
+        handlers = _get_tool_handlers(db, client_pool=mock_pool)
+        result = await handlers["create_photo_batch"](
+            {
+                "phone": "+79001234567",
+                "target": "12345",
+                "file_paths": ",".join(files),
+                "confirm": True,
+            }
+        )
+        assert "Батч создан" in _text(result)
+
+        from src.database.bundles import PhotoLoaderBundle
+        from src.services.photo_publish_service import PhotoPublishService
+        from src.services.photo_task_service import PhotoTaskService
+
+        readback = PhotoTaskService(
+            PhotoLoaderBundle.from_database(db), PhotoPublishService(mock_pool)
+        )
+        items = await readback.list_items(limit=10)
+        assert len(items) == 1
+        assert items[0].send_mode == PhotoSendMode.ALBUM
+        assert set(items[0].file_paths) == set(files)
+
 
 class TestRunPhotoDue:
     @pytest.mark.anyio


### PR DESCRIPTION
## Summary

`create_photo_batch` (`photo_loader_write.py`) built **one entry per file**:

```python
entries = [{"files": [fp], "at": now} for fp in files]
```

`PhotoTaskService.create_batch` creates one item per entry and normalizes `send_mode` by `len(files)` of each entry (==1). `normalize_mode` (`photo_task_service.py:45-50`) downgrades `ALBUM→SEPARATE` when `files_count < 2`. The result: `create_photo_batch(mode=album, files=[a,b,c])` silently became **3 separate single-photo messages**, never an album.

By contrast `send_photos_now`/`schedule_photos` pass all files in one call → normalize once → album works. Only batch was split.

## Fix

Put all files in a single entry so `normalize_mode` sees `len(files)>1`:

```python
entries = [{"files": files, "at": now}]
```

The `at`/immediate-send semantics are unchanged by this fix (#1173 is separate).

## Test
Added `test_create_batch_album_keeps_single_item` — an e2e test against the **real** `PhotoTaskService.create_batch`:
- `create_photo_batch(file_paths="a.jpg,b.jpg,c.jpg")` → assert **1 item** with `send_mode == ALBUM` and all 3 files.
- RED on main: `len(items) == 3` (one SEPARATE item per file).

```
pytest tests/test_agent_tools_photo_loader.py -q   ✅ 52 passed
pytest tests/test_agent_tool_smoke_contract.py -q  ✅ 7 passed
ruff check src/ tests/                              ✅ clean
```

Closes #1180