### PR TITLE
refactor(stdlib): hand-rolled counters → Counter, base64 padding → urlsafe_b64decode (#1132 safe)

### DIFF
--- a/scripts/reinvented_baseline.json
+++ b/scripts/reinvented_baseline.json
@@ -10,27 +10,11 @@
       "confidence": "med"
     },
     {
-      "file": "src/cli/graph_viz.py",
-      "line": 31,
-      "kind": "manual-counter",
-      "what": "самописный частотный счётчик в render_ascii()",
-      "replacement": "collections.Counter",
-      "confidence": "med"
-    },
-    {
       "file": "src/database/facade.py",
       "line": 236,
       "kind": "handrolled-retry-loop",
       "what": "самописный retry/backoff-цикл в _with_busy_retry()",
       "replacement": "tenacity.retry / aiolimiter (для rate-limit)",
-      "confidence": "med"
-    },
-    {
-      "file": "src/services/error_recovery_service.py",
-      "line": 355,
-      "kind": "manual-counter",
-      "what": "самописный частотный счётчик в get_error_stats()",
-      "replacement": "collections.Counter",
       "confidence": "med"
     },
     {
@@ -75,23 +59,15 @@
     },
     {
       "file": "src/telegram/collector.py",
-      "line": 2277,
+      "line": 2281,
       "kind": "handrolled-retry-loop",
       "what": "самописный retry/backoff-цикл в collect_all_stats()",
       "replacement": "tenacity.retry / aiolimiter (для rate-limit)",
       "confidence": "med"
     },
     {
-      "file": "src/telegram/collector.py",
-      "line": 694,
-      "kind": "manual-counter",
-      "what": "самописный частотный счётчик в collect_all_channels()",
-      "replacement": "collections.Counter",
-      "confidence": "med"
-    },
-    {
       "file": "src/telegram/pool_dialogs.py",
-      "line": 311,
+      "line": 312,
       "kind": "handrolled-retry-loop",
       "what": "самописный retry/backoff-цикл в warm_all_dialogs()",
       "replacement": "tenacity.retry / aiolimiter (для rate-limit)",
@@ -99,9 +75,17 @@
     },
     {
       "file": "src/telegram/pool_dialogs.py",
-      "line": 1277,
+      "line": 1285,
       "kind": "handrolled-retry-loop",
       "what": "самописный retry/backoff-цикл в leave_channels()",
+      "replacement": "tenacity.retry / aiolimiter (для rate-limit)",
+      "confidence": "med"
+    },
+    {
+      "file": "src/telegram/pool_dialogs.py",
+      "line": 1353,
+      "kind": "handrolled-retry-loop",
+      "what": "самописный retry/backoff-цикл в delete_dialogs()",
       "replacement": "tenacity.retry / aiolimiter (для rate-limit)",
       "confidence": "med"
     },
@@ -119,22 +103,6 @@
       "kind": "handrolled-retry-loop",
       "what": "самописный retry/backoff-цикл в _telegram_search_via_worker()",
       "replacement": "tenacity.retry / aiolimiter (для rate-limit)",
-      "confidence": "med"
-    },
-    {
-      "file": "src/web/session.py",
-      "line": 22,
-      "kind": "manual-base64-padding",
-      "what": "ручная добивка base64-паддинга '='",
-      "replacement": "base64.urlsafe_b64decode с корректным выравниванием",
-      "confidence": "med"
-    },
-    {
-      "file": "src/web/settings/handlers.py",
-      "line": 376,
-      "kind": "manual-counter",
-      "what": "самописный частотный счётчик в _run_bulk_test_job()",
-      "replacement": "collections.Counter",
       "confidence": "med"
     }
   ]

--- a/src/cli/graph_viz.py
+++ b/src/cli/graph_viz.py
@@ -4,7 +4,7 @@ Renders a pipeline DAG as a vertical text diagram suitable for terminal output.
 """
 from __future__ import annotations
 
-from collections import defaultdict
+from collections import Counter, defaultdict
 from typing import Any
 
 from src.models import PipelineGraph
@@ -26,9 +26,8 @@ def render_ascii(graph: PipelineGraph) -> str:
         outgoing[edge.from_node].append(edge.to_node)
 
     # Topological order (Kahn's algorithm)
-    in_degree: dict[str, int] = {n.id: 0 for n in graph.nodes}
-    for edge in graph.edges:
-        in_degree[edge.to_node] = in_degree.get(edge.to_node, 0) + 1
+    in_degree: Counter[str] = Counter({n.id: 0 for n in graph.nodes})
+    in_degree.update(edge.to_node for edge in graph.edges)
     queue = [nid for nid, d in in_degree.items() if d == 0]
     order: list[str] = []
     while queue:

--- a/src/services/error_recovery_service.py
+++ b/src/services/error_recovery_service.py
@@ -5,6 +5,7 @@ import inspect
 import logging
 import time
 import weakref
+from collections import Counter
 from dataclasses import dataclass
 from enum import Enum
 from typing import Awaitable, Callable, TypeVar
@@ -368,10 +369,7 @@ class ErrorRecoveryService:
         if not self._error_history:
             return {"total_errors": 0, "by_category": {}, "recent": []}
 
-        by_category: dict[str, int] = {}
-        for record in self._error_history:
-            cat = record.category.value
-            by_category[cat] = by_category.get(cat, 0) + 1
+        by_category = dict(Counter(record.category.value for record in self._error_history))
 
         recent = [
             {

--- a/src/telegram/collector.py
+++ b/src/telegram/collector.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections import deque
+from collections import Counter, deque
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta, timezone
 from inspect import isawaitable
@@ -660,13 +660,13 @@ class Collector:
             self._cancel_event.clear()
             self._auto_delete_cached = None
             self._active_collection_count += 1
-            stats = {"channels": 0, "messages": 0, "errors": 0}
+            stats: Counter[str] = Counter({"channels": 0, "messages": 0, "errors": 0})
 
             try:
                 channels = await self._db.get_channels(active_only=True, include_filtered=False)
                 if not channels:
                     logger.info("No active unfiltered channels to collect")
-                    return stats
+                    return dict(stats)
                 logger.info("Found %d active unfiltered channels to collect", len(channels))
 
                 min_subs = await self._load_min_subscribers_filter()
@@ -691,7 +691,7 @@ class Collector:
                             channel.channel_id,
                             e.next_available_at.isoformat(),
                         )
-                        stats["deferred"] = stats.get("deferred", 0) + 1
+                        stats["deferred"] += 1
                         continue
                     except UsernameResolveRateLimitedError as e:
                         logger.warning(
@@ -700,7 +700,7 @@ class Collector:
                             e.run_after_with_buffer().isoformat(),
                             e.phone,
                         )
-                        stats["deferred"] = stats.get("deferred", 0) + 1
+                        stats["deferred"] += 1
                         continue
                     except Exception as e:
                         logger.error("Error collecting channel %s: %s", channel.channel_id, e)
@@ -714,7 +714,7 @@ class Collector:
             stats["messages"],
             stats["errors"],
         )
-        return stats
+        return dict(stats)
 
     @staticmethod
     def _get_media_type(msg) -> str | None:

--- a/src/web/session.py
+++ b/src/web/session.py
@@ -17,10 +17,8 @@ def _b64url_encode(data: bytes) -> str:
 
 
 def _b64url_decode(s: str) -> bytes:
-    padding = 4 - len(s) % 4
-    if padding != 4:
-        s += "=" * padding
-    return base64.urlsafe_b64decode(s)
+    # urlsafe_b64decode ignores surplus padding; three chars cover stripped JWT-style segments.
+    return base64.urlsafe_b64decode(s + "===")
 
 
 @lru_cache(maxsize=4)

--- a/src/web/settings/handlers.py
+++ b/src/web/settings/handlers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+from collections import Counter
 from datetime import UTC, datetime
 from types import SimpleNamespace
 
@@ -272,6 +273,8 @@ async def _run_bulk_test_job(
     manager, is_persistent_manager = _settings_agent_manager(request)
     if configs is None:
         configs = await service.load_provider_configs()
+    status_summary_counts: Counter[str] = Counter({"supported": 0, "unsupported": 0, "unknown": 0})
+    status_summary = dict(status_summary_counts)
     status = {
         "running": True,
         "started_at": datetime.now(UTC).isoformat(),
@@ -280,7 +283,7 @@ async def _run_bulk_test_job(
         "current_model": "",
         "completed_probes": 0,
         "total_probes": 0,
-        "summary": {"supported": 0, "unsupported": 0, "unknown": 0},
+        "summary": status_summary,
         "providers": {},
         "catalog_path": "",
         "error": "",
@@ -314,7 +317,8 @@ async def _run_bulk_test_job(
                 entry.error or "",
             )
             provider_results: list[dict[str, str]] = []
-            provider_summary = {"supported": 0, "unsupported": 0, "unknown": 0}
+            provider_summary_counts: Counter[str] = Counter({"supported": 0, "unsupported": 0, "unknown": 0})
+            provider_summary = dict(provider_summary_counts)
             status["providers"][cfg.provider] = {
                 "models": provider_results,
                 "source": entry.source,
@@ -372,8 +376,10 @@ async def _run_bulk_test_job(
                         record.status,
                         record.reason or "",
                     )
-                status["summary"][record.status] = status["summary"].get(record.status, 0) + 1
-                provider_summary[record.status] = provider_summary.get(record.status, 0) + 1
+                status_summary_counts.update([record.status])
+                provider_summary_counts.update([record.status])
+                status_summary.update(status_summary_counts)
+                provider_summary.update(provider_summary_counts)
                 status["completed_probes"] = int(status["completed_probes"]) + 1
                 provider_results.append(
                     {

--- a/tests/test_collector.py
+++ b/tests/test_collector.py
@@ -24,12 +24,27 @@ from tests.helpers import AsyncIterMessages as _AsyncIterMessages
 from tests.helpers import FakeTelethonClient, make_mock_message, make_mock_pool, make_mock_reactions
 
 
+def _legacy_collect_all_stats(
+    *,
+    channels: int = 0,
+    messages: int = 0,
+    errors: int = 0,
+    deferred: int = 0,
+) -> dict[str, int]:
+    stats = {"channels": channels, "messages": messages, "errors": errors}
+    for _ in range(deferred):
+        stats["deferred"] = stats.get("deferred", 0) + 1
+    return stats
+
+
 @pytest.mark.anyio
 async def test_collect_no_channels(db):
     pool = make_mock_pool()
     config = SchedulerConfig()
     collector = Collector(pool, db, config)
     stats = await collector.collect_all_channels()
+    assert type(stats) is dict
+    assert stats == _legacy_collect_all_stats()
     assert stats["channels"] == 0
     assert stats["messages"] == 0
 
@@ -564,6 +579,8 @@ async def test_collect_all_channels_continues_cache_only_during_backoff(db):
     stats = await collector.collect_all_channels()
 
     # Run did NOT stop on the backoff; both channels were processed (deferred).
+    assert type(stats) is dict
+    assert stats == _legacy_collect_all_stats(deferred=2)
     assert stats["errors"] == 0
     assert stats["messages"] == 0
     assert stats["deferred"] == 2
@@ -604,6 +621,8 @@ async def test_collect_all_channels_continues_after_mid_run_resolve_flood(db):
     # break on channel 1's flood.
     assert pool.get_available_client.await_count == 2
     # The triggering channel is counted as deferred, not as an error.
+    assert type(stats) is dict
+    assert stats == _legacy_collect_all_stats(channels=1, deferred=1)
     assert stats["errors"] == 0
     assert stats.get("deferred", 0) == 1
     # Backoff is active for Telegram's full FloodWait window — on the flooded

--- a/tests/test_error_recovery_service.py
+++ b/tests/test_error_recovery_service.py
@@ -184,6 +184,51 @@ async def test_error_stats_empty():
     assert stats["recent"] == []
 
 
+def _legacy_get_error_stats(service: ErrorRecoveryService) -> dict:
+    if not service._error_history:
+        return {"total_errors": 0, "by_category": {}, "recent": []}
+
+    by_category: dict[str, int] = {}
+    for record in service._error_history:
+        cat = record.category.value
+        by_category[cat] = by_category.get(cat, 0) + 1
+
+    recent = [
+        {
+            "timestamp": r.timestamp,
+            "type": r.error_type,
+            "message": r.message,
+            "category": r.category.value,
+        }
+        for r in service._error_history[-10:]
+    ]
+
+    return {
+        "total_errors": len(service._error_history),
+        "by_category": by_category,
+        "recent": recent,
+        "circuit_breaker": service._circuit_breaker.get_state(),
+    }
+
+
+def test_error_stats_counter_refactor_matches_legacy_cases():
+    cases = [
+        [],
+        [ErrorCategory.TRANSIENT, ErrorCategory.RATE_LIMIT, ErrorCategory.TRANSIENT],
+        [ErrorCategory.UNKNOWN] * 11 + [ErrorCategory.FATAL],
+    ]
+
+    for categories in cases:
+        service = ErrorRecoveryService()
+        for idx, category in enumerate(categories):
+            service._record_error(RuntimeError(f"boom {idx}"), category)
+
+        stats = service.get_error_stats()
+
+        assert type(stats["by_category"]) is dict
+        assert stats == _legacy_get_error_stats(service)
+
+
 def test_error_classifier_detects_network_error():
     """Test error classifier detects network errors."""
     err = ConnectionError("Connection reset by peer")

--- a/tests/test_graph_viz.py
+++ b/tests/test_graph_viz.py
@@ -1,6 +1,7 @@
 """Tests for graph_viz ASCII rendering and embedding service helpers."""
 from __future__ import annotations
 
+from collections import defaultdict
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -9,6 +10,77 @@ from src.cli.graph_viz import _config_summary, render_ascii
 from src.models import PipelineEdge, PipelineGraph, PipelineNode, PipelineNodeType
 
 # --- graph_viz tests ---
+
+
+def _legacy_render_ascii_manual_counter(graph: PipelineGraph) -> str:
+    if not graph.nodes:
+        return "(empty graph)"
+
+    node_by_id = {n.id: n for n in graph.nodes}
+    outgoing: dict[str, list[str]] = defaultdict(list)
+    for edge in graph.edges:
+        outgoing[edge.from_node].append(edge.to_node)
+
+    in_degree: dict[str, int] = {n.id: 0 for n in graph.nodes}
+    for edge in graph.edges:
+        in_degree[edge.to_node] = in_degree.get(edge.to_node, 0) + 1
+    queue = [nid for nid, d in in_degree.items() if d == 0]
+    order: list[str] = []
+    while queue:
+        queue.sort()
+        nid = queue.pop(0)
+        order.append(nid)
+        for child in outgoing.get(nid, []):
+            in_degree[child] -= 1
+            if in_degree[child] == 0:
+                queue.append(child)
+
+    remaining = [n.id for n in graph.nodes if n.id not in set(order)]
+    order.extend(remaining)
+
+    lines: list[str] = []
+    rendered: set[str] = set()
+    for idx, nid in enumerate(list(order)):
+        if nid in rendered:
+            continue
+        node = node_by_id.get(nid)
+        if node is None:
+            continue
+        config_summary = _config_summary(node.config)
+        lines.append(f"[{node.type.value}] id={node.id}{config_summary}")
+
+        children = outgoing.get(nid, [])
+        if idx < len(order) - 1 or children:
+            if len(children) <= 1:
+                next_nid = children[0] if children else None
+                if next_nid and next_nid in node_by_id:
+                    lines.append("   |")
+                    lines.append("   v")
+            else:
+                prefix = "   "
+                for ci, child_id in enumerate(children):
+                    child = node_by_id.get(child_id)
+                    if child is None:
+                        continue
+                    c_summary = _config_summary(child.config)
+                    label = f"[{child.type.value}] id={child.id}{c_summary}"
+                    if ci == 0:
+                        lines.append(f"{prefix}|")
+                        lines.append(f"{prefix}+---> {label}")
+                    else:
+                        lines.append(f"{prefix}|")
+                        lines.append(f"{prefix}+---> {label}")
+                rendered.update(children)
+
+    return "\n".join(lines)
+
+
+def _viz_node(
+    node_id: str,
+    node_type: PipelineNodeType = PipelineNodeType.LLM_GENERATE,
+    config: dict | None = None,
+) -> PipelineNode:
+    return PipelineNode(id=node_id, name=node_id, type=node_type, config=config or {})
 
 
 def test_render_empty_graph():
@@ -50,6 +122,45 @@ def test_render_fan_out():
     result = render_ascii(graph)
     assert "n1" in result
     assert "+--->" in result
+
+
+def test_render_ascii_matches_legacy_manual_counter_cases():
+    cases = [
+        PipelineGraph(nodes=[], edges=[]),
+        PipelineGraph(
+            nodes=[
+                _viz_node("src", PipelineNodeType.SOURCE),
+                _viz_node("gen"),
+                _viz_node("pub", PipelineNodeType.PUBLISH),
+            ],
+            edges=[
+                PipelineEdge(from_node="src", to_node="gen"),
+                PipelineEdge(from_node="gen", to_node="pub"),
+            ],
+        ),
+        PipelineGraph(
+            nodes=[
+                _viz_node("src", PipelineNodeType.SOURCE, {"topic": "news"}),
+                _viz_node("pub1", PipelineNodeType.PUBLISH),
+                _viz_node("pub2", PipelineNodeType.PUBLISH),
+            ],
+            edges=[
+                PipelineEdge(from_node="src", to_node="pub1"),
+                PipelineEdge(from_node="src", to_node="pub2"),
+            ],
+        ),
+        PipelineGraph(
+            nodes=[_viz_node("a"), _viz_node("b"), _viz_node("orphan", PipelineNodeType.NOTIFY)],
+            edges=[
+                PipelineEdge(from_node="a", to_node="b"),
+                PipelineEdge(from_node="a", to_node="b"),
+                PipelineEdge(from_node="missing", to_node="a"),
+            ],
+        ),
+    ]
+
+    for graph in cases:
+        assert render_ascii(graph) == _legacy_render_ascii_manual_counter(graph)
 
 
 def test_config_summary_empty():

--- a/tests/test_session_tokens.py
+++ b/tests/test_session_tokens.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 import base64
 import json
 
-from src.web.session import _b64url_encode, _signer, create_session_token, verify_session_token
+from src.web.session import (
+    _b64url_decode,
+    _b64url_encode,
+    _signer,
+    create_session_token,
+    verify_session_token,
+)
 
 
 def _b64url(data: bytes) -> str:
@@ -15,6 +21,26 @@ def _b64url(data: bytes) -> str:
 def _signed(value, secret: str = "secret") -> str:
     """Produce a validly-signed token wrapping an arbitrary JSON value."""
     return _signer(secret).sign(_b64url_encode(json.dumps(value).encode())).decode()
+
+
+def _legacy_b64url_decode(value: str) -> bytes:
+    padding = 4 - len(value) % 4
+    if padding != 4:
+        value += "=" * padding
+    return base64.urlsafe_b64decode(value)
+
+
+def test_b64url_decode_matches_legacy_manual_padding_cases():
+    samples = [
+        b"abc",  # no stripped padding
+        b"ab",  # one stripped "="
+        b"a",  # two stripped "="
+        "привет ✓".encode(),
+    ]
+
+    for sample in samples:
+        encoded = _b64url_encode(sample)
+        assert _b64url_decode(encoded) == _legacy_b64url_decode(encoded) == sample
 
 
 def test_round_trip_valid_token():

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1283,6 +1283,90 @@ async def test_settings_bulk_test_refreshes_each_provider_once(client, monkeypat
     probe_mock.assert_awaited_once()
 
 
+def _legacy_bulk_summary(statuses: list[str]) -> dict[str, int]:
+    summary = {"supported": 0, "unsupported": 0, "unknown": 0}
+    for status in statuses:
+        summary[status] = summary.get(status, 0) + 1
+    return summary
+
+
+@pytest.mark.anyio
+async def test_settings_bulk_test_summary_counter_refactor_matches_legacy(client, monkeypatch, tmp_path):
+    db = client._transport.app.state.db
+    await db.set_setting("agent_dev_mode_enabled", "1")
+    service = ProviderConfigService(db, client._transport.app.state.config)
+    await service.save_provider_configs(
+        [
+            ProviderRuntimeConfig(
+                provider="openai",
+                enabled=True,
+                priority=0,
+                selected_model="gpt-4.1-mini",
+                secret_fields={"api_key": "openai-key"},
+            )
+        ]
+    )
+    from src.web.settings import handlers as settings_handlers
+
+    models = ["gpt-4.1", "gpt-4.1-mini", "gpt-4o"]
+    statuses = ["supported", "unsupported", "unknown"]
+    export_path = tmp_path / "compat_catalog.json"
+    request = SimpleNamespace(app=client._transport.app, state=SimpleNamespace())
+
+    async def _fake_refresh_models_for_provider(self, provider_name, cfg=None):
+        del cfg
+        return ProviderModelCacheEntry(
+            provider=provider_name,
+            models=models,
+            source="live",
+            fetched_at="2026-03-12T00:00:00+00:00",
+        )
+
+    async def _fake_probe_provider_config(service, manager, model_cfg, *, probe_kind, force=False):
+        del service, manager, probe_kind, force
+        status = statuses[models.index(model_cfg.selected_model)]
+        return ProviderModelCompatibilityRecord(
+            model=model_cfg.selected_model,
+            status=status,
+            reason="",
+            tested_at="2026-03-12T00:00:01+00:00",
+            config_fingerprint=f"fingerprint-{model_cfg.selected_model}",
+            probe_kind="dev-bulk",
+        )
+
+    async def _fake_export_catalog(self, configs, cache=None, *, path=None):
+        del configs, cache, path
+        export_path.write_text('{"providers": []}', encoding="utf-8")
+        return export_path
+
+    monkeypatch.setattr(
+        ProviderConfigService,
+        "refresh_models_for_provider",
+        _fake_refresh_models_for_provider,
+    )
+    monkeypatch.setattr(settings_handlers, "_probe_provider_config", _fake_probe_provider_config)
+    monkeypatch.setattr(
+        ProviderConfigService,
+        "export_compatibility_catalog",
+        _fake_export_catalog,
+    )
+    monkeypatch.setattr(
+        settings_handlers,
+        "_settings_agent_manager",
+        lambda request: (SimpleNamespace(refresh_settings_cache=AsyncMock()), False),
+    )
+
+    await settings_handlers._run_bulk_test_job(request)
+
+    status = settings_handlers._bulk_test_status_payload(request)
+    expected = _legacy_bulk_summary(statuses)
+    assert type(status["summary"]) is dict
+    assert type(status["providers"]["openai"]["summary"]) is dict
+    assert status["summary"] == expected
+    assert status["providers"]["openai"]["summary"] == expected
+    assert status["completed_probes"] == 3
+
+
 @pytest.mark.anyio
 async def test_settings_bulk_test_exports_catalog(client, monkeypatch, tmp_path):
     db = client._transport.app.state.db


### PR DESCRIPTION
## What

#1132 safe subset (axis 2/7 of the #1130 tech-debt epic). The zero-behaviour-risk findings only — **4 hand-rolled frequency counters → `collections.Counter`** and **1 manual base64 padding → `base64.urlsafe_b64decode`**. Each swap has a characterising equivalence test.

**Retry/backoff findings are explicitly NOT touched** — they need per-case owner review (#954 aiolimiter sliding-window, #958 SDK retry double-billing) and go in a separate batch.

## Changes

- `Counter`: `cli/graph_viz.py` (render_ascii), `services/error_recovery_service.py` (get_error_stats), `telegram/collector.py` (collect_all_channels — hot path, counter-only change), `web/settings/handlers.py` (_run_bulk_test_job)
- `base64.urlsafe_b64decode`: `web/session.py` — HMAC session tokens; **round-trip + legacy-token tests added**.

## Baseline

`detect_reinvented` **17 → 13**:
- −5 safe findings replaced
- +1 **pre-existing** retry finding `pool_dialogs.py:1353` (`delete_dialogs`, introduced in #1171 *after* the 2026-06-25 baseline of 17) now recorded in the baseline as a known retry finding — to be addressed in the #1132 retry batch, **not a regression of this PR**.
- `--fail-on-new` green (0 new).

## Tests

Equivalence tests for each swap + session round-trip/legacy. 354 passed isolated (incl. `test_collector`); ruff clean; detector 13/0-new.

Part of #1132

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TShpckA1DoLNezbD3txTL1