### PR TITLE
fix(photo-loader): count terminal items as progress so bar reaches N/N

### DIFF
--- a/src/services/jobs_read_model.py
+++ b/src/services/jobs_read_model.py
@@ -61,6 +61,13 @@ _PHOTO_ITEM_STATE = {
     PhotoBatchStatus.FAILED: JobRuntimeState.FAILED,
     PhotoBatchStatus.CANCELLED: JobRuntimeState.CANCELLED,
 }
+# An item counts as "processed" for the progress bar once it reaches any terminal
+# state — succeeded OR failed OR cancelled — so the bar always reaches N/N (#1152).
+_PHOTO_TERMINAL_STATUSES = frozenset(
+    status
+    for status, state in _PHOTO_ITEM_STATE.items()
+    if state in {JobRuntimeState.COMPLETED, JobRuntimeState.FAILED, JobRuntimeState.CANCELLED}
+)
 
 # UTC-aware floor for jobs without a timestamp (e.g. scheduler jobs) so they sort
 # last; kept aware to match ``normalize_utc`` keys in the sort below.
@@ -143,9 +150,12 @@ class JobsReadModel:
             if batch.id is not None
             else {}
         )
+        # "Progress" means how many items reached a terminal state — not how many
+        # SUCCEEDED. Counting only COMPLETED froze the bar at e.g. 2/3 forever once
+        # any item FAILED, even though the batch was fully terminal (#1152 follow-up).
         return PhotoBatchView(
             **batch.model_dump(),
-            completed_items=counts.get(PhotoBatchStatus.COMPLETED, 0),
+            completed_items=sum(counts.get(status, 0) for status in _PHOTO_TERMINAL_STATUSES),
             total_items=sum(counts.values()),
         )
 

--- a/tests/test_jobs_read_model.py
+++ b/tests/test_jobs_read_model.py
@@ -188,6 +188,41 @@ async def test_photo_batch_read_model_counts_progress(db):
     assert batch.total_items == 3
 
 
+async def test_photo_batch_progress_counts_all_terminal_items(db):
+    """Progress counts items that reached ANY terminal state (completed/failed/
+    cancelled), so the bar reaches N/N even when some items failed — counting only
+    COMPLETED used to freeze the bar at e.g. 2/3 forever (#1152 follow-up)."""
+    batch_id = await db.repos.photo_loader.create_batch(
+        PhotoBatch(
+            phone="+1",
+            target_dialog_id=10,
+            target_title="Chan",
+            status=PhotoBatchStatus.FAILED,
+        )
+    )
+    for fname, status in (
+        ("a.jpg", PhotoBatchStatus.COMPLETED),
+        ("b.jpg", PhotoBatchStatus.FAILED),
+        ("c.jpg", PhotoBatchStatus.CANCELLED),
+    ):
+        await db.repos.photo_loader.create_item(
+            PhotoBatchItem(
+                batch_id=batch_id,
+                phone="+1",
+                target_dialog_id=10,
+                file_paths=[fname],
+                status=status,
+            )
+        )
+
+    batch = await JobsReadModel(db).get_photo_batch(batch_id)
+
+    assert batch is not None
+    # all three are terminal → bar reaches N/N, not stuck at 1/3
+    assert batch.completed_items == 3
+    assert batch.total_items == 3
+
+
 async def test_list_jobs_filters_by_source_and_state(db):
     await db.repos.tasks.create_collection_task(100, "Chan")  # pending collection task
 


### PR DESCRIPTION
## What

Follow-up to #1152. The batch progress counter in `JobsReadModel._from_photo_batch` counted only `COMPLETED` items, so a batch with any `FAILED`/`CANCELLED` item froze at e.g. `2/3` forever — the batch was fully terminal but the counter implied work was still in flight.

## Fix

`completed_items` now counts every item in a **terminal** state (completed / failed / cancelled), so the bar always reaches `N/N`. The terminal set `_PHOTO_TERMINAL_STATUSES` is derived from the existing `_PHOTO_ITEM_STATE` map (single source of truth — stays in sync if statuses change). `total_items` is unchanged (all items).

"Progress" = how many items finished, not how many succeeded — matches the "completeness bar" intent. Per-item success/failure remains visible via the batch status itself.

## Tests

New regression test `test_photo_batch_progress_counts_all_terminal_items` — a batch of completed+failed+cancelled reports `completed_items == total_items == 3`. **Mutation-verified**: reverting the prod change to `counts.get(COMPLETED, 0)` makes the test fail (`1 != 3`). Existing `test_photo_batch_read_model_counts_progress` (completed+running+pending → 1/3) stays valid. `ruff` clean; 73 passed locally.

Closes #1152

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TShpckA1DoLNezbD3txTL1