### PR TITLE
fix(pool): synchronize teardown lease releases

### DIFF
--- a/src/telegram/pool_lifecycle.py
+++ b/src/telegram/pool_lifecycle.py
@@ -369,8 +369,8 @@ class ClientLifecycleMixin:
         self._session_overrides.pop(phone, None)
         async with self._lock:
             leases = list(self._active_leases.pop(phone, []))
-        client = self.clients.pop(phone, None)
-        self._in_use.discard(phone)
+            client = self.clients.pop(phone, None)
+            await self._lease_pool.release(phone)
         self.reset_dialogs_warm(phone)
         self.invalidate_dialogs_cache(phone)
         self.clear_premium_flood(phone)
@@ -426,9 +426,10 @@ class ClientLifecycleMixin:
                 await asyncio.wait_for(self.remove_client(phone), timeout=5.0)
             except asyncio.TimeoutError:
                 logger.warning("Timeout disconnecting %s, forcing cleanup", phone)
-                self.clients.pop(phone, None)
-                self._in_use.discard(phone)
-                self._active_leases.pop(phone, None)
+                async with self._lock:
+                    self.clients.pop(phone, None)
+                    self._active_leases.pop(phone, None)
+                    await self._lease_pool.release(phone)
                 self.reset_dialogs_warm(phone)
             except Exception:
                 logger.debug("Error disconnecting %s", phone, exc_info=True)
@@ -534,7 +535,8 @@ class ClientLifecycleMixin:
         except Exception as exc:
             logger.error("Failed to acquire client for %s: %s", phone, exc)
             if not account_lease.shared:
-                await self._lease_pool.release(phone)
+                async with self._lock:
+                    await self._lease_pool.release(phone)
             if lease is not None and lease.disconnect_on_release:
                 try:
                     await self._backend_router.release(lease)

--- a/tests/test_client_pool_lifecycle.py
+++ b/tests/test_client_pool_lifecycle.py
@@ -8,6 +8,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from src.models import Account
+from src.telegram.account_lease_pool import AccountLease
 from src.telegram.client_pool import ClientPool
 
 
@@ -83,6 +85,18 @@ def _pool_with_in_use(in_use: set[str]) -> ClientPool:
     pool._lease_pool.release = AsyncMock()
     pool._backend_router = MagicMock()
     pool._backend_router.release = AsyncMock()
+    return pool
+
+
+def _pool_with_lifecycle_state(in_use: set[str]) -> ClientPool:
+    pool = _pool_with_in_use(in_use)
+    pool.clients = {}
+    pool._session_overrides = {}
+    pool._dialogs_fetched = set()
+    pool._dialogs_fetched_at_monotonic = {}
+    pool._dialogs_cache = {}
+    pool._premium_flood_wait_until = {}
+    pool._mtproto_watchdog = None
     return pool
 
 
@@ -186,6 +200,112 @@ async def test_release_client_no_await_window_between_pop_and_discard():
     )
     assert in_use == set()
     assert "+7" not in pool._active_leases
+
+
+@pytest.mark.anyio
+async def test_remove_client_releases_in_use_under_client_pool_lock():
+    """#1191: remove_client must release the shared _in_use marker through
+    AccountLeasePool.release while ClientPool._lock still protects the local
+    teardown state. On the old code this spy was never called because
+    remove_client did a bare _in_use.discard outside both locks."""
+    pool = _pool_with_lifecycle_state(in_use={"+7"})
+    lease = SimpleNamespace(disconnect_on_release=False)
+    pool.clients["+7"] = object()
+    pool._active_leases["+7"] = [lease]
+
+    observed: dict[str, object] = {}
+
+    async def _spy_release(phone):
+        observed["client_lock_held"] = pool._lock.locked()
+        observed["active_leases_snapshot"] = {k: list(v) for k, v in pool._active_leases.items()}
+        observed["client_present_snapshot"] = phone in pool.clients
+        observed["in_use_snapshot"] = set(pool._in_use)
+        pool._in_use.discard(phone)
+
+    pool._lease_pool.release = _spy_release
+
+    await pool.remove_client("+7")
+
+    assert observed.get("client_lock_held") is True, (
+        "remove_client did not release _in_use through AccountLeasePool.release "
+        "while holding ClientPool._lock (#1191)"
+    )
+    assert observed["active_leases_snapshot"] == {}
+    assert observed["client_present_snapshot"] is False
+    assert observed["in_use_snapshot"] == {"+7"}
+    assert "+7" not in pool.clients
+    assert "+7" not in pool._active_leases
+    assert "+7" not in pool._in_use
+
+
+@pytest.mark.anyio
+async def test_disconnect_all_timeout_releases_in_use_under_client_pool_lock():
+    """#1191: the forced timeout cleanup path must use AccountLeasePool.release
+    under ClientPool._lock, not a bare _in_use.discard."""
+    pool = _pool_with_lifecycle_state(in_use={"+7"})
+    pool.clients["+7"] = object()
+    pool._active_leases["+7"] = [SimpleNamespace(disconnect_on_release=False)]
+
+    async def _timeout_remove(phone):
+        raise asyncio.TimeoutError
+
+    pool.remove_client = _timeout_remove  # type: ignore[method-assign]
+
+    observed: dict[str, object] = {}
+
+    async def _spy_release(phone):
+        observed["client_lock_held"] = pool._lock.locked()
+        observed["active_leases_snapshot"] = {k: list(v) for k, v in pool._active_leases.items()}
+        observed["client_present_snapshot"] = phone in pool.clients
+        observed["in_use_snapshot"] = set(pool._in_use)
+        pool._in_use.discard(phone)
+
+    pool._lease_pool.release = _spy_release
+
+    await pool.disconnect_all()
+
+    assert observed.get("client_lock_held") is True, (
+        "disconnect_all timeout cleanup did not release _in_use through "
+        "AccountLeasePool.release while holding ClientPool._lock (#1191)"
+    )
+    assert observed["active_leases_snapshot"] == {}
+    assert observed["client_present_snapshot"] is False
+    assert observed["in_use_snapshot"] == {"+7"}
+    assert "+7" not in pool.clients
+    assert "+7" not in pool._active_leases
+    assert "+7" not in pool._in_use
+
+
+@pytest.mark.anyio
+async def test_acquire_from_lease_failure_releases_in_use_under_client_pool_lock():
+    """#1191: when a non-shared lease fails before becoming active, the release
+    must still happen inside ClientPool._lock. On the old code the spy saw the
+    release with ClientPool._lock free."""
+    pool = _pool_with_in_use(in_use={"+7"})
+    pool.clients = {}
+    pool._backend_router.acquire_client = AsyncMock(side_effect=RuntimeError("boom"))
+    account_lease = AccountLease(
+        account=Account(phone="+7", session_string="session", is_active=True),
+        shared=False,
+    )
+
+    observed: dict[str, object] = {}
+
+    async def _spy_release(phone):
+        observed["client_lock_held"] = pool._lock.locked()
+        observed["in_use_snapshot"] = set(pool._in_use)
+        pool._in_use.discard(phone)
+
+    pool._lease_pool.release = _spy_release
+
+    result = await pool._acquire_from_lease(account_lease)
+
+    assert result is None
+    assert observed.get("client_lock_held") is True, (
+        "_acquire_from_lease failure release did not run under ClientPool._lock (#1191)"
+    )
+    assert observed["in_use_snapshot"] == {"+7"}
+    assert "+7" not in pool._in_use
 
 
 @pytest.mark.anyio

--- a/tests/test_main_client_pool_collector_paths.py
+++ b/tests/test_main_client_pool_collector_paths.py
@@ -309,6 +309,8 @@ class TestClientPoolProperties:
         pool._session_overrides = {"+1": "s"}
         pool._lock = asyncio.Lock()
         pool._active_leases = {}
+        pool._lease_pool = MagicMock()
+        pool._lease_pool.release = AsyncMock()
         pool.clients = {"+1": MagicMock()}
         pool._in_use = {"+1"}
         pool._premium_in_use = set()
@@ -319,6 +321,7 @@ class TestClientPoolProperties:
         await pool.remove_client("+1")
         assert "+1" not in pool._session_overrides
         assert "+1" not in pool.clients
+        pool._lease_pool.release.assert_awaited_once_with("+1")
 
     @pytest.mark.anyio
     async def test_get_db_cached_dialogs_empty(self):


### PR DESCRIPTION
## Summary
- Route `remove_client` teardown cleanup through `_lease_pool.release(phone)` while holding `ClientPool._lock`.
- Route `disconnect_all` timeout force-cleanup through `_lease_pool.release(phone)` while holding `ClientPool._lock`.
- Route `_acquire_from_lease` non-shared failure cleanup through `_lease_pool.release(phone)` while holding `ClientPool._lock`.
- Add regression tests that spy on `_lease_pool.release` and assert `ClientPool._lock` is held at the release/discard point.

## Validation
- `pytest tests/test_client_pool_lifecycle.py -v` passed.
- Mutation check: temporarily restored the old teardown/release behavior; the three new #1191 regression tests failed, then passed again after restoring the fix.
- `pytest tests/test_main_client_pool_collector_paths.py::TestClientPoolProperties::test_remove_client -v` passed.
- `ruff check src/ tests/ conftest.py` passed.
- `pytest tests/ -v -m aiosqlite_serial` passed: 941 passed, 9242 deselected.
- `pytest tests/ -v -m "not aiosqlite_serial" -n auto` was run after the main fix. It exposed one local test-double update, now fixed and verified, plus unrelated provider/env failures in `tests/test_quality_scoring_service.py` and `tests/test_pipelines.py` caused by live/default provider behavior and unclosed socket warnings in this environment.

Closes #1191