### PR TITLE
fix(pool): make release_client pop+discard atomic (close #1181 race)

### DIFF
--- a/src/telegram/pool_lifecycle.py
+++ b/src/telegram/pool_lifecycle.py
@@ -248,8 +248,8 @@ class ClientLifecycleMixin:
         disconnect-on-release one so the native client/connection is torn down
         promptly instead of lingering until an unrelated caller releases (#838/8).
         """
+        lease = None
         async with self._lock:
-            lease = None
             stack = self._active_leases.get(phone)
             if stack:
                 # Strict LIFO: release the most-recently-acquired lease for this phone.
@@ -262,9 +262,20 @@ class ClientLifecycleMixin:
                 lease = stack.pop()
                 if not stack:
                     self._active_leases.pop(phone, None)
-            should_release = not self._active_leases.get(phone)
-        if should_release:
-            await self._lease_pool.release(phone)
+            # Drop the exclusive _in_use marker in the SAME critical section that
+            # pops the lease stack, holding ClientPool._lock across the nested
+            # _lease_pool.release (which takes AccountLeasePool._lock). With both
+            # locks held there is no window in which a concurrent acquirer — the
+            # fallback in _acquire_phone_lease (ClientPool._lock) OR
+            # AccountLeasePool.acquire_by_phone (AccountLeasePool._lock) — can
+            # observe a stale exclusive marker, grab a shared lease, and then let
+            # a later caller take exclusive once this discard completes: that
+            # sequence puts shared+exclusive on one session concurrently (#1181).
+            # Lock order ClientPool._lock -> AccountLeasePool._lock has no reverse
+            # holder (AccountLeasePool never calls back into ClientPool), so the
+            # nesting cannot deadlock.
+            if not self._active_leases.get(phone):
+                await self._lease_pool.release(phone)
         if lease is not None and lease.disconnect_on_release:
             await self._backend_router.release(lease)
 

--- a/tests/test_client_pool_lifecycle.py
+++ b/tests/test_client_pool_lifecycle.py
@@ -71,6 +71,123 @@ async def test_release_client_falls_back_to_lifo_without_native_lease():
     pool._backend_router.release.assert_not_awaited()
 
 
+def _pool_with_in_use(in_use: set[str]) -> ClientPool:
+    """A bare pool whose _in_use is a real, observable set (shared with the
+    lease pool in production). The #1181 race is about the visibility of this
+    set's exclusive marker, so the tests must poke the real object."""
+    pool = ClientPool.__new__(ClientPool)
+    pool._lock = asyncio.Lock()
+    pool._in_use = in_use
+    pool._active_leases = {}
+    pool._lease_pool = MagicMock()
+    pool._lease_pool.release = AsyncMock()
+    pool._backend_router = MagicMock()
+    pool._backend_router.release = AsyncMock()
+    return pool
+
+
+@pytest.mark.anyio
+async def test_release_client_discards_in_use_under_client_pool_lock():
+    """#1181 regression: the exclusive _in_use marker must be discarded in the
+    SAME ClientPool._lock critical section that pops the _active_leases stack.
+    Previously release_client released ClientPool._lock, THEN called
+    _lease_pool.release (which takes AccountLeasePool._lock to discard) — an
+    await window in which a concurrent _acquire_phone_lease could observe the
+    stale marker, grab a shared lease, and let a later caller take exclusive
+    after the discard: shared+exclusive on one session.
+
+    Pins the fix by asserting ClientPool._lock is still held at the moment
+    _lease_pool.release runs (no window), and that the pop has already emptied
+    the stack by then (pop -> discard ordering under one lock)."""
+    pool = _pool_with_in_use(in_use={"+7"})
+    lease = SimpleNamespace(disconnect_on_release=False)
+    pool._active_leases["+7"] = [lease]
+
+    observed: dict[str, object] = {}
+
+    async def _spy_release(phone):
+        # _lease_pool.release performs _in_use.discard under AccountLeasePool._lock.
+        # For the race window to be closed it must ALSO run under ClientPool._lock.
+        observed["client_lock_held"] = pool._lock.locked()
+        observed["active_leases_snapshot"] = {k: list(v) for k, v in pool._active_leases.items()}
+        observed["in_use_snapshot"] = set(pool._in_use)
+        # Mirror the real AccountLeasePool.release: drop the marker here.
+        pool._in_use.discard(phone)
+
+    pool._lease_pool.release = _spy_release
+
+    await pool.release_client("+7")
+
+    # The discard ran while ClientPool._lock was held (old bug: False here).
+    assert observed["client_lock_held"] is True, (
+        "_in_use.discard ran outside ClientPool._lock — pop/discard window reopened (#1181)"
+    )
+    # The pop already emptied the stack before the discard ran (no reordering).
+    assert observed["active_leases_snapshot"] == {}
+    # _in_use still holds the marker at the instant release is entered (discard
+    # happens inside _lease_pool.release, after this snapshot).
+    assert observed["in_use_snapshot"] == {"+7"}
+    # After release_client returns, both the stack and the marker are gone.
+    assert "+7" not in pool._active_leases
+    assert "+7" not in pool._in_use
+
+
+@pytest.mark.anyio
+async def test_release_client_skips_discard_under_lock_when_stack_remains():
+    """#1181: when the popped lease leaves remaining leases on the stack, the
+    phone is still exclusively held, so _in_use must NOT be discarded — and the
+    decision still happens under ClientPool._lock (atomic with the pop)."""
+    pool = _pool_with_in_use(in_use={"+7"})
+    kept = SimpleNamespace(disconnect_on_release=False)
+    top = SimpleNamespace(disconnect_on_release=False)
+    pool._active_leases["+7"] = [kept, top]
+
+    await pool.release_client("+7")
+
+    pool._lease_pool.release.assert_not_awaited()
+    assert pool._active_leases["+7"] == [kept]
+    assert pool._in_use == {"+7"}, "marker must survive while leases remain on the stack"
+
+
+@pytest.mark.anyio
+async def test_release_client_no_await_window_between_pop_and_discard():
+    """#1181 contract (the issue's minimum bar): there is no scheduling point
+    between popping _active_leases and discarding the _in_use marker. Spies
+    _lease_pool.release (the call that owns the discard under
+    AccountLeasePool._lock in production) and records ClientPool._lock state at
+    the exact moment of discard. With the fix the only await between pop and
+    discard is _lease_pool.release itself, executed while ClientPool._lock is
+    held — so no concurrent acquirer can interleave.
+
+    Regression guard: on the pre-fix code _lease_pool.release ran AFTER
+    ClientPool._lock was released, so the snapshot here would catch the lock
+    FREE mid-discard."""
+    in_use: set[str] = {"+7"}
+    pool = _pool_with_in_use(in_use=in_use)
+    lease = SimpleNamespace(disconnect_on_release=False)
+    pool._active_leases["+7"] = [lease]
+
+    # Stand in for AccountLeasePool.release: it owns the discard under its own
+    # lock; we record the ClientPool._lock state at the exact moment of discard.
+    timeline: list[tuple[str, bool]] = []
+
+    async def _discard_under_lease_lock(phone):
+        timeline.append(("discard", pool._lock.locked()))
+        # Mirror the real AccountLeasePool.release: drop the marker here.
+        pool._in_use.discard(phone)
+
+    pool._lease_pool.release = _discard_under_lease_lock
+
+    await pool.release_client("+7")
+
+    assert timeline == [("discard", True)], (
+        "_in_use.discard did not run under ClientPool._lock — the pop/discard "
+        "window is open, allowing shared+exclusive on one session (#1181)"
+    )
+    assert in_use == set()
+    assert "+7" not in pool._active_leases
+
+
 @pytest.mark.anyio
 async def test_disconnect_all_cancels_background_tasks():
     """Warm/refresh background tasks must be cancelled on teardown (audit #836/11)."""


### PR DESCRIPTION
Closes #1181

## Problem
`release_client` (`src/telegram/pool_lifecycle.py`) popped `_active_leases` under `ClientPool._lock`, **released the lock**, then called `_lease_pool.release(phone)` which discards the exclusive `_in_use` marker under a *different* lock (`AccountLeasePool._lock`). The await window between the locks let a concurrent `_acquire_phone_lease`:

1. observe the stale exclusive marker (`phone in _in_use` still true),
2. grab a **shared** lease, then
3. let a later caller take **exclusive** once the discard completed

→ **shared + exclusive on one session concurrently**, violating the in-use exclusion invariant. `_in_use` is the *same* set object shared by both classes (`AccountLeasePool(db, self._in_use)` in `client_pool.py`), and the two paths mutate it under two different locks, so the window was real.

## Fix
Drop the `_in_use` marker inside the **same** `ClientPool._lock` critical section that pops the lease stack — holding `ClientPool._lock` across the nested `_lease_pool.release` (which itself takes `AccountLeasePool._lock`). With **both** locks held during the discard:

- the `_acquire_phone_lease` fallback path (`ClientPool._lock`, pool_lifecycle.py:446-450) cannot observe a stale marker, and
- `AccountLeasePool.acquire_by_phone` (`AccountLeasePool._lock`) cannot observe a stale marker.

Lock order `ClientPool._lock → AccountLeasePool._lock` has **no reverse holder** (`AccountLeasePool` never calls back into `ClientPool`), so the nesting cannot deadlock. `should_release` semantics are preserved: the discard only fires when the stack is empty after the pop.

## Tests (`tests/test_client_pool_lifecycle.py`)
- `test_release_client_discards_in_use_under_client_pool_lock` — pins the fix: `ClientPool._lock` is still held at the moment `_lease_pool.release` runs, and the pop has already emptied the stack before the discard (pop → discard ordering under one lock).
- `test_release_client_no_await_window_between_pop_and_discard` — contract test (the issue's minimum bar): no scheduling point between pop and discard; the discard timeline is `[("discard", True)]` (lock held). On the pre-fix code this yields `[("discard", False)]` → test fails.
- `test_release_client_skips_discard_under_lock_when_stack_remains` — when leases remain on the stack the phone is still exclusively held, so `_in_use` is **not** discarded and `_lease_pool.release` is not awaited.

The first two are verified to **fail on the reverted (pre-fix) code** and pass on the fix.

## Validation
\`\`\`
pytest tests/test_client_pool_lifecycle.py tests/test_account_lease_pool.py tests/test_client_pool_decomposition.py -q   # 31 passed
pytest tests/test_client_pool.py tests/test_client_pool_extended.py tests/test_client_pool_runtime.py ... -q               # 91 passed
ruff check src/ tests/                                                                                                    # All checks passed
\`\`\`

No public-contract changes (`release_client` signature/observable behaviour unchanged). Scope respected: only `pool_lifecycle.py` + its tests touched; `ci.yml` untouched.