### PR TITLE
refactor(complexity): split _publish_snapshots & _build_report (#1131 batch 1)

### DIFF
--- a/src/filters/analyzer.py
+++ b/src/filters/analyzer.py
@@ -49,19 +49,18 @@ class ChannelAnalyzer:
             logger=logger,
         )
 
-    async def _build_report(
+    async def _fetch_channels_for_report(self, channel_id: int | None, started_at: float) -> list:
+        channels = await self._repo.fetch_channels_for_analysis(channel_id)
+        logger.info("filter/analyze: fetched %d channels in %.1fs", len(channels), time.monotonic() - started_at)
+        return channels
+
+    async def _fetch_analysis_maps(
         self,
         channel_id: int | None = None,
         *,
         skip_cross_dupe: bool = False,
         sample_size: int | None = None,
-    ) -> FilterReport:
-        t0 = time.monotonic()
-        channels = await self._repo.fetch_channels_for_analysis(channel_id)
-        logger.info("filter/analyze: fetched %d channels in %.1fs", len(channels), time.monotonic() - t0)
-        if not channels:
-            return FilterReport()
-
+    ) -> tuple:
         if self._repo._can_parallel():
             logger.info(
                 "filter/analyze: all maps — started (parallel%s)",
@@ -94,113 +93,202 @@ class ChannelAnalyzer:
             cyrillic_map = await _timed_fetch(
                 "cyrillic map", self._repo.fetch_cyrillic_map(channel_id, sample_size=sample_size)
             )
+        return uniqueness_map, subscriber_map, short_map, cross_dupe_map, cyrillic_map
 
-        min_subs = await self._load_min_subscribers_filter()
+    def _append_uniqueness_flag(self, flags: list[str], channel_id_value: int, uniqueness_map: dict) -> float | None:
+        uniqueness_pct: float | None = None
+        low_uniqueness = False
+        if channel_id_value in uniqueness_map:
+            total, uniq = uniqueness_map[channel_id_value]
+            if total > 0:
+                raw_uniqueness = uniq / total * 100
+                uniqueness_pct = round(raw_uniqueness, 1)
+                low_uniqueness = raw_uniqueness < LOW_UNIQUENESS_THRESHOLD
+        if low_uniqueness:
+            flags.append("low_uniqueness")
+        return uniqueness_pct
 
-        results: list[ChannelFilterResult] = []
-        for channel in channels:
-            channel_id_value = channel["channel_id"]
-            message_count = int(channel["message_count"] or 0)
-            flags: list[str] = []
-
-            uniqueness_pct: float | None = None
-            low_uniqueness = False
-            if channel_id_value in uniqueness_map:
-                total, uniq = uniqueness_map[channel_id_value]
-                if total > 0:
-                    raw_uniqueness = uniq / total * 100
-                    uniqueness_pct = round(raw_uniqueness, 1)
-                    low_uniqueness = raw_uniqueness < LOW_UNIQUENESS_THRESHOLD
-            if low_uniqueness:
-                flags.append("low_uniqueness")
-
-            subscriber_ratio: float | None = None
-            low_subscriber = False
-            subscriber_count = subscriber_map.get(channel_id_value)
-            if subscriber_count is not None and message_count > 0:
-                raw_ratio = subscriber_count / message_count
-                subscriber_ratio = round(raw_ratio, 2)
-                is_broadcast = channel["channel_type"] in BROADCAST_CHANNEL_TYPES
-                threshold = (
-                    LOW_SUBSCRIBER_RATIO_THRESHOLD
-                    if is_broadcast
-                    else LOW_SUBSCRIBER_RATIO_CHAT_THRESHOLD
-                )
-                low_subscriber = raw_ratio < threshold
-            manual_subs_flagged = False
-            if min_subs > 0 and subscriber_count is not None and subscriber_count < min_subs:
-                flags.append("low_subscriber_manual")
-                manual_subs_flagged = True
-
-            if low_subscriber and not manual_subs_flagged:
-                flags.append("low_subscriber_ratio")
-
-            cross_dupe_pct: float | None = None
-            cross_dupe = False
-            if channel_id_value in cross_dupe_map:
-                uniq_total, duped = cross_dupe_map[channel_id_value]
-                if uniq_total > 0:
-                    raw_cross_pct = duped / uniq_total * 100
-                    cross_dupe_pct = round(raw_cross_pct, 1)
-                    cross_dupe = raw_cross_pct > CROSS_DUPE_THRESHOLD
-            if cross_dupe:
-                flags.append("cross_channel_spam")
-
-            cyrillic_pct: float | None = None
-            non_cyrillic = False
-            if channel_id_value in cyrillic_map:
-                cyr_total, cyr_count = cyrillic_map[channel_id_value]
-                if cyr_total > 0:
-                    raw_cyr_pct = cyr_count / cyr_total * 100
-                    cyrillic_pct = round(raw_cyr_pct, 1)
-                    non_cyrillic = raw_cyr_pct < NON_CYRILLIC_THRESHOLD
-            if non_cyrillic:
-                flags.append("non_cyrillic")
-
-            short_msg_pct: float | None = None
-            noisy_chat = False
-            is_chat = channel["channel_type"] in CHAT_CHANNEL_TYPES
-            if is_chat and channel_id_value in short_map:
-                short_total, short_count = short_map[channel_id_value]
-                if short_total > 0:
-                    raw_short_pct = short_count / short_total * 100
-                    short_msg_pct = round(raw_short_pct, 1)
-                    noisy_chat = raw_short_pct > CHAT_NOISE_THRESHOLD
-            if noisy_chat:
-                flags.append("chat_noise")
-
-            raw_username = channel["username"]
-            if raw_username and SUSPICIOUS_USERNAME_RE.match(raw_username):
-                flags.append("suspicious_username")
-
-            results.append(
-                ChannelFilterResult(
-                    channel_id=channel_id_value,
-                    title=channel["title"],
-                    username=channel["username"],
-                    message_count=message_count,
-                    flags=flags,
-                    uniqueness_pct=uniqueness_pct,
-                    subscriber_ratio=subscriber_ratio,
-                    cyrillic_pct=cyrillic_pct,
-                    short_msg_pct=short_msg_pct,
-                    cross_dupe_pct=cross_dupe_pct,
-                    is_filtered=bool(flags),
-                )
+    def _append_subscriber_flags(
+        self,
+        flags: list[str],
+        channel,
+        message_count: int,
+        subscriber_count: int | None,
+        min_subs: int,
+    ) -> float | None:
+        subscriber_ratio: float | None = None
+        low_subscriber = False
+        if subscriber_count is not None and message_count > 0:
+            raw_ratio = subscriber_count / message_count
+            subscriber_ratio = round(raw_ratio, 2)
+            is_broadcast = channel["channel_type"] in BROADCAST_CHANNEL_TYPES
+            threshold = (
+                LOW_SUBSCRIBER_RATIO_THRESHOLD
+                if is_broadcast
+                else LOW_SUBSCRIBER_RATIO_CHAT_THRESHOLD
             )
+            low_subscriber = raw_ratio < threshold
+        manual_subs_flagged = False
+        if min_subs > 0 and subscriber_count is not None and subscriber_count < min_subs:
+            flags.append("low_subscriber_manual")
+            manual_subs_flagged = True
 
+        if low_subscriber and not manual_subs_flagged:
+            flags.append("low_subscriber_ratio")
+        return subscriber_ratio
+
+    def _append_cross_dupe_flag(self, flags: list[str], channel_id_value: int, cross_dupe_map: dict) -> float | None:
+        cross_dupe_pct: float | None = None
+        cross_dupe = False
+        if channel_id_value in cross_dupe_map:
+            uniq_total, duped = cross_dupe_map[channel_id_value]
+            if uniq_total > 0:
+                raw_cross_pct = duped / uniq_total * 100
+                cross_dupe_pct = round(raw_cross_pct, 1)
+                cross_dupe = raw_cross_pct > CROSS_DUPE_THRESHOLD
+        if cross_dupe:
+            flags.append("cross_channel_spam")
+        return cross_dupe_pct
+
+    def _append_cyrillic_flag(self, flags: list[str], channel_id_value: int, cyrillic_map: dict) -> float | None:
+        cyrillic_pct: float | None = None
+        non_cyrillic = False
+        if channel_id_value in cyrillic_map:
+            cyr_total, cyr_count = cyrillic_map[channel_id_value]
+            if cyr_total > 0:
+                raw_cyr_pct = cyr_count / cyr_total * 100
+                cyrillic_pct = round(raw_cyr_pct, 1)
+                non_cyrillic = raw_cyr_pct < NON_CYRILLIC_THRESHOLD
+        if non_cyrillic:
+            flags.append("non_cyrillic")
+        return cyrillic_pct
+
+    def _append_chat_noise_flag(
+        self,
+        flags: list[str],
+        channel,
+        channel_id_value: int,
+        short_map: dict,
+    ) -> float | None:
+        short_msg_pct: float | None = None
+        noisy_chat = False
+        is_chat = channel["channel_type"] in CHAT_CHANNEL_TYPES
+        if is_chat and channel_id_value in short_map:
+            short_total, short_count = short_map[channel_id_value]
+            if short_total > 0:
+                raw_short_pct = short_count / short_total * 100
+                short_msg_pct = round(raw_short_pct, 1)
+                noisy_chat = raw_short_pct > CHAT_NOISE_THRESHOLD
+        if noisy_chat:
+            flags.append("chat_noise")
+        return short_msg_pct
+
+    def _append_suspicious_username_flag(self, flags: list[str], channel) -> None:
+        raw_username = channel["username"]
+        if raw_username and SUSPICIOUS_USERNAME_RE.match(raw_username):
+            flags.append("suspicious_username")
+
+    def _build_channel_result(
+        self,
+        channel,
+        *,
+        uniqueness_map: dict,
+        subscriber_map: dict,
+        short_map: dict,
+        cross_dupe_map: dict,
+        cyrillic_map: dict,
+        min_subs: int,
+    ) -> ChannelFilterResult:
+        channel_id_value = channel["channel_id"]
+        message_count = int(channel["message_count"] or 0)
+        flags: list[str] = []
+
+        uniqueness_pct = self._append_uniqueness_flag(flags, channel_id_value, uniqueness_map)
+        subscriber_count = subscriber_map.get(channel_id_value)
+        subscriber_ratio = self._append_subscriber_flags(flags, channel, message_count, subscriber_count, min_subs)
+        cross_dupe_pct = self._append_cross_dupe_flag(flags, channel_id_value, cross_dupe_map)
+        cyrillic_pct = self._append_cyrillic_flag(flags, channel_id_value, cyrillic_map)
+        short_msg_pct = self._append_chat_noise_flag(flags, channel, channel_id_value, short_map)
+        self._append_suspicious_username_flag(flags, channel)
+
+        return ChannelFilterResult(
+            channel_id=channel_id_value,
+            title=channel["title"],
+            username=channel["username"],
+            message_count=message_count,
+            flags=flags,
+            uniqueness_pct=uniqueness_pct,
+            subscriber_ratio=subscriber_ratio,
+            cyrillic_pct=cyrillic_pct,
+            short_msg_pct=short_msg_pct,
+            cross_dupe_pct=cross_dupe_pct,
+            is_filtered=bool(flags),
+        )
+
+    def _build_channel_results(
+        self,
+        channels: list,
+        *,
+        uniqueness_map: dict,
+        subscriber_map: dict,
+        short_map: dict,
+        cross_dupe_map: dict,
+        cyrillic_map: dict,
+        min_subs: int,
+    ) -> list[ChannelFilterResult]:
+        return [
+            self._build_channel_result(
+                channel,
+                uniqueness_map=uniqueness_map,
+                subscriber_map=subscriber_map,
+                short_map=short_map,
+                cross_dupe_map=cross_dupe_map,
+                cyrillic_map=cyrillic_map,
+                min_subs=min_subs,
+            )
+            for channel in channels
+        ]
+
+    def _filter_report_from_results(self, results: list[ChannelFilterResult], started_at: float) -> FilterReport:
         filtered_count = sum(1 for result in results if result.is_filtered)
         logger.info(
             "filter/analyze: report complete — %d channels, %d filtered in %.1fs",
             len(results),
             filtered_count,
-            time.monotonic() - t0,
+            time.monotonic() - started_at,
         )
         return FilterReport(
             results=results,
             total_channels=len(results),
             filtered_count=filtered_count,
         )
+
+    async def _build_report(
+        self,
+        channel_id: int | None = None,
+        *,
+        skip_cross_dupe: bool = False,
+        sample_size: int | None = None,
+    ) -> FilterReport:
+        t0 = time.monotonic()
+        channels = await self._fetch_channels_for_report(channel_id, t0)
+        if not channels:
+            return FilterReport()
+
+        uniqueness_map, subscriber_map, short_map, cross_dupe_map, cyrillic_map = await self._fetch_analysis_maps(
+            channel_id, skip_cross_dupe=skip_cross_dupe, sample_size=sample_size
+        )
+        min_subs = await self._load_min_subscribers_filter()
+        results = self._build_channel_results(
+            channels,
+            uniqueness_map=uniqueness_map,
+            subscriber_map=subscriber_map,
+            short_map=short_map,
+            cross_dupe_map=cross_dupe_map,
+            cyrillic_map=cyrillic_map,
+            min_subs=min_subs,
+        )
+        return self._filter_report_from_results(results, t0)
 
     async def analyze_channel(self, channel_id: int) -> ChannelFilterResult:
         report = await self._build_report(channel_id=channel_id)

--- a/src/runtime/worker.py
+++ b/src/runtime/worker.py
@@ -52,9 +52,7 @@ async def _publish_worker_down_snapshot(container, exc: AccountSessionDecryptErr
     )
 
 
-async def _publish_snapshots(container, *, stop_event: asyncio.Event | None = None) -> None:
-    now = datetime.now(timezone.utc)
-    connected_phones = sorted(getattr(container.pool, "clients", {}).keys())
+async def _load_active_accounts(container) -> list:
     active_accounts = []
     for getter_name in ("get_account_summaries", "get_accounts"):
         getter = getattr(container.db, getter_name, None)
@@ -69,6 +67,10 @@ async def _publish_snapshots(container, *, stop_event: asyncio.Event | None = No
                 break
         except Exception:
             logger.debug("Failed to load accounts while publishing account status snapshot", exc_info=True)
+    return active_accounts
+
+
+def _resolve_available_phones(active_accounts: list, connected_phones: list[str], now: datetime) -> tuple[dict, list]:
     flood_waits = {}
     available_phones = []
     if active_accounts:
@@ -85,16 +87,23 @@ async def _publish_snapshots(container, *, stop_event: asyncio.Event | None = No
                 available_phones.append(phone)
     else:
         available_phones = list(connected_phones)
+    return flood_waits, available_phones
+
+
+def _resolve_pool_warming(pool) -> bool:
     is_warming_method = None
-    pool_attrs = getattr(container.pool, "__dict__", {})
+    pool_attrs = getattr(pool, "__dict__", {})
     if isinstance(pool_attrs, dict) and "is_warming" in pool_attrs:
         is_warming_method = pool_attrs["is_warming"]
-    elif callable(getattr(type(container.pool), "is_warming", None)):
-        is_warming_method = getattr(container.pool, "is_warming")
-    is_warming = bool(is_warming_method()) if callable(is_warming_method) else False
+    elif callable(getattr(type(pool), "is_warming", None)):
+        is_warming_method = getattr(pool, "is_warming")
+    return bool(is_warming_method()) if callable(is_warming_method) else False
+
+
+def _resolve_backoffs(pool, connected_phones: list[str]) -> dict[str, str]:
     # Per-phone live-resolve backoff deadlines (#790) — surfaced for web parity.
     resolve_backoffs: dict[str, str] = {}
-    get_backoff_until = getattr(container.pool, "get_resolve_username_backoff_until", None)
+    get_backoff_until = getattr(pool, "get_resolve_username_backoff_until", None)
     if callable(get_backoff_until):
         for phone in connected_phones:
             try:
@@ -103,12 +112,28 @@ async def _publish_snapshots(container, *, stop_event: asyncio.Event | None = No
                 break
             if isinstance(until, datetime):
                 resolve_backoffs[phone] = until.isoformat()
+    return resolve_backoffs
+
+
+async def _publish_worker_heartbeat_snapshot(container, now: datetime) -> None:
     await container.db.repos.runtime_snapshots.upsert_snapshot(
         RuntimeSnapshot(
             snapshot_type="worker_heartbeat",
             payload={"status": "alive", "timestamp": now.isoformat()},
         )
     )
+
+
+async def _publish_accounts_status_snapshot(
+    container,
+    *,
+    connected_phones: list[str],
+    available_phones: list,
+    flood_waits: dict,
+    resolve_backoffs: dict[str, str],
+    is_warming: bool,
+    now: datetime,
+) -> None:
     await container.db.repos.runtime_snapshots.upsert_snapshot(
         RuntimeSnapshot(
             snapshot_type="accounts_status",
@@ -123,36 +148,45 @@ async def _publish_snapshots(container, *, stop_event: asyncio.Event | None = No
             },
         )
     )
-    pool = container.pool
+
+
+def _pool_counters_payload(pool) -> dict:
     dialogs_cache = getattr(pool, "_dialogs_cache", {})
     active_leases = getattr(pool, "_active_leases", {})
     premium_flood_waits = getattr(pool, "_premium_flood_wait_until", {})
     session_overrides = getattr(pool, "_session_overrides", {})
+    return {
+        "dialogs_cache_entries": (
+            len(dialogs_cache) if hasattr(dialogs_cache, "__len__") else 0
+        ),
+        "active_leases": (
+            {k: len(v) for k, v in active_leases.items()}
+            if isinstance(active_leases, dict)
+            else {}
+        ),
+        "premium_flood_waits": (
+            len(premium_flood_waits)
+            if hasattr(premium_flood_waits, "__len__")
+            else 0
+        ),
+        "session_overrides": (
+            len(session_overrides)
+            if hasattr(session_overrides, "__len__")
+            else 0
+        ),
+    }
+
+
+async def _publish_pool_counters_snapshot(container) -> None:
     await container.db.repos.runtime_snapshots.upsert_snapshot(
         RuntimeSnapshot(
             snapshot_type="pool_counters",
-            payload={
-                "dialogs_cache_entries": (
-                    len(dialogs_cache) if hasattr(dialogs_cache, "__len__") else 0
-                ),
-                "active_leases": (
-                    {k: len(v) for k, v in active_leases.items()}
-                    if isinstance(active_leases, dict)
-                    else {}
-                ),
-                "premium_flood_waits": (
-                    len(premium_flood_waits)
-                    if hasattr(premium_flood_waits, "__len__")
-                    else 0
-                ),
-                "session_overrides": (
-                    len(session_overrides)
-                    if hasattr(session_overrides, "__len__")
-                    else 0
-                ),
-            },
+            payload=_pool_counters_payload(container.pool),
         )
     )
+
+
+async def _publish_collector_status_snapshot(container, connected_phones: list[str]) -> None:
     await container.db.repos.runtime_snapshots.upsert_snapshot(
         RuntimeSnapshot(
             snapshot_type="collector_status",
@@ -164,6 +198,9 @@ async def _publish_snapshots(container, *, stop_event: asyncio.Event | None = No
             },
         )
     )
+
+
+async def _publish_scheduler_status_snapshot(container) -> None:
     await container.db.repos.runtime_snapshots.upsert_snapshot(
         RuntimeSnapshot(
             snapshot_type="scheduler_status",
@@ -173,12 +210,18 @@ async def _publish_snapshots(container, *, stop_event: asyncio.Event | None = No
             },
         )
     )
+
+
+async def _publish_scheduler_jobs_snapshot(container) -> None:
     jobs = []
     if hasattr(container.scheduler, "get_potential_jobs"):
         jobs = await container.scheduler.get_potential_jobs()
     await container.db.repos.runtime_snapshots.upsert_snapshot(
         RuntimeSnapshot(snapshot_type="scheduler_jobs", payload={"jobs": jobs})
     )
+
+
+def _collection_queue_status_payload(container, now: datetime) -> dict:
     queue = getattr(container, "collection_queue", None)
     active_task_ids = list(getattr(queue, "_active_task_ids", {}).keys()) if queue is not None else []
     target_worker_count = 0
@@ -186,19 +229,26 @@ async def _publish_snapshots(container, *, stop_event: asyncio.Event | None = No
         getter = getattr(queue, "_target_worker_count", None)
         if callable(getter):
             target_worker_count = getter()
+    return {
+        "paused": bool(getattr(queue, "is_paused", False)) if queue is not None else False,
+        "current_task_id": active_task_ids[0] if active_task_ids else None,
+        "active_task_ids": active_task_ids,
+        "running_count": len(active_task_ids),
+        "target_worker_count": target_worker_count,
+        "timestamp": now.isoformat(),
+    }
+
+
+async def _publish_collection_queue_status_snapshot(container, now: datetime) -> None:
     await container.db.repos.runtime_snapshots.upsert_snapshot(
         RuntimeSnapshot(
             snapshot_type="collection_queue_status",
-            payload={
-                "paused": bool(getattr(queue, "is_paused", False)) if queue is not None else False,
-                "current_task_id": active_task_ids[0] if active_task_ids else None,
-                "active_task_ids": active_task_ids,
-                "running_count": len(active_task_ids),
-                "target_worker_count": target_worker_count,
-                "timestamp": now.isoformat(),
-            },
+            payload=_collection_queue_status_payload(container, now),
         )
     )
+
+
+async def _notification_target_status_payload(container, stop_event: asyncio.Event | None) -> dict:
     target_status = await container.notification_target_service.describe_target()
     bot_payload = {"configured": False}
     if target_status.state == "available":
@@ -225,15 +275,47 @@ async def _publish_snapshots(container, *, stop_event: asyncio.Event | None = No
                     "bot_id": bot.bot_id,
                     "created_at": bot.created_at.isoformat() if bot.created_at else None,
                 }
+    return {
+        "target": asdict(target_status),
+        "bot": bot_payload,
+    }
+
+
+async def _publish_notification_target_status_snapshot(
+    container,
+    stop_event: asyncio.Event | None,
+) -> None:
     await container.db.repos.runtime_snapshots.upsert_snapshot(
         RuntimeSnapshot(
             snapshot_type="notification_target_status",
-            payload={
-                "target": asdict(target_status),
-                "bot": bot_payload,
-            },
+            payload=await _notification_target_status_payload(container, stop_event),
         )
     )
+
+
+async def _publish_snapshots(container, *, stop_event: asyncio.Event | None = None) -> None:
+    now = datetime.now(timezone.utc)
+    connected_phones = sorted(getattr(container.pool, "clients", {}).keys())
+    active_accounts = await _load_active_accounts(container)
+    flood_waits, available_phones = _resolve_available_phones(active_accounts, connected_phones, now)
+    is_warming = _resolve_pool_warming(container.pool)
+    resolve_backoffs = _resolve_backoffs(container.pool, connected_phones)
+    await _publish_worker_heartbeat_snapshot(container, now)
+    await _publish_accounts_status_snapshot(
+        container,
+        connected_phones=connected_phones,
+        available_phones=available_phones,
+        flood_waits=flood_waits,
+        resolve_backoffs=resolve_backoffs,
+        is_warming=is_warming,
+        now=now,
+    )
+    await _publish_pool_counters_snapshot(container)
+    await _publish_collector_status_snapshot(container, connected_phones)
+    await _publish_scheduler_status_snapshot(container)
+    await _publish_scheduler_jobs_snapshot(container)
+    await _publish_collection_queue_status_snapshot(container, now)
+    await _publish_notification_target_status_snapshot(container, stop_event)
 
 
 async def _run_worker_async(config: AppConfig) -> None:


### PR DESCRIPTION
## What

#1131 batch 1 of ~4 (axis 1/7 of the #1130 tech-debt epic: cyclomatic complexity). Behaviour-preserving split of two **isolated** rank-E functions into private sub-methods.

| Function | Before | After |
|---|---|---|
| `runtime/worker.py::_publish_snapshots` | E(40) | out of rank-E |
| `filters/analyzer.py::ChannelAnalyzer._build_report` | E(32) | out of rank-E |

`code_health.py` rank-E count **8 → 6**; average complexity unchanged.

## No behaviour change — proven

- **AST-equivalence** (per #1046's diff-harness): the extracted sub-method bodies are AST-equivalent to the original function bodies — all analyzer/worker blocks reported equivalent (subscriber / cross-dupe / cyrillic / chat-noise / suspicious-username / result-ctor / final-report; worker snapshot blocks).
- **Characterising tests green**: `tests/test_filters.py` (10+ `ChannelAnalyzer.analyze` cases) + `tests/test_runtime_worker.py` → **72 passed** isolated.
- #1172's `except asyncio.TimeoutError` branch in `_publish_snapshots` is preserved.

> The one-off AST verification script was used as proof and not committed (it's batch-1-specific scaffolding, not a reusable guard). Equivalence is re-checkable from the diff.

Part of #1131 (remaining batches: cli/test funcs; start_container + _dispatch_stream_message hot paths; _pipeline_add + generate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TShpckA1DoLNezbD3txTL1