### PR TITLE
[codex] Suppress notification snapshot timeout tracebacks

### DIFF
--- a/src/runtime/worker.py
+++ b/src/runtime/worker.py
@@ -213,6 +213,8 @@ async def _publish_snapshots(container, *, stop_event: asyncio.Event | None = No
             if _is_expected_shutdown_cancellation(stop_event):
                 raise
             logger.warning("Notification bot snapshot refresh was cancelled; continuing worker")
+        except asyncio.TimeoutError:
+            logger.warning("Notification bot snapshot timed out (network); continuing")
         except Exception:
             logger.warning("Failed to refresh notification bot snapshot", exc_info=True)
         else:

--- a/tests/test_runtime_worker.py
+++ b/tests/test_runtime_worker.py
@@ -211,6 +211,24 @@ async def test_publish_snapshots_notification_bot_cancelled_is_nonfatal(caplog):
     assert "Notification bot snapshot refresh was cancelled; continuing worker" in caplog.text
 
 
+async def test_publish_snapshots_notification_bot_timeout_is_nonfatal(caplog):
+    container = _make_container(target_state="available")
+    with patch("src.runtime.worker.NotificationService") as mock_notif_svc:
+        mock_notif = MagicMock()
+        mock_notif.get_status = AsyncMock(side_effect=asyncio.TimeoutError("bot timeout"))
+        mock_notif_svc.return_value = mock_notif
+
+        caplog.set_level("WARNING", logger="src.runtime.worker")
+        await _publish_snapshots(container)
+
+    calls = container.db.repos.runtime_snapshots.upsert_snapshot.call_args_list
+    notif_call = [c for c in calls if c[0][0].snapshot_type == "notification_target_status"][0]
+    bot_payload = notif_call[0][0].payload["bot"]
+    assert bot_payload["configured"] is False
+    assert "Notification bot snapshot timed out (network); continuing" in caplog.text
+    assert "Traceback" not in caplog.text
+
+
 async def test_publish_worker_down_snapshot_for_decrypt_failure():
     container = _make_container()
     exc = AccountSessionDecryptError(phone="+1234", status="key_mismatch")


### PR DESCRIPTION
## Summary

Closes #1172.

- Handle `asyncio.TimeoutError` separately while refreshing the notification bot snapshot.
- Log a single warning line for expected network timeouts instead of routing them through the generic `exc_info=True` handler.
- Keep the generic exception path unchanged so unexpected failures still include a traceback.
- Add a runtime worker test that asserts the timeout warning is logged and no `Traceback` appears in `caplog`.

## Validation

- `ruff check src/ tests/ conftest.py` passed.
- `pytest tests/test_runtime_worker.py -v` passed: 19 passed.
- `pytest tests/ -v -m "not aiosqlite_serial" -n auto` failed on unrelated existing/local-environment tests: `tests/test_quality_scoring_service.py::{test_score_content_uses_default_provider,test_score_and_check_with_default_provider,test_score_and_check_custom_threshold_higher,test_score_content_long_string}` and `tests/test_pipelines.py::test_pipelines_page_renders`.
- `pytest tests/ -v -m aiosqlite_serial` failed on unrelated existing/local-environment timeout: `tests/test_agent_tool_smoke_contract.py::test_deepagents_all_tools_smoke_with_minimal_contract_args`.