### PR TITLE
fix(agent): keep resolve_entity lease alive for caller (#1187)

### DIFF
--- a/src/agent/tools/_registry.py
+++ b/src/agent/tools/_registry.py
@@ -709,6 +709,49 @@ async def require_phone_permission(db: object, phone: str, tool_name: str) -> di
 _NUMERIC_ID_RE = _re.compile(r"^-?\d+$")
 
 
+@dataclass(slots=True)
+class ResolvedEntityLease:
+    """Resolved entity plus ownership of client leases acquired for that resolve."""
+
+    client: object | None
+    entity: object | None
+    error: dict | None
+    _client_pool: object | None = None
+    _release_phones: tuple[str, ...] = ()
+    _released: bool = False
+
+    def __iter__(self):
+        yield self.client
+        yield self.entity
+        yield self.error
+
+    async def release(self) -> None:
+        """Release acquired client leases in LIFO order without masking callers."""
+        if self._released:
+            return
+        self._released = True
+        releaser = getattr(self._client_pool, "release_client", None)
+        if releaser is None:
+            return
+        for phone in reversed(self._release_phones):
+            try:
+                result = releaser(phone)
+                if isawaitable(result):
+                    await result
+            except Exception:
+                logger.debug("Failed to release resolve_entity lease for %s", phone, exc_info=True)
+
+
+async def _released_resolve_entity_result(
+    client_pool: object,
+    release_phones: list[str],
+    error: dict,
+) -> ResolvedEntityLease:
+    result = ResolvedEntityLease(None, None, error, client_pool, tuple(release_phones))
+    await result.release()
+    return result
+
+
 def should_try_dialog_title_lookup(identifier: object) -> bool:
     """Return True when an identifier can reasonably be a dialog title."""
     value = str(identifier or "").strip()
@@ -794,24 +837,23 @@ async def resolve_entity(
     chat_id: str,
     *,
     is_user: bool = False,
-) -> tuple[object, object, dict | None]:
+) -> ResolvedEntityLease:
     """Resolve a chat/user entity for Telethon operations with dialog-cache warming fallback.
 
     For usernames, t.me links, and "me" → uses the shared pool resolver when available.
     For numeric IDs → uses ``ClientPool.resolve_dialog_entity()`` which warms the entity cache
     automatically when the entity isn't cached yet (e.g. private groups without a username).
 
-    Returns ``(raw_client, entity, None)`` on success or ``(None, None, error_response)`` on failure.
+    Returns a ``ResolvedEntityLease`` that still unpacks as
+    ``(raw_client, entity, error_response)`` for compatibility. Successful
+    results own the acquired client lease until the caller awaits
+    ``result.release()`` after it has finished using ``raw_client``.
     Pass ``is_user=True`` when *chat_id* is a user ID (e.g. the ``user_id`` param in admin tools).
     """
     result = await client_pool.get_native_client_by_phone(phone)
     if result is None:
-        return None, None, _text_response(f"Клиент для {phone} не найден или flood-wait активен.")
+        return ResolvedEntityLease(None, None, _text_response(f"Клиент для {phone} не найден или flood-wait активен."))
     raw_client, native_phone = result
-    # Release every acquired lease on every exit path (success / not-found /
-    # exception): an unreleased phone stays in _in_use forever and drops out of
-    # the collector rotation (#1187, same leak class as #1179). Release the phone
-    # the pool returned — release_client pops the lease stack LIFO (#838/8).
     acquired_phones: list[str] = [native_phone]
     try:
         # Non-numeric identifiers: use the shared pool resolver when available so
@@ -824,15 +866,23 @@ async def resolve_entity(
                     entity = await resolver(raw_client, native_phone, cid, operation="agent_resolve_entity")
                 else:
                     entity = await raw_client.get_entity(cid)
-                return raw_client, entity, None
+                return ResolvedEntityLease(raw_client, entity, None, client_pool, tuple(acquired_phones))
             except Exception as e:
-                return None, None, _text_response(f"Ошибка: не удалось найти чат/пользователя '{chat_id}': {e}")
+                return await _released_resolve_entity_result(
+                    client_pool,
+                    acquired_phones,
+                    _text_response(f"Ошибка: не удалось найти чат/пользователя '{chat_id}': {e}"),
+                )
 
         # Numeric ID: use resolve_dialog_entity which handles cache warming
         dialog_id = int(cid)
         session_result = await client_pool.get_client_by_phone(phone)
         if session_result is None:
-            return None, None, _text_response(f"Клиент для {phone} не найден или flood-wait активен.")
+            return await _released_resolve_entity_result(
+                client_pool,
+                acquired_phones,
+                _text_response(f"Клиент для {phone} не найден или flood-wait активен."),
+            )
         session, regular_phone = session_result
         acquired_phones.append(regular_phone)
 
@@ -841,28 +891,40 @@ async def resolve_entity(
             entity = await client_pool.resolve_dialog_entity(session, regular_phone, dialog_id, target_type)
             if entity is None:
                 raise ValueError("entity is None")
-            return raw_client, entity, None
+            return ResolvedEntityLease(raw_client, entity, None, client_pool, tuple(acquired_phones))
         except (ValueError, TypeError, KeyError):
             pass
         except Exception as e:
             # Propagate flood waits and auth errors — do not retry
-            return None, None, _text_response(f"Ошибка: не удалось получить entity для {chat_id}: {e}")
+            return await _released_resolve_entity_result(
+                client_pool,
+                acquired_phones,
+                _text_response(f"Ошибка: не удалось получить entity для {chat_id}: {e}"),
+            )
 
         # Fallback: if not is_user, also try as PeerUser (numeric user DMs without username)
         if not is_user:
             try:
                 entity = await client_pool.resolve_dialog_entity(session, regular_phone, dialog_id, "dm")
                 if entity is not None:
-                    return raw_client, entity, None
+                    return ResolvedEntityLease(raw_client, entity, None, client_pool, tuple(acquired_phones))
             except (ValueError, TypeError, KeyError):
                 pass
             except Exception as e:
-                return None, None, _text_response(f"Ошибка: не удалось получить entity для {chat_id}: {e}")
+                return await _released_resolve_entity_result(
+                    client_pool,
+                    acquired_phones,
+                    _text_response(f"Ошибка: не удалось получить entity для {chat_id}: {e}"),
+                )
 
-        return None, None, _text_response(
-            f"Ошибка: не удалось найти чат/пользователя с ID {chat_id}. "
-            f"Попробуйте сначала обновить кэш диалогов (refresh_dialogs)."
+        return await _released_resolve_entity_result(
+            client_pool,
+            acquired_phones,
+            _text_response(
+                f"Ошибка: не удалось найти чат/пользователя с ID {chat_id}. "
+                f"Попробуйте сначала обновить кэш диалогов (refresh_dialogs)."
+            ),
         )
-    finally:
-        for acquired in acquired_phones:
-            await client_pool.release_client(acquired)
+    except BaseException:
+        await ResolvedEntityLease(None, None, None, client_pool, tuple(acquired_phones)).release()
+        raise

--- a/src/agent/tools/_registry.py
+++ b/src/agent/tools/_registry.py
@@ -807,53 +807,62 @@ async def resolve_entity(
     result = await client_pool.get_native_client_by_phone(phone)
     if result is None:
         return None, None, _text_response(f"Клиент для {phone} не найден или flood-wait активен.")
-    raw_client, _ = result
-
-    # Non-numeric identifiers: use the shared pool resolver when available so
-    # username/t.me live resolves obey the same FloodWait budget as workers.
-    cid = chat_id.strip()
-    if not _NUMERIC_ID_RE.match(cid):
-        try:
-            resolver = explicit_pool_method(client_pool, "resolve_entity_with_warm")
-            if resolver is not None:
-                entity = await resolver(raw_client, phone, cid, operation="agent_resolve_entity")
-            else:
-                entity = await raw_client.get_entity(cid)
-            return raw_client, entity, None
-        except Exception as e:
-            return None, None, _text_response(f"Ошибка: не удалось найти чат/пользователя '{chat_id}': {e}")
-
-    # Numeric ID: use resolve_dialog_entity which handles cache warming
-    dialog_id = int(cid)
-    session_result = await client_pool.get_client_by_phone(phone)
-    if session_result is None:
-        return None, None, _text_response(f"Клиент для {phone} не найден или flood-wait активен.")
-    session, _ = session_result
-
-    target_type = "dm" if is_user else None
+    raw_client, native_phone = result
+    # Release every acquired lease on every exit path (success / not-found /
+    # exception): an unreleased phone stays in _in_use forever and drops out of
+    # the collector rotation (#1187, same leak class as #1179). Release the phone
+    # the pool returned — release_client pops the lease stack LIFO (#838/8).
+    acquired_phones: list[str] = [native_phone]
     try:
-        entity = await client_pool.resolve_dialog_entity(session, phone, dialog_id, target_type)
-        if entity is None:
-            raise ValueError("entity is None")
-        return raw_client, entity, None
-    except (ValueError, TypeError, KeyError):
-        pass
-    except Exception as e:
-        # Propagate flood waits and auth errors — do not retry
-        return None, None, _text_response(f"Ошибка: не удалось получить entity для {chat_id}: {e}")
-
-    # Fallback: if not is_user, also try as PeerUser (numeric user DMs without username)
-    if not is_user:
-        try:
-            entity = await client_pool.resolve_dialog_entity(session, phone, dialog_id, "dm")
-            if entity is not None:
+        # Non-numeric identifiers: use the shared pool resolver when available so
+        # username/t.me live resolves obey the same FloodWait budget as workers.
+        cid = chat_id.strip()
+        if not _NUMERIC_ID_RE.match(cid):
+            try:
+                resolver = explicit_pool_method(client_pool, "resolve_entity_with_warm")
+                if resolver is not None:
+                    entity = await resolver(raw_client, native_phone, cid, operation="agent_resolve_entity")
+                else:
+                    entity = await raw_client.get_entity(cid)
                 return raw_client, entity, None
+            except Exception as e:
+                return None, None, _text_response(f"Ошибка: не удалось найти чат/пользователя '{chat_id}': {e}")
+
+        # Numeric ID: use resolve_dialog_entity which handles cache warming
+        dialog_id = int(cid)
+        session_result = await client_pool.get_client_by_phone(phone)
+        if session_result is None:
+            return None, None, _text_response(f"Клиент для {phone} не найден или flood-wait активен.")
+        session, regular_phone = session_result
+        acquired_phones.append(regular_phone)
+
+        target_type = "dm" if is_user else None
+        try:
+            entity = await client_pool.resolve_dialog_entity(session, regular_phone, dialog_id, target_type)
+            if entity is None:
+                raise ValueError("entity is None")
+            return raw_client, entity, None
         except (ValueError, TypeError, KeyError):
             pass
         except Exception as e:
+            # Propagate flood waits and auth errors — do not retry
             return None, None, _text_response(f"Ошибка: не удалось получить entity для {chat_id}: {e}")
 
-    return None, None, _text_response(
-        f"Ошибка: не удалось найти чат/пользователя с ID {chat_id}. "
-        f"Попробуйте сначала обновить кэш диалогов (refresh_dialogs)."
-    )
+        # Fallback: if not is_user, also try as PeerUser (numeric user DMs without username)
+        if not is_user:
+            try:
+                entity = await client_pool.resolve_dialog_entity(session, regular_phone, dialog_id, "dm")
+                if entity is not None:
+                    return raw_client, entity, None
+            except (ValueError, TypeError, KeyError):
+                pass
+            except Exception as e:
+                return None, None, _text_response(f"Ошибка: не удалось получить entity для {chat_id}: {e}")
+
+        return None, None, _text_response(
+            f"Ошибка: не удалось найти чат/пользователя с ID {chat_id}. "
+            f"Попробуйте сначала обновить кэш диалогов (refresh_dialogs)."
+        )
+    finally:
+        for acquired in acquired_phones:
+            await client_pool.release_client(acquired)

--- a/src/agent/tools/messaging_chat_state.py
+++ b/src/agent/tools/messaging_chat_state.py
@@ -226,14 +226,18 @@ def register_chat_state_read_tools(db: Any, ctx: Any, client_pool: Any) -> list[
         reaction_users_limit = normalize_reaction_users_limit(args.get("reaction_users_limit"))
         if not chat_id:
             return _text_response("Ошибка: chat_id обязателен.")
+        resolved_entity = None
         try:
-            client, entity, err = await resolve_entity(client_pool, phone, chat_id)
+            resolved_entity = await resolve_entity(client_pool, phone, chat_id)
+            client, entity, err = resolved_entity
             if err:
                 fallback_chat_id, fallback_err = await find_single_dialog_id_by_title(db, client_pool, phone, chat_id)
                 if fallback_err:
                     return fallback_err
                 if fallback_chat_id:
-                    client, entity, err = await resolve_entity(client_pool, phone, fallback_chat_id)
+                    await resolved_entity.release()
+                    resolved_entity = await resolve_entity(client_pool, phone, fallback_chat_id)
+                    client, entity, err = resolved_entity
                     if not err:
                         chat_id = fallback_chat_id
                 if err:
@@ -321,6 +325,9 @@ def register_chat_state_read_tools(db: Any, ctx: Any, client_pool: Any) -> list[
             return _text_response("\n".join(lines))
         except Exception as e:
             return _text_response(f"Ошибка чтения сообщений: {e}")
+        finally:
+            if resolved_entity is not None:
+                await resolved_entity.release()
 
     tools.append(read_messages)
     return tools

--- a/tests/test_agent_tools_messaging_errors.py
+++ b/tests/test_agent_tools_messaging_errors.py
@@ -18,6 +18,41 @@ class SnapshotClientPool:
         return set(self.clients)
 
 
+class DisconnectingIterClient:
+    def __init__(self, entity, messages):
+        self.entity = entity
+        self.messages = list(messages)
+        self.disconnected = False
+
+    async def get_entity(self, cid):
+        if self.disconnected:
+            raise RuntimeError("client disconnected before get_entity")
+        return self.entity
+
+    async def disconnect(self):
+        self.disconnected = True
+
+    async def iter_messages(self, entity, **kwargs):
+        if self.disconnected:
+            raise RuntimeError("client disconnected before iter_messages")
+        for message in self.messages:
+            yield message
+
+
+class DisconnectingReleasePool:
+    def __init__(self, phone, client):
+        self.clients = {phone: object()}
+        self.client = client
+        self.release_calls = []
+
+    async def get_native_client_by_phone(self, phone):
+        return self.client, phone
+
+    async def release_client(self, phone):
+        self.release_calls.append(phone)
+        await self.client.disconnect()
+
+
 @pytest.fixture
 def mock_db():
     db = MagicMock(spec=Database)
@@ -61,8 +96,14 @@ def _setup_resolve_entity(pool, client, entity=None):
     """Configure pool to return a working client+entity pair."""
     if entity is None:
         entity = SimpleNamespace(id=100)
-    pool.get_native_client_by_phone = AsyncMock(return_value=(client, None))
-    pool.get_client_by_phone = AsyncMock(return_value=(MagicMock(), None))
+    async def _get_native(phone, **_kwargs):
+        return client, phone
+
+    async def _get_regular(phone, **_kwargs):
+        return MagicMock(), phone
+
+    pool.get_native_client_by_phone = AsyncMock(side_effect=_get_native)
+    pool.get_client_by_phone = AsyncMock(side_effect=_get_regular)
     # Non-numeric path
     client.get_entity = AsyncMock(return_value=entity)
     return entity
@@ -814,6 +855,26 @@ class TestReadMessagesTool:
         assert "Hello world" in text
         assert "1 сообщений" in text
         assert "реакции:" not in text
+
+    @pytest.mark.anyio
+    async def test_read_messages_uses_resolved_client_before_release(self, mock_db):
+        entity = SimpleNamespace(id=100)
+        msg = SimpleNamespace(id=1, sender_id=42, date=None, text="lease stays live")
+        client = DisconnectingIterClient(entity, [msg])
+        pool = DisconnectingReleasePool("+79001234567", client)
+
+        handlers = _get_tool_handlers(mock_db, client_pool=pool)
+        result = await handlers["read_messages"]({
+            "phone": "+79001234567",
+            "chat_id": "@test",
+            "limit": 10,
+        })
+
+        text = _text(result)
+        assert "lease stays live" in text
+        assert "Ошибка чтения сообщений" not in text
+        assert client.disconnected
+        assert pool.release_calls == ["+79001234567"]
 
     @pytest.mark.anyio
     async def test_with_message_reactions(self, mock_db, mock_pool):

--- a/tests/test_agent_tools_messaging_errors.py
+++ b/tests/test_agent_tools_messaging_errors.py
@@ -30,6 +30,9 @@ def mock_db():
 @pytest.fixture
 def mock_pool():
     pool = MagicMock()
+    # resolve_entity (#1187) and resolve_photo_target (#1179) release the lease
+    # they acquire; mock pools that flow through them need an awaitable release.
+    pool.release_client = AsyncMock()
     return pool
 
 

--- a/tests/test_agent_tools_registry.py
+++ b/tests/test_agent_tools_registry.py
@@ -19,6 +19,7 @@ from src.agent.tools._registry import (
     require_confirmation,
     require_phone_permission,
     require_pool,
+    resolve_entity,
     resolve_live_read_phone,
     resolve_phone,
 )
@@ -411,3 +412,183 @@ class TestRequirePhonePermission:
             result = await require_phone_permission(db, "+7900", "search_messages")
         assert result is not None
         assert "не разрешён" in result["content"][0]["text"]
+
+
+# ── resolve_entity client-lease hygiene (#1187) ──────────────────────────────
+
+
+class _FakeNativeClient:
+    """Minimal stand-in for a native Telethon client returned by the pool."""
+
+    def __init__(self, entity, *, raise_on_get_entity=None):
+        self._entity = entity
+        self._raise = raise_on_get_entity
+
+    async def get_entity(self, cid):
+        if self._raise is not None:
+            raise self._raise
+        return self._entity
+
+
+class _LeaseTrackingPool:
+    """Fake ClientPool that counts native/regular leases and records releases.
+
+    resolve_entity has TWO acquire sites — get_native_client_by_phone (always)
+    and get_client_by_phone (numeric path only) — and before #1187 released
+    neither. This pool mirrors the _LeaseTrackingPool shape from #1183
+    (resolve_photo_target) but tracks both acquire kinds so a test can assert
+    acquire == release on every exit path.
+    """
+
+    def __init__(
+        self,
+        *,
+        entity=None,
+        warm_resolver=True,
+        resolve_dialog=None,
+        native_none=False,
+        regular_none=False,
+        native_client=None,
+    ):
+        self._entity = entity if entity is not None else SimpleNamespace(id=4242)
+        self._native_client = native_client if native_client is not None else _FakeNativeClient(self._entity)
+        self._resolve_dialog = resolve_dialog
+        self._native_none = native_none
+        self._regular_none = regular_none
+        # Disable the warm resolver by shadowing the class method with None;
+        # explicit_pool_method treats a non-callable instance attr as absent.
+        if not warm_resolver:
+            self.resolve_entity_with_warm = None
+        self.native_acquired = 0
+        self.regular_acquired = 0
+        self.released: list[str] = []
+
+    async def get_native_client_by_phone(self, phone):
+        if self._native_none:
+            return None
+        self.native_acquired += 1
+        return self._native_client, phone
+
+    async def get_client_by_phone(self, phone):
+        if self._regular_none:
+            return None
+        self.regular_acquired += 1
+        return object(), phone
+
+    async def release_client(self, phone):
+        self.released.append(phone)
+
+    # Class-level so utils.introspection.explicit_pool_method finds it.
+    async def resolve_entity_with_warm(self, raw_client, phone, cid, *, operation=None):
+        return self._entity
+
+    async def resolve_dialog_entity(self, session, phone, dialog_id, target_type=None):
+        if self._resolve_dialog is not None:
+            return self._resolve_dialog(dialog_id, target_type)
+        return self._entity
+
+    @property
+    def total_acquired(self) -> int:
+        return self.native_acquired + self.regular_acquired
+
+
+class TestResolveEntityLease:
+    """resolve_entity must release every client lease it acquires on every exit
+    path (success / not-found / exception). A leaked lease leaves the phone in
+    ClientPool._in_use forever and drops it out of the exclusive collector
+    rotation (#1187, same class as resolve_photo_target #1179)."""
+
+    PHONE = "+79001234567"
+
+    @pytest.mark.anyio
+    async def test_username_path_releases_native_lease(self):
+        """Non-numeric id (username) acquires only the native lease (#1) and must
+        release exactly it on the success path."""
+        pool = _LeaseTrackingPool()
+        raw_client, entity, err = await resolve_entity(pool, self.PHONE, "@channel")
+        assert err is None
+        assert entity is pool._entity
+        assert raw_client is pool._native_client
+        assert pool.native_acquired == 1
+        assert pool.regular_acquired == 0
+        assert pool.released == [self.PHONE]
+        assert pool.total_acquired == len(pool.released)
+
+    @pytest.mark.anyio
+    async def test_me_path_releases_native_lease_via_get_entity_fallback(self):
+        """'me' is non-numeric and hits the raw_client.get_entity fallback (no
+        warm resolver) — still a single native lease, single release."""
+        pool = _LeaseTrackingPool(warm_resolver=False)
+        raw_client, entity, err = await resolve_entity(pool, self.PHONE, "me")
+        assert err is None
+        assert entity is pool._entity
+        assert pool.native_acquired == 1
+        assert pool.regular_acquired == 0
+        assert pool.released == [self.PHONE]
+        assert pool.total_acquired == len(pool.released)
+
+    @pytest.mark.anyio
+    async def test_numeric_path_releases_both_leases(self):
+        """Numeric id acquires BOTH the native (#1) and regular (#2) leases — the
+        double-leak site called out in #1187. Both must be released on success."""
+        pool = _LeaseTrackingPool()
+        raw_client, entity, err = await resolve_entity(pool, self.PHONE, "123456")
+        assert err is None
+        assert entity is pool._entity
+        assert pool.native_acquired == 1
+        assert pool.regular_acquired == 1
+        assert pool.released == [self.PHONE, self.PHONE]
+        assert pool.total_acquired == len(pool.released)
+
+    @pytest.mark.anyio
+    async def test_numeric_not_found_still_releases_both_leases(self):
+        """resolve_dialog_entity raising ValueError (entity not cached) must still
+        release both acquired leases before the not-found error response."""
+        def raise_valueerror(dialog_id, target_type):
+            raise ValueError("entity is None")
+
+        pool = _LeaseTrackingPool(resolve_dialog=raise_valueerror)
+        raw_client, entity, err = await resolve_entity(pool, self.PHONE, "987654")
+        assert err is not None
+        assert entity is None
+        assert pool.native_acquired == 1
+        assert pool.regular_acquired == 1
+        assert pool.released == [self.PHONE, self.PHONE]
+        assert pool.total_acquired == len(pool.released)
+
+    @pytest.mark.anyio
+    async def test_username_exception_path_releases_native_lease(self):
+        """If the username resolver raises, the native lease is still released
+        (try/finally) and an error response is returned."""
+        boom = RuntimeError("network down")
+        client = _FakeNativeClient(None, raise_on_get_entity=boom)
+        pool = _LeaseTrackingPool(warm_resolver=False, native_client=client)
+        raw_client, entity, err = await resolve_entity(pool, self.PHONE, "@ghost")
+        assert err is not None
+        assert entity is None
+        assert pool.native_acquired == 1
+        assert pool.regular_acquired == 0
+        assert pool.released == [self.PHONE]
+        assert pool.total_acquired == len(pool.released)
+
+    @pytest.mark.anyio
+    async def test_numeric_regular_client_unavailable_releases_native_lease(self):
+        """On the numeric path, if the regular client is unavailable (None), only
+        the native lease was acquired — it must still be released."""
+        pool = _LeaseTrackingPool(regular_none=True)
+        raw_client, entity, err = await resolve_entity(pool, self.PHONE, "555")
+        assert err is not None
+        assert pool.native_acquired == 1
+        assert pool.regular_acquired == 0
+        assert pool.released == [self.PHONE]
+        assert pool.total_acquired == len(pool.released)
+
+    @pytest.mark.anyio
+    async def test_native_client_unavailable_acquires_and_releases_nothing(self):
+        """If get_native_client_by_phone returns None, no lease is acquired and
+        nothing should be released."""
+        pool = _LeaseTrackingPool(native_none=True)
+        raw_client, entity, err = await resolve_entity(pool, self.PHONE, "@channel")
+        assert err is not None
+        assert pool.total_acquired == 0
+        assert pool.released == []

--- a/tests/test_agent_tools_registry.py
+++ b/tests/test_agent_tools_registry.py
@@ -420,24 +420,36 @@ class TestRequirePhonePermission:
 class _FakeNativeClient:
     """Minimal stand-in for a native Telethon client returned by the pool."""
 
-    def __init__(self, entity, *, raise_on_get_entity=None):
+    def __init__(self, entity, *, messages=None, raise_on_get_entity=None):
         self._entity = entity
+        self._messages = list(messages or [])
         self._raise = raise_on_get_entity
+        self.disconnected = False
 
     async def get_entity(self, cid):
+        if self.disconnected:
+            raise RuntimeError("client disconnected")
         if self._raise is not None:
             raise self._raise
         return self._entity
 
+    async def disconnect(self):
+        self.disconnected = True
+
+    async def iter_messages(self, entity, **kwargs):
+        if self.disconnected:
+            raise RuntimeError("client disconnected")
+        for message in self._messages:
+            yield message
+
 
 class _LeaseTrackingPool:
-    """Fake ClientPool that counts native/regular leases and records releases.
+    """Fake ClientPool with a real LIFO lease stack and native disconnect.
 
     resolve_entity has TWO acquire sites — get_native_client_by_phone (always)
     and get_client_by_phone (numeric path only) — and before #1187 released
-    neither. This pool mirrors the _LeaseTrackingPool shape from #1183
-    (resolve_photo_target) but tracks both acquire kinds so a test can assert
-    acquire == release on every exit path.
+    neither. This pool tracks both acquire kinds and makes native release
+    disconnect the returned client so use-after-disconnect is visible in tests.
     """
 
     def __init__(
@@ -449,34 +461,45 @@ class _LeaseTrackingPool:
         native_none=False,
         regular_none=False,
         native_client=None,
+        release_failures=None,
     ):
         self._entity = entity if entity is not None else SimpleNamespace(id=4242)
         self._native_client = native_client if native_client is not None else _FakeNativeClient(self._entity)
         self._resolve_dialog = resolve_dialog
         self._native_none = native_none
         self._regular_none = regular_none
+        self._release_failures = set(release_failures or ())
         # Disable the warm resolver by shadowing the class method with None;
         # explicit_pool_method treats a non-callable instance attr as absent.
         if not warm_resolver:
             self.resolve_entity_with_warm = None
         self.native_acquired = 0
         self.regular_acquired = 0
-        self.released: list[str] = []
+        self.released: list[tuple[str, str]] = []
+        self._lease_stack: list[tuple[str, object]] = []
 
     async def get_native_client_by_phone(self, phone):
         if self._native_none:
             return None
         self.native_acquired += 1
+        self._lease_stack.append(("native", self._native_client))
         return self._native_client, phone
 
     async def get_client_by_phone(self, phone):
         if self._regular_none:
             return None
         self.regular_acquired += 1
-        return object(), phone
+        session = object()
+        self._lease_stack.append(("regular", session))
+        return session, phone
 
     async def release_client(self, phone):
-        self.released.append(phone)
+        kind, lease_client = self._lease_stack.pop()
+        self.released.append((phone, kind))
+        if kind == "native":
+            await lease_client.disconnect()
+        if kind in self._release_failures:
+            raise RuntimeError(f"{kind} release failed")
 
     # Class-level so utils.introspection.explicit_pool_method finds it.
     async def resolve_entity_with_warm(self, raw_client, phone, cid, *, operation=None):
@@ -491,54 +514,100 @@ class _LeaseTrackingPool:
     def total_acquired(self) -> int:
         return self.native_acquired + self.regular_acquired
 
+    @property
+    def released_phones(self) -> list[str]:
+        return [phone for phone, _kind in self.released]
+
+    @property
+    def released_kinds(self) -> list[str]:
+        return [kind for _phone, kind in self.released]
+
 
 class TestResolveEntityLease:
-    """resolve_entity must release every client lease it acquires on every exit
-    path (success / not-found / exception). A leaked lease leaves the phone in
-    ClientPool._in_use forever and drops it out of the exclusive collector
-    rotation (#1187, same class as resolve_photo_target #1179)."""
+    """resolve_entity must transfer successful native-lease ownership to the
+    caller and release all acquired leases on error/not-found. A leaked lease
+    leaves the phone in ClientPool._in_use forever and drops it out of the
+    exclusive collector rotation (#1187, same class as resolve_photo_target
+    #1179)."""
 
     PHONE = "+79001234567"
 
     @pytest.mark.anyio
-    async def test_username_path_releases_native_lease(self):
-        """Non-numeric id (username) acquires only the native lease (#1) and must
-        release exactly it on the success path."""
+    async def test_username_path_returns_release_handle_for_native_lease(self):
+        """Non-numeric id (username) acquires only the native lease (#1). The
+        returned client stays connected until the caller releases the handle."""
         pool = _LeaseTrackingPool()
-        raw_client, entity, err = await resolve_entity(pool, self.PHONE, "@channel")
+        result = await resolve_entity(pool, self.PHONE, "@channel")
+        raw_client, entity, err = result
         assert err is None
         assert entity is pool._entity
         assert raw_client is pool._native_client
         assert pool.native_acquired == 1
         assert pool.regular_acquired == 0
-        assert pool.released == [self.PHONE]
+        assert pool.released == []
+        assert not pool._native_client.disconnected
+        await result.release()
+        assert pool.released == [(self.PHONE, "native")]
         assert pool.total_acquired == len(pool.released)
+        assert pool._native_client.disconnected
 
     @pytest.mark.anyio
-    async def test_me_path_releases_native_lease_via_get_entity_fallback(self):
+    async def test_me_path_returns_release_handle_via_get_entity_fallback(self):
         """'me' is non-numeric and hits the raw_client.get_entity fallback (no
-        warm resolver) — still a single native lease, single release."""
+        warm resolver) — still a single native lease owned by the caller."""
         pool = _LeaseTrackingPool(warm_resolver=False)
-        raw_client, entity, err = await resolve_entity(pool, self.PHONE, "me")
+        result = await resolve_entity(pool, self.PHONE, "me")
+        raw_client, entity, err = result
         assert err is None
         assert entity is pool._entity
         assert pool.native_acquired == 1
         assert pool.regular_acquired == 0
-        assert pool.released == [self.PHONE]
+        assert pool.released == []
+        await result.release()
+        assert pool.released == [(self.PHONE, "native")]
         assert pool.total_acquired == len(pool.released)
 
     @pytest.mark.anyio
-    async def test_numeric_path_releases_both_leases(self):
+    async def test_numeric_path_release_handle_releases_both_leases_lifo(self):
         """Numeric id acquires BOTH the native (#1) and regular (#2) leases — the
-        double-leak site called out in #1187. Both must be released on success."""
+        double-leak site called out in #1187. The handle releases regular first
+        and native last so the returned native client lives through use."""
         pool = _LeaseTrackingPool()
-        raw_client, entity, err = await resolve_entity(pool, self.PHONE, "123456")
+        result = await resolve_entity(pool, self.PHONE, "123456")
+        raw_client, entity, err = result
         assert err is None
         assert entity is pool._entity
         assert pool.native_acquired == 1
         assert pool.regular_acquired == 1
-        assert pool.released == [self.PHONE, self.PHONE]
+        assert pool.released == []
+        assert not pool._native_client.disconnected
+        await result.release()
+        assert pool.released == [(self.PHONE, "regular"), (self.PHONE, "native")]
         assert pool.total_acquired == len(pool.released)
+        assert pool._native_client.disconnected
+
+    @pytest.mark.anyio
+    async def test_returned_client_remains_usable_until_release(self):
+        """Regression guard for PR #1188 blocker: the old finally release
+        disconnected raw_client before read_recent_messages could iterate."""
+        entity = SimpleNamespace(id=4242)
+        message = SimpleNamespace(id=1, text="still connected")
+        client = _FakeNativeClient(entity, messages=[message])
+        pool = _LeaseTrackingPool(entity=entity, warm_resolver=False, native_client=client)
+
+        result = await resolve_entity(pool, self.PHONE, "@channel")
+        raw_client, resolved_entity, err = result
+
+        assert err is None
+        assert resolved_entity is entity
+        messages = [msg async for msg in raw_client.iter_messages(resolved_entity, limit=1)]
+        assert messages == [message]
+        assert not client.disconnected
+
+        await result.release()
+        assert client.disconnected
+        with pytest.raises(RuntimeError, match="client disconnected"):
+            [msg async for msg in raw_client.iter_messages(resolved_entity, limit=1)]
 
     @pytest.mark.anyio
     async def test_numeric_not_found_still_releases_both_leases(self):
@@ -548,13 +617,16 @@ class TestResolveEntityLease:
             raise ValueError("entity is None")
 
         pool = _LeaseTrackingPool(resolve_dialog=raise_valueerror)
-        raw_client, entity, err = await resolve_entity(pool, self.PHONE, "987654")
+        result = await resolve_entity(pool, self.PHONE, "987654")
+        raw_client, entity, err = result
         assert err is not None
         assert entity is None
         assert pool.native_acquired == 1
         assert pool.regular_acquired == 1
-        assert pool.released == [self.PHONE, self.PHONE]
+        assert pool.released == [(self.PHONE, "regular"), (self.PHONE, "native")]
         assert pool.total_acquired == len(pool.released)
+        await result.release()
+        assert pool.released == [(self.PHONE, "regular"), (self.PHONE, "native")]
 
     @pytest.mark.anyio
     async def test_username_exception_path_releases_native_lease(self):
@@ -563,12 +635,13 @@ class TestResolveEntityLease:
         boom = RuntimeError("network down")
         client = _FakeNativeClient(None, raise_on_get_entity=boom)
         pool = _LeaseTrackingPool(warm_resolver=False, native_client=client)
-        raw_client, entity, err = await resolve_entity(pool, self.PHONE, "@ghost")
+        result = await resolve_entity(pool, self.PHONE, "@ghost")
+        raw_client, entity, err = result
         assert err is not None
         assert entity is None
         assert pool.native_acquired == 1
         assert pool.regular_acquired == 0
-        assert pool.released == [self.PHONE]
+        assert pool.released == [(self.PHONE, "native")]
         assert pool.total_acquired == len(pool.released)
 
     @pytest.mark.anyio
@@ -576,11 +649,12 @@ class TestResolveEntityLease:
         """On the numeric path, if the regular client is unavailable (None), only
         the native lease was acquired — it must still be released."""
         pool = _LeaseTrackingPool(regular_none=True)
-        raw_client, entity, err = await resolve_entity(pool, self.PHONE, "555")
+        result = await resolve_entity(pool, self.PHONE, "555")
+        raw_client, entity, err = result
         assert err is not None
         assert pool.native_acquired == 1
         assert pool.regular_acquired == 0
-        assert pool.released == [self.PHONE]
+        assert pool.released == [(self.PHONE, "native")]
         assert pool.total_acquired == len(pool.released)
 
     @pytest.mark.anyio
@@ -588,7 +662,23 @@ class TestResolveEntityLease:
         """If get_native_client_by_phone returns None, no lease is acquired and
         nothing should be released."""
         pool = _LeaseTrackingPool(native_none=True)
-        raw_client, entity, err = await resolve_entity(pool, self.PHONE, "@channel")
+        result = await resolve_entity(pool, self.PHONE, "@channel")
+        raw_client, entity, err = result
         assert err is not None
         assert pool.total_acquired == 0
         assert pool.released == []
+
+    @pytest.mark.anyio
+    async def test_release_handle_continues_after_one_release_fails(self):
+        """Best-effort release: one failing release_client call must not block
+        later leases from being released."""
+        pool = _LeaseTrackingPool(release_failures={"regular"})
+        result = await resolve_entity(pool, self.PHONE, "123456")
+        raw_client, entity, err = result
+
+        assert err is None
+        assert entity is pool._entity
+        await result.release()
+
+        assert pool.released_kinds == ["regular", "native"]
+        assert pool._native_client.disconnected


### PR DESCRIPTION
## Summary

Redesigns the #1187 `resolve_entity` lease fix after dual-review found the first PR version could disconnect the native client before the caller used it.

Chosen implementation: **variant B**. `resolve_entity` now returns a `ResolvedEntityLease` result object that still unpacks as `(raw_client, entity, error)` for compatibility, but also owns the acquired leases until the consumer awaits `result.release()`.

Why not variant A: skipping native release inside `resolve_entity` avoids the immediate disconnect, but without transferring a release handle it leaves the native success lease owned by nobody. The helper returns a live client, so the caller has to own the release boundary.

## Fix

- `src/agent/tools/_registry.py`
  - Added `ResolvedEntityLease.release()`.
  - Success paths return a live client plus release handle.
  - Error, not-found, and exception paths release acquired leases before returning/raising.
  - Release is LIFO via `reversed(release_phones)`.
  - Release is best-effort: one failing `release_client` call does not block later releases.
- `src/agent/tools/messaging_chat_state.py`
  - `read_messages` now keeps the `resolve_entity` lease alive through `iter_messages` and reaction-user fetch, then releases in `finally`.
  - Title fallback releases the first failed resolve handle before resolving the fallback id.

## Tests

Updated the existing #1187 leak tests to match the new ownership boundary:

- success returns a release handle, then releases native or regular+native after caller use;
- numeric release is LIFO: regular first, native last;
- not-found/error/unavailable paths still release immediately;
- release is idempotent and best-effort.

Added use-after-disconnect regression coverage:

- `test_returned_client_remains_usable_until_release` uses a fake native client whose `release_client` disconnects it; the client must still support `iter_messages` after `resolve_entity` returns and before `result.release()`.
- `test_read_messages_uses_resolved_client_before_release` exercises the real `read_messages` consumer with a pool whose release disconnects the client. The old PR finally-release would disconnect before `iter_messages`, producing `Ошибка чтения сообщений`; the redesigned fix reads the message, then disconnects on release.

## Verification

```
ruff check src/ tests/ conftest.py
pytest tests/test_agent_tools_registry.py tests/test_agent_tools_messaging_errors.py -v
```

Result: `142 passed`.

Closes #1187
