### PR TITLE
refactor: split rank-E report and snapshot helpers

### DIFF
--- a/scripts/verify_refactor_ast_equivalence.py
+++ b/scripts/verify_refactor_ast_equivalence.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""AST guard for the #1131 batch-1 complexity refactor.
+
+The script compares the original rank-E functions from a git base ref with the
+current extracted helper composition. It intentionally checks AST shapes, not
+runtime output, so it can catch accidental rewrites in refactor-only changes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import copy
+import difflib
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class AstMismatch(AssertionError):
+    pass
+
+
+class ReplaceLoads(ast.NodeTransformer):
+    def __init__(self, replacements: dict[str, ast.expr]) -> None:
+        self._replacements = replacements
+
+    def visit_Name(self, node: ast.Name) -> ast.AST:
+        if isinstance(node.ctx, ast.Load) and node.id in self._replacements:
+            replacement = copy.deepcopy(self._replacements[node.id])
+            return ast.copy_location(replacement, node)
+        return node
+
+
+def _parse_expr(source: str) -> ast.expr:
+    return ast.parse(source, mode="eval").body
+
+
+def _base_source(base_ref: str, path: str) -> str:
+    return subprocess.check_output(["git", "show", f"{base_ref}:{path}"], cwd=ROOT, text=True)
+
+
+def _current_source(path: str) -> str:
+    return (ROOT / path).read_text()
+
+
+def _tree(source: str) -> ast.Module:
+    return ast.parse(source)
+
+
+def _function(tree: ast.AST, name: str, *, class_name: str | None = None) -> ast.FunctionDef | ast.AsyncFunctionDef:
+    scope = tree
+    if class_name is not None:
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef) and node.name == class_name:
+                scope = node
+                break
+        else:
+            raise AstMismatch(f"class {class_name!r} not found")
+
+    for node in ast.iter_child_nodes(scope):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            return node
+    raise AstMismatch(f"function {name!r} not found")
+
+
+def _dump(node: ast.AST | list[ast.stmt]) -> str:
+    if isinstance(node, list):
+        node = ast.Module(body=node, type_ignores=[])
+    ast.fix_missing_locations(node)
+    return ast.dump(node, include_attributes=False, indent=2)
+
+
+def _unparse(node: ast.AST | list[ast.stmt]) -> str:
+    if isinstance(node, list):
+        node = ast.Module(body=node, type_ignores=[])
+    ast.fix_missing_locations(node)
+    return ast.unparse(node)
+
+
+def _assert_same(label: str, left: ast.AST | list[ast.stmt], right: ast.AST | list[ast.stmt]) -> None:
+    left_dump = _dump(left)
+    right_dump = _dump(right)
+    if left_dump == right_dump:
+        print(f"OK {label}")
+        return
+    diff = "\n".join(
+        difflib.unified_diff(
+            _unparse(left).splitlines(),
+            _unparse(right).splitlines(),
+            fromfile=f"{label}: expected",
+            tofile=f"{label}: actual",
+            lineterm="",
+        )
+    )
+    raise AstMismatch(f"{label} AST mismatch\n{diff}")
+
+
+def _clone_statements(statements: list[ast.stmt]) -> list[ast.stmt]:
+    return copy.deepcopy(statements)
+
+
+def _body_without_return(func: ast.FunctionDef | ast.AsyncFunctionDef) -> list[ast.stmt]:
+    body = _clone_statements(func.body)
+    if body and isinstance(body[-1], ast.Return):
+        return body[:-1]
+    return body
+
+
+def _replace_loads_in_statements(statements: list[ast.stmt], replacements: dict[str, ast.expr]) -> list[ast.stmt]:
+    cloned = _clone_statements(statements)
+    return [ReplaceLoads(replacements).visit(stmt) for stmt in cloned]  # type: ignore[list-item]
+
+
+def _return_to_assign(
+    func: ast.FunctionDef | ast.AsyncFunctionDef,
+    target: str,
+    replacements: dict[str, ast.expr] | None = None,
+) -> list[ast.stmt]:
+    statements = _clone_statements(func.body)
+    converted: list[ast.stmt] = []
+    for stmt in statements:
+        if isinstance(stmt, ast.Return):
+            converted.append(ast.Assign(targets=[ast.Name(id=target, ctx=ast.Store())], value=stmt.value))
+        else:
+            converted.append(stmt)
+    if replacements:
+        converted = [ReplaceLoads(replacements).visit(stmt) for stmt in converted]  # type: ignore[list-item]
+    return converted
+
+
+def _return_value(func: ast.FunctionDef | ast.AsyncFunctionDef) -> ast.expr:
+    final = func.body[-1]
+    if not isinstance(final, ast.Return) or final.value is None:
+        raise AstMismatch(f"{func.name} does not end with a value return")
+    return copy.deepcopy(final.value)
+
+
+def _runtime_snapshot_payload(stmt: ast.stmt) -> ast.expr:
+    if not isinstance(stmt, ast.Expr) or not isinstance(stmt.value, ast.Await):
+        raise AstMismatch("expected awaited upsert_snapshot expression")
+    call = stmt.value.value
+    if not isinstance(call, ast.Call) or not call.args:
+        raise AstMismatch("expected upsert_snapshot call")
+    snapshot = call.args[0]
+    if not isinstance(snapshot, ast.Call):
+        raise AstMismatch("expected RuntimeSnapshot call")
+    for keyword in snapshot.keywords:
+        if keyword.arg == "payload":
+            return copy.deepcopy(keyword.value)
+    raise AstMismatch("RuntimeSnapshot payload keyword not found")
+
+
+def _runtime_snapshot_type(stmt: ast.stmt) -> str:
+    if not isinstance(stmt, ast.Expr) or not isinstance(stmt.value, ast.Await):
+        raise AstMismatch("expected awaited upsert_snapshot expression")
+    call = stmt.value.value
+    if not isinstance(call, ast.Call) or not call.args:
+        raise AstMismatch("expected upsert_snapshot call")
+    snapshot = call.args[0]
+    if not isinstance(snapshot, ast.Call):
+        raise AstMismatch("expected RuntimeSnapshot call")
+    for keyword in snapshot.keywords:
+        if keyword.arg == "snapshot_type" and isinstance(keyword.value, ast.Constant):
+            return str(keyword.value.value)
+    raise AstMismatch("RuntimeSnapshot snapshot_type keyword not found")
+
+
+def _append_call_arg(stmt: ast.stmt) -> ast.expr:
+    if not isinstance(stmt, ast.Expr) or not isinstance(stmt.value, ast.Call):
+        raise AstMismatch("expected append expression")
+    call = stmt.value
+    if not call.args:
+        raise AstMismatch("expected append call argument")
+    return copy.deepcopy(call.args[0])
+
+
+def _assert_current_calls(label: str, func: ast.FunctionDef | ast.AsyncFunctionDef, expected: list[str]) -> None:
+    found: list[str] = []
+    for stmt in func.body:
+        expr: ast.AST | None = None
+        if isinstance(stmt, ast.Expr):
+            expr = stmt.value.value if isinstance(stmt.value, ast.Await) else stmt.value
+        elif isinstance(stmt, ast.Assign):
+            expr = stmt.value.value if isinstance(stmt.value, ast.Await) else stmt.value
+        elif isinstance(stmt, ast.Return):
+            expr = stmt.value.value if isinstance(stmt.value, ast.Await) else stmt.value
+        if isinstance(expr, ast.Call):
+            called = expr.func
+            if isinstance(called, ast.Name) and called.id.startswith("_"):
+                found.append(called.id)
+            elif isinstance(called, ast.Attribute) and called.attr.startswith("_"):
+                found.append(called.attr)
+    if found != expected:
+        raise AstMismatch(f"{label} helper call order changed: expected {expected}, got {found}")
+    print(f"OK {label} helper call order")
+
+
+def verify_worker(base_ref: str) -> None:
+    base = _function(_tree(_base_source(base_ref, "src/runtime/worker.py")), "_publish_snapshots")
+    current_tree = _tree(_current_source("src/runtime/worker.py"))
+    current = _function(current_tree, "_publish_snapshots")
+    _assert_current_calls(
+        "worker _publish_snapshots",
+        current,
+        [
+            "_load_active_accounts",
+            "_resolve_available_phones",
+            "_resolve_pool_warming",
+            "_resolve_backoffs",
+            "_publish_worker_heartbeat_snapshot",
+            "_publish_accounts_status_snapshot",
+            "_publish_pool_counters_snapshot",
+            "_publish_collector_status_snapshot",
+            "_publish_scheduler_status_snapshot",
+            "_publish_scheduler_jobs_snapshot",
+            "_publish_collection_queue_status_snapshot",
+            "_publish_notification_target_status_snapshot",
+        ],
+    )
+
+    _assert_same("worker kept setup", base.body[0:2], current.body[0:2])
+    _assert_same("worker accounts load", base.body[2:4], _body_without_return(_function(current_tree, "_load_active_accounts")))
+    _assert_same(
+        "worker available phones",
+        base.body[4:7],
+        _body_without_return(_function(current_tree, "_resolve_available_phones")),
+    )
+    _assert_same(
+        "worker pool warming",
+        base.body[7:11],
+        _return_to_assign(
+            _function(current_tree, "_resolve_pool_warming"),
+            "is_warming",
+            {"pool": _parse_expr("container.pool")},
+        ),
+    )
+    _assert_same(
+        "worker resolve backoffs",
+        base.body[11:14],
+        _replace_loads_in_statements(
+            _body_without_return(_function(current_tree, "_resolve_backoffs")),
+            {"pool": _parse_expr("container.pool")},
+        ),
+    )
+    _assert_same("worker heartbeat snapshot", [base.body[14]], _function(current_tree, "_publish_worker_heartbeat_snapshot").body)
+    _assert_same("worker accounts snapshot", [base.body[15]], _function(current_tree, "_publish_accounts_status_snapshot").body)
+
+    pool_payload_func = _function(current_tree, "_pool_counters_payload")
+    _assert_same("worker pool counter locals", base.body[17:21], pool_payload_func.body[:-1])
+    _assert_same("worker pool counter payload", _runtime_snapshot_payload(base.body[21]), _return_value(pool_payload_func))
+    _assert_same("worker collector snapshot", [base.body[22]], _function(current_tree, "_publish_collector_status_snapshot").body)
+    _assert_same("worker scheduler status snapshot", [base.body[23]], _function(current_tree, "_publish_scheduler_status_snapshot").body)
+    _assert_same("worker scheduler jobs snapshot", base.body[24:27], _function(current_tree, "_publish_scheduler_jobs_snapshot").body)
+
+    queue_payload_func = _function(current_tree, "_collection_queue_status_payload")
+    _assert_same("worker queue locals", base.body[27:31], queue_payload_func.body[:-1])
+    _assert_same("worker queue payload", _runtime_snapshot_payload(base.body[31]), _return_value(queue_payload_func))
+
+    notification_payload_func = _function(current_tree, "_notification_target_status_payload")
+    _assert_same("worker notification locals", base.body[32:35], notification_payload_func.body[:-1])
+    _assert_same("worker notification payload", _runtime_snapshot_payload(base.body[35]), _return_value(notification_payload_func))
+
+    notification_snapshot = _function(current_tree, "_publish_notification_target_status_snapshot").body[0]
+    if _runtime_snapshot_type(notification_snapshot) != "notification_target_status":
+        raise AstMismatch("worker notification snapshot_type changed")
+    print("OK worker notification snapshot_type")
+
+
+def verify_analyzer(base_ref: str) -> None:
+    base = _function(_tree(_base_source(base_ref, "src/filters/analyzer.py")), "_build_report", class_name="ChannelAnalyzer")
+    current_tree = _tree(_current_source("src/filters/analyzer.py"))
+    current = _function(current_tree, "_build_report", class_name="ChannelAnalyzer")
+    _assert_current_calls(
+        "analyzer _build_report",
+        current,
+        [
+            "_fetch_channels_for_report",
+            "_fetch_analysis_maps",
+            "_load_min_subscribers_filter",
+            "_build_channel_results",
+            "_filter_report_from_results",
+        ],
+    )
+
+    class_name = "ChannelAnalyzer"
+    _assert_same("analyzer timer setup", [base.body[0]], [current.body[0]])
+    _assert_same(
+        "analyzer channel fetch",
+        base.body[1:3],
+        _replace_loads_in_statements(
+            _body_without_return(_function(current_tree, "_fetch_channels_for_report", class_name=class_name)),
+            {"started_at": _parse_expr("t0")},
+        ),
+    )
+    _assert_same("analyzer empty report branch", [base.body[3]], [current.body[2]])
+    _assert_same(
+        "analyzer map fetch",
+        [base.body[4]],
+        _body_without_return(_function(current_tree, "_fetch_analysis_maps", class_name=class_name)),
+    )
+    _assert_same("analyzer min subscribers", [base.body[5]], [current.body[4]])
+
+    original_loop = base.body[7]
+    if not isinstance(original_loop, ast.For):
+        raise AstMismatch("expected original analyzer result loop")
+    loop_body = original_loop.body
+    result_func = _function(current_tree, "_build_channel_result", class_name=class_name)
+    _assert_same("analyzer result locals", loop_body[0:3], result_func.body[0:3])
+    _assert_same(
+        "analyzer uniqueness block",
+        loop_body[3:7],
+        _body_without_return(_function(current_tree, "_append_uniqueness_flag", class_name=class_name)),
+    )
+    _assert_same("analyzer subscriber count lookup", [loop_body[9]], [result_func.body[4]])
+    _assert_same(
+        "analyzer subscriber block",
+        loop_body[7:9] + loop_body[10:14],
+        _body_without_return(_function(current_tree, "_append_subscriber_flags", class_name=class_name)),
+    )
+    _assert_same(
+        "analyzer cross-dupe block",
+        loop_body[14:18],
+        _body_without_return(_function(current_tree, "_append_cross_dupe_flag", class_name=class_name)),
+    )
+    _assert_same(
+        "analyzer cyrillic block",
+        loop_body[18:22],
+        _body_without_return(_function(current_tree, "_append_cyrillic_flag", class_name=class_name)),
+    )
+    _assert_same(
+        "analyzer chat-noise block",
+        loop_body[22:27],
+        _body_without_return(_function(current_tree, "_append_chat_noise_flag", class_name=class_name)),
+    )
+    _assert_same(
+        "analyzer suspicious username block",
+        loop_body[27:29],
+        _function(current_tree, "_append_suspicious_username_flag", class_name=class_name).body,
+    )
+    _assert_same("analyzer result constructor", _append_call_arg(loop_body[29]), _return_value(result_func))
+    _assert_same(
+        "analyzer final report",
+        base.body[8:11],
+        _replace_loads_in_statements(
+            _function(current_tree, "_filter_report_from_results", class_name=class_name).body,
+            {"started_at": _parse_expr("t0")},
+        ),
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-ref", default="origin/main")
+    args = parser.parse_args()
+
+    verify_worker(args.base_ref)
+    verify_analyzer(args.base_ref)
+    print("AST equivalence checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except AstMismatch as exc:
+        print(exc, file=sys.stderr)
+        raise SystemExit(1)

--- a/src/filters/analyzer.py
+++ b/src/filters/analyzer.py
@@ -49,19 +49,18 @@ class ChannelAnalyzer:
             logger=logger,
         )
 
-    async def _build_report(
+    async def _fetch_channels_for_report(self, channel_id: int | None, started_at: float) -> list:
+        channels = await self._repo.fetch_channels_for_analysis(channel_id)
+        logger.info("filter/analyze: fetched %d channels in %.1fs", len(channels), time.monotonic() - started_at)
+        return channels
+
+    async def _fetch_analysis_maps(
         self,
         channel_id: int | None = None,
         *,
         skip_cross_dupe: bool = False,
         sample_size: int | None = None,
-    ) -> FilterReport:
-        t0 = time.monotonic()
-        channels = await self._repo.fetch_channels_for_analysis(channel_id)
-        logger.info("filter/analyze: fetched %d channels in %.1fs", len(channels), time.monotonic() - t0)
-        if not channels:
-            return FilterReport()
-
+    ) -> tuple:
         if self._repo._can_parallel():
             logger.info(
                 "filter/analyze: all maps — started (parallel%s)",
@@ -94,113 +93,202 @@ class ChannelAnalyzer:
             cyrillic_map = await _timed_fetch(
                 "cyrillic map", self._repo.fetch_cyrillic_map(channel_id, sample_size=sample_size)
             )
+        return uniqueness_map, subscriber_map, short_map, cross_dupe_map, cyrillic_map
 
-        min_subs = await self._load_min_subscribers_filter()
+    def _append_uniqueness_flag(self, flags: list[str], channel_id_value: int, uniqueness_map: dict) -> float | None:
+        uniqueness_pct: float | None = None
+        low_uniqueness = False
+        if channel_id_value in uniqueness_map:
+            total, uniq = uniqueness_map[channel_id_value]
+            if total > 0:
+                raw_uniqueness = uniq / total * 100
+                uniqueness_pct = round(raw_uniqueness, 1)
+                low_uniqueness = raw_uniqueness < LOW_UNIQUENESS_THRESHOLD
+        if low_uniqueness:
+            flags.append("low_uniqueness")
+        return uniqueness_pct
 
-        results: list[ChannelFilterResult] = []
-        for channel in channels:
-            channel_id_value = channel["channel_id"]
-            message_count = int(channel["message_count"] or 0)
-            flags: list[str] = []
-
-            uniqueness_pct: float | None = None
-            low_uniqueness = False
-            if channel_id_value in uniqueness_map:
-                total, uniq = uniqueness_map[channel_id_value]
-                if total > 0:
-                    raw_uniqueness = uniq / total * 100
-                    uniqueness_pct = round(raw_uniqueness, 1)
-                    low_uniqueness = raw_uniqueness < LOW_UNIQUENESS_THRESHOLD
-            if low_uniqueness:
-                flags.append("low_uniqueness")
-
-            subscriber_ratio: float | None = None
-            low_subscriber = False
-            subscriber_count = subscriber_map.get(channel_id_value)
-            if subscriber_count is not None and message_count > 0:
-                raw_ratio = subscriber_count / message_count
-                subscriber_ratio = round(raw_ratio, 2)
-                is_broadcast = channel["channel_type"] in BROADCAST_CHANNEL_TYPES
-                threshold = (
-                    LOW_SUBSCRIBER_RATIO_THRESHOLD
-                    if is_broadcast
-                    else LOW_SUBSCRIBER_RATIO_CHAT_THRESHOLD
-                )
-                low_subscriber = raw_ratio < threshold
-            manual_subs_flagged = False
-            if min_subs > 0 and subscriber_count is not None and subscriber_count < min_subs:
-                flags.append("low_subscriber_manual")
-                manual_subs_flagged = True
-
-            if low_subscriber and not manual_subs_flagged:
-                flags.append("low_subscriber_ratio")
-
-            cross_dupe_pct: float | None = None
-            cross_dupe = False
-            if channel_id_value in cross_dupe_map:
-                uniq_total, duped = cross_dupe_map[channel_id_value]
-                if uniq_total > 0:
-                    raw_cross_pct = duped / uniq_total * 100
-                    cross_dupe_pct = round(raw_cross_pct, 1)
-                    cross_dupe = raw_cross_pct > CROSS_DUPE_THRESHOLD
-            if cross_dupe:
-                flags.append("cross_channel_spam")
-
-            cyrillic_pct: float | None = None
-            non_cyrillic = False
-            if channel_id_value in cyrillic_map:
-                cyr_total, cyr_count = cyrillic_map[channel_id_value]
-                if cyr_total > 0:
-                    raw_cyr_pct = cyr_count / cyr_total * 100
-                    cyrillic_pct = round(raw_cyr_pct, 1)
-                    non_cyrillic = raw_cyr_pct < NON_CYRILLIC_THRESHOLD
-            if non_cyrillic:
-                flags.append("non_cyrillic")
-
-            short_msg_pct: float | None = None
-            noisy_chat = False
-            is_chat = channel["channel_type"] in CHAT_CHANNEL_TYPES
-            if is_chat and channel_id_value in short_map:
-                short_total, short_count = short_map[channel_id_value]
-                if short_total > 0:
-                    raw_short_pct = short_count / short_total * 100
-                    short_msg_pct = round(raw_short_pct, 1)
-                    noisy_chat = raw_short_pct > CHAT_NOISE_THRESHOLD
-            if noisy_chat:
-                flags.append("chat_noise")
-
-            raw_username = channel["username"]
-            if raw_username and SUSPICIOUS_USERNAME_RE.match(raw_username):
-                flags.append("suspicious_username")
-
-            results.append(
-                ChannelFilterResult(
-                    channel_id=channel_id_value,
-                    title=channel["title"],
-                    username=channel["username"],
-                    message_count=message_count,
-                    flags=flags,
-                    uniqueness_pct=uniqueness_pct,
-                    subscriber_ratio=subscriber_ratio,
-                    cyrillic_pct=cyrillic_pct,
-                    short_msg_pct=short_msg_pct,
-                    cross_dupe_pct=cross_dupe_pct,
-                    is_filtered=bool(flags),
-                )
+    def _append_subscriber_flags(
+        self,
+        flags: list[str],
+        channel,
+        message_count: int,
+        subscriber_count: int | None,
+        min_subs: int,
+    ) -> float | None:
+        subscriber_ratio: float | None = None
+        low_subscriber = False
+        if subscriber_count is not None and message_count > 0:
+            raw_ratio = subscriber_count / message_count
+            subscriber_ratio = round(raw_ratio, 2)
+            is_broadcast = channel["channel_type"] in BROADCAST_CHANNEL_TYPES
+            threshold = (
+                LOW_SUBSCRIBER_RATIO_THRESHOLD
+                if is_broadcast
+                else LOW_SUBSCRIBER_RATIO_CHAT_THRESHOLD
             )
+            low_subscriber = raw_ratio < threshold
+        manual_subs_flagged = False
+        if min_subs > 0 and subscriber_count is not None and subscriber_count < min_subs:
+            flags.append("low_subscriber_manual")
+            manual_subs_flagged = True
 
+        if low_subscriber and not manual_subs_flagged:
+            flags.append("low_subscriber_ratio")
+        return subscriber_ratio
+
+    def _append_cross_dupe_flag(self, flags: list[str], channel_id_value: int, cross_dupe_map: dict) -> float | None:
+        cross_dupe_pct: float | None = None
+        cross_dupe = False
+        if channel_id_value in cross_dupe_map:
+            uniq_total, duped = cross_dupe_map[channel_id_value]
+            if uniq_total > 0:
+                raw_cross_pct = duped / uniq_total * 100
+                cross_dupe_pct = round(raw_cross_pct, 1)
+                cross_dupe = raw_cross_pct > CROSS_DUPE_THRESHOLD
+        if cross_dupe:
+            flags.append("cross_channel_spam")
+        return cross_dupe_pct
+
+    def _append_cyrillic_flag(self, flags: list[str], channel_id_value: int, cyrillic_map: dict) -> float | None:
+        cyrillic_pct: float | None = None
+        non_cyrillic = False
+        if channel_id_value in cyrillic_map:
+            cyr_total, cyr_count = cyrillic_map[channel_id_value]
+            if cyr_total > 0:
+                raw_cyr_pct = cyr_count / cyr_total * 100
+                cyrillic_pct = round(raw_cyr_pct, 1)
+                non_cyrillic = raw_cyr_pct < NON_CYRILLIC_THRESHOLD
+        if non_cyrillic:
+            flags.append("non_cyrillic")
+        return cyrillic_pct
+
+    def _append_chat_noise_flag(
+        self,
+        flags: list[str],
+        channel,
+        channel_id_value: int,
+        short_map: dict,
+    ) -> float | None:
+        short_msg_pct: float | None = None
+        noisy_chat = False
+        is_chat = channel["channel_type"] in CHAT_CHANNEL_TYPES
+        if is_chat and channel_id_value in short_map:
+            short_total, short_count = short_map[channel_id_value]
+            if short_total > 0:
+                raw_short_pct = short_count / short_total * 100
+                short_msg_pct = round(raw_short_pct, 1)
+                noisy_chat = raw_short_pct > CHAT_NOISE_THRESHOLD
+        if noisy_chat:
+            flags.append("chat_noise")
+        return short_msg_pct
+
+    def _append_suspicious_username_flag(self, flags: list[str], channel) -> None:
+        raw_username = channel["username"]
+        if raw_username and SUSPICIOUS_USERNAME_RE.match(raw_username):
+            flags.append("suspicious_username")
+
+    def _build_channel_result(
+        self,
+        channel,
+        *,
+        uniqueness_map: dict,
+        subscriber_map: dict,
+        short_map: dict,
+        cross_dupe_map: dict,
+        cyrillic_map: dict,
+        min_subs: int,
+    ) -> ChannelFilterResult:
+        channel_id_value = channel["channel_id"]
+        message_count = int(channel["message_count"] or 0)
+        flags: list[str] = []
+
+        uniqueness_pct = self._append_uniqueness_flag(flags, channel_id_value, uniqueness_map)
+        subscriber_count = subscriber_map.get(channel_id_value)
+        subscriber_ratio = self._append_subscriber_flags(flags, channel, message_count, subscriber_count, min_subs)
+        cross_dupe_pct = self._append_cross_dupe_flag(flags, channel_id_value, cross_dupe_map)
+        cyrillic_pct = self._append_cyrillic_flag(flags, channel_id_value, cyrillic_map)
+        short_msg_pct = self._append_chat_noise_flag(flags, channel, channel_id_value, short_map)
+        self._append_suspicious_username_flag(flags, channel)
+
+        return ChannelFilterResult(
+            channel_id=channel_id_value,
+            title=channel["title"],
+            username=channel["username"],
+            message_count=message_count,
+            flags=flags,
+            uniqueness_pct=uniqueness_pct,
+            subscriber_ratio=subscriber_ratio,
+            cyrillic_pct=cyrillic_pct,
+            short_msg_pct=short_msg_pct,
+            cross_dupe_pct=cross_dupe_pct,
+            is_filtered=bool(flags),
+        )
+
+    def _build_channel_results(
+        self,
+        channels: list,
+        *,
+        uniqueness_map: dict,
+        subscriber_map: dict,
+        short_map: dict,
+        cross_dupe_map: dict,
+        cyrillic_map: dict,
+        min_subs: int,
+    ) -> list[ChannelFilterResult]:
+        return [
+            self._build_channel_result(
+                channel,
+                uniqueness_map=uniqueness_map,
+                subscriber_map=subscriber_map,
+                short_map=short_map,
+                cross_dupe_map=cross_dupe_map,
+                cyrillic_map=cyrillic_map,
+                min_subs=min_subs,
+            )
+            for channel in channels
+        ]
+
+    def _filter_report_from_results(self, results: list[ChannelFilterResult], started_at: float) -> FilterReport:
         filtered_count = sum(1 for result in results if result.is_filtered)
         logger.info(
             "filter/analyze: report complete — %d channels, %d filtered in %.1fs",
             len(results),
             filtered_count,
-            time.monotonic() - t0,
+            time.monotonic() - started_at,
         )
         return FilterReport(
             results=results,
             total_channels=len(results),
             filtered_count=filtered_count,
         )
+
+    async def _build_report(
+        self,
+        channel_id: int | None = None,
+        *,
+        skip_cross_dupe: bool = False,
+        sample_size: int | None = None,
+    ) -> FilterReport:
+        t0 = time.monotonic()
+        channels = await self._fetch_channels_for_report(channel_id, t0)
+        if not channels:
+            return FilterReport()
+
+        uniqueness_map, subscriber_map, short_map, cross_dupe_map, cyrillic_map = await self._fetch_analysis_maps(
+            channel_id, skip_cross_dupe=skip_cross_dupe, sample_size=sample_size
+        )
+        min_subs = await self._load_min_subscribers_filter()
+        results = self._build_channel_results(
+            channels,
+            uniqueness_map=uniqueness_map,
+            subscriber_map=subscriber_map,
+            short_map=short_map,
+            cross_dupe_map=cross_dupe_map,
+            cyrillic_map=cyrillic_map,
+            min_subs=min_subs,
+        )
+        return self._filter_report_from_results(results, t0)
 
     async def analyze_channel(self, channel_id: int) -> ChannelFilterResult:
         report = await self._build_report(channel_id=channel_id)

--- a/src/runtime/worker.py
+++ b/src/runtime/worker.py
@@ -52,9 +52,7 @@ async def _publish_worker_down_snapshot(container, exc: AccountSessionDecryptErr
     )
 
 
-async def _publish_snapshots(container, *, stop_event: asyncio.Event | None = None) -> None:
-    now = datetime.now(timezone.utc)
-    connected_phones = sorted(getattr(container.pool, "clients", {}).keys())
+async def _load_active_accounts(container) -> list:
     active_accounts = []
     for getter_name in ("get_account_summaries", "get_accounts"):
         getter = getattr(container.db, getter_name, None)
@@ -69,6 +67,10 @@ async def _publish_snapshots(container, *, stop_event: asyncio.Event | None = No
                 break
         except Exception:
             logger.debug("Failed to load accounts while publishing account status snapshot", exc_info=True)
+    return active_accounts
+
+
+def _resolve_available_phones(active_accounts: list, connected_phones: list[str], now: datetime) -> tuple[dict, list]:
     flood_waits = {}
     available_phones = []
     if active_accounts:
@@ -85,16 +87,23 @@ async def _publish_snapshots(container, *, stop_event: asyncio.Event | None = No
                 available_phones.append(phone)
     else:
         available_phones = list(connected_phones)
+    return flood_waits, available_phones
+
+
+def _resolve_pool_warming(pool) -> bool:
     is_warming_method = None
-    pool_attrs = getattr(container.pool, "__dict__", {})
+    pool_attrs = getattr(pool, "__dict__", {})
     if isinstance(pool_attrs, dict) and "is_warming" in pool_attrs:
         is_warming_method = pool_attrs["is_warming"]
-    elif callable(getattr(type(container.pool), "is_warming", None)):
-        is_warming_method = getattr(container.pool, "is_warming")
-    is_warming = bool(is_warming_method()) if callable(is_warming_method) else False
+    elif callable(getattr(type(pool), "is_warming", None)):
+        is_warming_method = getattr(pool, "is_warming")
+    return bool(is_warming_method()) if callable(is_warming_method) else False
+
+
+def _resolve_backoffs(pool, connected_phones: list[str]) -> dict[str, str]:
     # Per-phone live-resolve backoff deadlines (#790) — surfaced for web parity.
     resolve_backoffs: dict[str, str] = {}
-    get_backoff_until = getattr(container.pool, "get_resolve_username_backoff_until", None)
+    get_backoff_until = getattr(pool, "get_resolve_username_backoff_until", None)
     if callable(get_backoff_until):
         for phone in connected_phones:
             try:
@@ -103,12 +112,28 @@ async def _publish_snapshots(container, *, stop_event: asyncio.Event | None = No
                 break
             if isinstance(until, datetime):
                 resolve_backoffs[phone] = until.isoformat()
+    return resolve_backoffs
+
+
+async def _publish_worker_heartbeat_snapshot(container, now: datetime) -> None:
     await container.db.repos.runtime_snapshots.upsert_snapshot(
         RuntimeSnapshot(
             snapshot_type="worker_heartbeat",
             payload={"status": "alive", "timestamp": now.isoformat()},
         )
     )
+
+
+async def _publish_accounts_status_snapshot(
+    container,
+    *,
+    connected_phones: list[str],
+    available_phones: list,
+    flood_waits: dict,
+    resolve_backoffs: dict[str, str],
+    is_warming: bool,
+    now: datetime,
+) -> None:
     await container.db.repos.runtime_snapshots.upsert_snapshot(
         RuntimeSnapshot(
             snapshot_type="accounts_status",
@@ -123,36 +148,45 @@ async def _publish_snapshots(container, *, stop_event: asyncio.Event | None = No
             },
         )
     )
-    pool = container.pool
+
+
+def _pool_counters_payload(pool) -> dict:
     dialogs_cache = getattr(pool, "_dialogs_cache", {})
     active_leases = getattr(pool, "_active_leases", {})
     premium_flood_waits = getattr(pool, "_premium_flood_wait_until", {})
     session_overrides = getattr(pool, "_session_overrides", {})
+    return {
+        "dialogs_cache_entries": (
+            len(dialogs_cache) if hasattr(dialogs_cache, "__len__") else 0
+        ),
+        "active_leases": (
+            {k: len(v) for k, v in active_leases.items()}
+            if isinstance(active_leases, dict)
+            else {}
+        ),
+        "premium_flood_waits": (
+            len(premium_flood_waits)
+            if hasattr(premium_flood_waits, "__len__")
+            else 0
+        ),
+        "session_overrides": (
+            len(session_overrides)
+            if hasattr(session_overrides, "__len__")
+            else 0
+        ),
+    }
+
+
+async def _publish_pool_counters_snapshot(container) -> None:
     await container.db.repos.runtime_snapshots.upsert_snapshot(
         RuntimeSnapshot(
             snapshot_type="pool_counters",
-            payload={
-                "dialogs_cache_entries": (
-                    len(dialogs_cache) if hasattr(dialogs_cache, "__len__") else 0
-                ),
-                "active_leases": (
-                    {k: len(v) for k, v in active_leases.items()}
-                    if isinstance(active_leases, dict)
-                    else {}
-                ),
-                "premium_flood_waits": (
-                    len(premium_flood_waits)
-                    if hasattr(premium_flood_waits, "__len__")
-                    else 0
-                ),
-                "session_overrides": (
-                    len(session_overrides)
-                    if hasattr(session_overrides, "__len__")
-                    else 0
-                ),
-            },
+            payload=_pool_counters_payload(container.pool),
         )
     )
+
+
+async def _publish_collector_status_snapshot(container, connected_phones: list[str]) -> None:
     await container.db.repos.runtime_snapshots.upsert_snapshot(
         RuntimeSnapshot(
             snapshot_type="collector_status",
@@ -164,6 +198,9 @@ async def _publish_snapshots(container, *, stop_event: asyncio.Event | None = No
             },
         )
     )
+
+
+async def _publish_scheduler_status_snapshot(container) -> None:
     await container.db.repos.runtime_snapshots.upsert_snapshot(
         RuntimeSnapshot(
             snapshot_type="scheduler_status",
@@ -173,12 +210,18 @@ async def _publish_snapshots(container, *, stop_event: asyncio.Event | None = No
             },
         )
     )
+
+
+async def _publish_scheduler_jobs_snapshot(container) -> None:
     jobs = []
     if hasattr(container.scheduler, "get_potential_jobs"):
         jobs = await container.scheduler.get_potential_jobs()
     await container.db.repos.runtime_snapshots.upsert_snapshot(
         RuntimeSnapshot(snapshot_type="scheduler_jobs", payload={"jobs": jobs})
     )
+
+
+def _collection_queue_status_payload(container, now: datetime) -> dict:
     queue = getattr(container, "collection_queue", None)
     active_task_ids = list(getattr(queue, "_active_task_ids", {}).keys()) if queue is not None else []
     target_worker_count = 0
@@ -186,19 +229,26 @@ async def _publish_snapshots(container, *, stop_event: asyncio.Event | None = No
         getter = getattr(queue, "_target_worker_count", None)
         if callable(getter):
             target_worker_count = getter()
+    return {
+        "paused": bool(getattr(queue, "is_paused", False)) if queue is not None else False,
+        "current_task_id": active_task_ids[0] if active_task_ids else None,
+        "active_task_ids": active_task_ids,
+        "running_count": len(active_task_ids),
+        "target_worker_count": target_worker_count,
+        "timestamp": now.isoformat(),
+    }
+
+
+async def _publish_collection_queue_status_snapshot(container, now: datetime) -> None:
     await container.db.repos.runtime_snapshots.upsert_snapshot(
         RuntimeSnapshot(
             snapshot_type="collection_queue_status",
-            payload={
-                "paused": bool(getattr(queue, "is_paused", False)) if queue is not None else False,
-                "current_task_id": active_task_ids[0] if active_task_ids else None,
-                "active_task_ids": active_task_ids,
-                "running_count": len(active_task_ids),
-                "target_worker_count": target_worker_count,
-                "timestamp": now.isoformat(),
-            },
+            payload=_collection_queue_status_payload(container, now),
         )
     )
+
+
+async def _notification_target_status_payload(container, stop_event: asyncio.Event | None) -> dict:
     target_status = await container.notification_target_service.describe_target()
     bot_payload = {"configured": False}
     if target_status.state == "available":
@@ -225,15 +275,47 @@ async def _publish_snapshots(container, *, stop_event: asyncio.Event | None = No
                     "bot_id": bot.bot_id,
                     "created_at": bot.created_at.isoformat() if bot.created_at else None,
                 }
+    return {
+        "target": asdict(target_status),
+        "bot": bot_payload,
+    }
+
+
+async def _publish_notification_target_status_snapshot(
+    container,
+    stop_event: asyncio.Event | None,
+) -> None:
     await container.db.repos.runtime_snapshots.upsert_snapshot(
         RuntimeSnapshot(
             snapshot_type="notification_target_status",
-            payload={
-                "target": asdict(target_status),
-                "bot": bot_payload,
-            },
+            payload=await _notification_target_status_payload(container, stop_event),
         )
     )
+
+
+async def _publish_snapshots(container, *, stop_event: asyncio.Event | None = None) -> None:
+    now = datetime.now(timezone.utc)
+    connected_phones = sorted(getattr(container.pool, "clients", {}).keys())
+    active_accounts = await _load_active_accounts(container)
+    flood_waits, available_phones = _resolve_available_phones(active_accounts, connected_phones, now)
+    is_warming = _resolve_pool_warming(container.pool)
+    resolve_backoffs = _resolve_backoffs(container.pool, connected_phones)
+    await _publish_worker_heartbeat_snapshot(container, now)
+    await _publish_accounts_status_snapshot(
+        container,
+        connected_phones=connected_phones,
+        available_phones=available_phones,
+        flood_waits=flood_waits,
+        resolve_backoffs=resolve_backoffs,
+        is_warming=is_warming,
+        now=now,
+    )
+    await _publish_pool_counters_snapshot(container)
+    await _publish_collector_status_snapshot(container, connected_phones)
+    await _publish_scheduler_status_snapshot(container)
+    await _publish_scheduler_jobs_snapshot(container)
+    await _publish_collection_queue_status_snapshot(container, now)
+    await _publish_notification_target_status_snapshot(container, stop_event)
 
 
 async def _run_worker_async(config: AppConfig) -> None:


### PR DESCRIPTION
Part of #1131

## Summary
- Split `src/runtime/worker.py::_publish_snapshots` into private snapshot/payload helpers while preserving snapshot publish order and the #1172 `asyncio.TimeoutError` notification-bot branch.
- Split `ChannelAnalyzer._build_report` into fetch/build/flag/report helper methods while preserving flag ordering and report construction.
- Added `scripts/verify_refactor_ast_equivalence.py` to compare the extracted helper composition against `origin/main` AST blocks.

## Code health delta
Before `python scripts/code_health.py --top 40`:
- CC distribution: `A:3483 B:502 C:221 D:34 E:8 F:0`, average `3.46`.
- Targets: `_publish_snapshots` `E(40)`, `ChannelAnalyzer._build_report` `E(32)`.

After `python scripts/code_health.py --top 40`:
- CC distribution: `A:3506 B:507 C:221 D:34 E:6 F:0`, average `3.44`.
- Target ranks from `radon cc -s src/runtime/worker.py src/filters/analyzer.py`: `_publish_snapshots` `A(1)`, `ChannelAnalyzer._build_report` `A(2)`.

## AST proof
- `python scripts/verify_refactor_ast_equivalence.py --base-ref origin/main` passed.
- The script checks helper call order and extracted AST blocks for worker setup, snapshots, queue payload, notification payload/snapshot type, analyzer map fetch, per-flag logic, result constructor, and final report.

## Validation
- `ruff check src/ tests/ conftest.py` passed.
- `pytest tests/test_runtime_worker.py -v` passed: `19 passed`.
- `pytest tests/test_filters.py -v` passed: `53 passed`.
- `pytest tests/test_db_access_conventions.py tests/test_test_levels.py -q` passed: `17 passed`.
- `pytest tests/ -v -m aiosqlite_serial` passed: `943 passed, 9266 deselected`.
- `pytest tests/ -v -m "not aiosqlite_serial" -n auto` completed but failed outside this refactor scope: 7 failures in `tests/test_quality_scoring_service.py`, `tests/routes/test_debug_routes.py::test_debug_memory_returns_json`, and `tests/test_pipelines.py::test_pipelines_page_renders`.