### PR TITLE
refactor(cli): split test command checks (#1131 batch 2)

### DIFF
--- a/src/cli/commands/test.py
+++ b/src/cli/commands/test.py
@@ -137,6 +137,17 @@ class TelegramLiveFloodDecision:
     next_available_at_utc: datetime | None = None
 
 
+@dataclass
+class TelegramLiveCheckState:
+    config_path: str
+    results: list[CheckResult]
+    copy_db: Database | None = None
+    tmp_path: str | None = None
+    config: object | None = None
+    pool: object | None = None
+    engine: object | None = None
+
+
 class TelegramLiveStepSkipError(RuntimeError):
     """Internal control-flow exception used to stop live checks on long flood waits."""
 
@@ -453,12 +464,10 @@ def _backup_sqlite_db(source_path: str, target_path: str) -> None:
         source.close()
 
 
-async def _run_write_checks(config_path: str) -> list[CheckResult]:
-    results: list[CheckResult] = []
-    tmp_path: str | None = None
-    copy_db: Database | None = None
-
-    # 1. write_db_copy
+async def _run_write_db_copy_check(
+    config_path: str,
+    results: list[CheckResult],
+) -> tuple[Database | None, str | None]:
     try:
         copy_db, tmp_path, _ = await _init_db_copy(config_path)
         stats = await copy_db.get_stats()
@@ -466,154 +475,160 @@ async def _run_write_checks(config_path: str) -> list[CheckResult]:
         results.append(
             CheckResult("write_db_copy", Status.PASS, f"Copied to {tmp_path} ({parts})"),
         )
+        return copy_db, tmp_path
     except Exception as exc:
         results.append(CheckResult("write_db_copy", Status.FAIL, str(exc)))
-        return results
+        return None, None
 
+
+async def _run_account_toggle_check(copy_db: Database, results: list[CheckResult]) -> None:
     try:
-        # 2. account_toggle
-        try:
-            accounts = await copy_db.get_accounts()
-            if not accounts:
-                results.append(
-                    CheckResult("account_toggle", Status.SKIP, "No accounts in DB"),
-                )
-            else:
-                acc = accounts[0]
-                original = acc.is_active
-                await copy_db.set_account_active(acc.id, not original)
-                refreshed = await copy_db.get_accounts()
-                toggled = next(a for a in refreshed if a.id == acc.id)
-                if toggled.is_active is not (not original):
-                    raise RuntimeError("account active state did not change")
-                results.append(
-                    CheckResult(
-                        "account_toggle",
-                        Status.PASS,
-                        f"id={acc.id} active: {original} -> {not original}",
-                    )
-                )
-        except Exception as exc:
-            results.append(CheckResult("account_toggle", Status.FAIL, str(exc)))
-
-        # 3. search_query_add
-        added_sq_id: int | None = None
-        try:
-            sq_repo = copy_db.repos.search_queries
-            added_sq_id = await sq_repo.add(
-                SearchQuery(name="__test_cli__", query="__test_cli__"),
+        accounts = await copy_db.get_accounts()
+        if not accounts:
+            results.append(
+                CheckResult("account_toggle", Status.SKIP, "No accounts in DB"),
             )
+        else:
+            acc = accounts[0]
+            original = acc.is_active
+            await copy_db.set_account_active(acc.id, not original)
+            refreshed = await copy_db.get_accounts()
+            toggled = next(a for a in refreshed if a.id == acc.id)
+            if toggled.is_active is not (not original):
+                raise RuntimeError("account active state did not change")
+            results.append(
+                CheckResult(
+                    "account_toggle",
+                    Status.PASS,
+                    f"id={acc.id} active: {original} -> {not original}",
+                )
+            )
+    except Exception as exc:
+        results.append(CheckResult("account_toggle", Status.FAIL, str(exc)))
+
+
+async def _run_search_query_add_check(copy_db: Database, results: list[CheckResult]):
+    added_sq_id: int | None = None
+    sq_repo = None
+    try:
+        sq_repo = copy_db.repos.search_queries
+        added_sq_id = await sq_repo.add(
+            SearchQuery(name="__test_cli__", query="__test_cli__"),
+        )
+        queries = await sq_repo.get_all()
+        found = any(q.id == added_sq_id for q in queries)
+        if not found:
+            raise RuntimeError("search query not found after add")
+        results.append(
+            CheckResult(
+                "search_query_add",
+                Status.PASS,
+                f'Added id={added_sq_id} query="__test_cli__"',
+            )
+        )
+    except Exception as exc:
+        results.append(CheckResult("search_query_add", Status.FAIL, str(exc)))
+    return sq_repo, added_sq_id
+
+
+async def _run_search_query_toggle_check(sq_repo, added_sq_id: int | None, results: list[CheckResult]) -> None:
+    if added_sq_id is not None:
+        try:
+            await sq_repo.set_active(added_sq_id, False)
+            queries = await sq_repo.get_all()
+            sq = next(q for q in queries if q.id == added_sq_id)
+            if sq.is_active is not False:
+                raise RuntimeError("search query active state did not change")
+            results.append(
+                CheckResult(
+                    "search_query_toggle",
+                    Status.PASS,
+                    f"id={added_sq_id} active: True -> False",
+                )
+            )
+        except Exception as exc:
+            results.append(CheckResult("search_query_toggle", Status.FAIL, str(exc)))
+    else:
+        results.append(
+            CheckResult("search_query_toggle", Status.SKIP, "search_query_add failed"),
+        )
+
+
+async def _run_search_query_delete_check(sq_repo, added_sq_id: int | None, results: list[CheckResult]) -> None:
+    if added_sq_id is not None:
+        try:
+            await sq_repo.delete(added_sq_id)
             queries = await sq_repo.get_all()
             found = any(q.id == added_sq_id for q in queries)
-            if not found:
-                raise RuntimeError("search query not found after add")
+            if found:
+                raise RuntimeError("search query still present after delete")
             results.append(
                 CheckResult(
-                    "search_query_add",
+                    "search_query_delete",
                     Status.PASS,
-                    f'Added id={added_sq_id} query="__test_cli__"',
+                    f"id={added_sq_id} deleted, verified absent",
                 )
             )
         except Exception as exc:
-            results.append(CheckResult("search_query_add", Status.FAIL, str(exc)))
+            results.append(CheckResult("search_query_delete", Status.FAIL, str(exc)))
+    else:
+        results.append(
+            CheckResult("search_query_delete", Status.SKIP, "search_query_add failed"),
+        )
 
-        # 4. search_query_toggle
-        if added_sq_id is not None:
-            try:
-                await sq_repo.set_active(added_sq_id, False)
-                queries = await sq_repo.get_all()
-                sq = next(q for q in queries if q.id == added_sq_id)
-                if sq.is_active is not False:
-                    raise RuntimeError("search query active state did not change")
-                results.append(
-                    CheckResult(
-                        "search_query_toggle",
-                        Status.PASS,
-                        f"id={added_sq_id} active: True -> False",
-                    )
-                )
-            except Exception as exc:
-                results.append(CheckResult("search_query_toggle", Status.FAIL, str(exc)))
-        else:
+
+async def _run_channel_toggle_check(copy_db: Database, results: list[CheckResult]) -> None:
+    try:
+        channels = await copy_db.get_channels_with_counts()
+        if not channels:
             results.append(
-                CheckResult("search_query_toggle", Status.SKIP, "search_query_add failed"),
+                CheckResult("channel_toggle", Status.SKIP, "No channels in DB"),
             )
-
-        # 5. search_query_delete
-        if added_sq_id is not None:
-            try:
-                await sq_repo.delete(added_sq_id)
-                queries = await sq_repo.get_all()
-                found = any(q.id == added_sq_id for q in queries)
-                if found:
-                    raise RuntimeError("search query still present after delete")
-                results.append(
-                    CheckResult(
-                        "search_query_delete",
-                        Status.PASS,
-                        f"id={added_sq_id} deleted, verified absent",
-                    )
-                )
-            except Exception as exc:
-                results.append(CheckResult("search_query_delete", Status.FAIL, str(exc)))
         else:
-            results.append(
-                CheckResult("search_query_delete", Status.SKIP, "search_query_add failed"),
-            )
-
-        # 6. channel_toggle
-        try:
-            channels = await copy_db.get_channels_with_counts()
-            if not channels:
-                results.append(
-                    CheckResult("channel_toggle", Status.SKIP, "No channels in DB"),
-                )
-            else:
-                ch = channels[0]
-                original = ch.is_active
-                await copy_db.set_channel_active(ch.id, not original)
-                refreshed = await copy_db.get_channels_with_counts()
-                toggled = next(c for c in refreshed if c.id == ch.id)
-                if toggled.is_active is not (not original):
-                    raise RuntimeError("channel active state did not change")
-                results.append(
-                    CheckResult(
-                        "channel_toggle",
-                        Status.PASS,
-                        f"id={ch.id} active: {original} -> {not original}",
-                    )
-                )
-        except Exception as exc:
-            results.append(CheckResult("channel_toggle", Status.FAIL, str(exc)))
-
-        # 7. filter_apply
-        try:
-            analyzer = ChannelAnalyzer(copy_db)
-            report = await analyzer.analyze_all()
-            count = await analyzer.apply_filters(report)
+            ch = channels[0]
+            original = ch.is_active
+            await copy_db.set_channel_active(ch.id, not original)
+            refreshed = await copy_db.get_channels_with_counts()
+            toggled = next(c for c in refreshed if c.id == ch.id)
+            if toggled.is_active is not (not original):
+                raise RuntimeError("channel active state did not change")
             results.append(
                 CheckResult(
-                    "filter_apply",
+                    "channel_toggle",
                     Status.PASS,
-                    f"{count} channels filtered",
+                    f"id={ch.id} active: {original} -> {not original}",
                 )
             )
-        except Exception as exc:
-            results.append(CheckResult("filter_apply", Status.FAIL, str(exc)))
+    except Exception as exc:
+        results.append(CheckResult("channel_toggle", Status.FAIL, str(exc)))
 
-        # 8. filter_reset
-        try:
-            analyzer = ChannelAnalyzer(copy_db)
-            await analyzer.reset_filters()
-            results.append(CheckResult("filter_reset", Status.PASS, "Filters cleared"))
-        except Exception as exc:
-            results.append(CheckResult("filter_reset", Status.FAIL, str(exc)))
 
-    finally:
-        if copy_db:
-            await copy_db.close()
+async def _run_filter_apply_check(copy_db: Database, results: list[CheckResult]) -> None:
+    try:
+        analyzer = ChannelAnalyzer(copy_db)
+        report = await analyzer.analyze_all()
+        count = await analyzer.apply_filters(report)
+        results.append(
+            CheckResult(
+                "filter_apply",
+                Status.PASS,
+                f"{count} channels filtered",
+            )
+        )
+    except Exception as exc:
+        results.append(CheckResult("filter_apply", Status.FAIL, str(exc)))
 
-    # 9. write_cleanup
+
+async def _run_filter_reset_check(copy_db: Database, results: list[CheckResult]) -> None:
+    try:
+        analyzer = ChannelAnalyzer(copy_db)
+        await analyzer.reset_filters()
+        results.append(CheckResult("filter_reset", Status.PASS, "Filters cleared"))
+    except Exception as exc:
+        results.append(CheckResult("filter_reset", Status.FAIL, str(exc)))
+
+
+async def _run_write_cleanup_check(tmp_path: str | None, results: list[CheckResult]) -> None:
     try:
         if tmp_path:
             os.unlink(tmp_path)
@@ -623,6 +638,30 @@ async def _run_write_checks(config_path: str) -> list[CheckResult]:
     except Exception as exc:
         results.append(CheckResult("write_cleanup", Status.FAIL, str(exc)))
 
+
+async def _run_write_mutation_checks(copy_db: Database, results: list[CheckResult]) -> None:
+    await _run_account_toggle_check(copy_db, results)
+    sq_repo, added_sq_id = await _run_search_query_add_check(copy_db, results)
+    await _run_search_query_toggle_check(sq_repo, added_sq_id, results)
+    await _run_search_query_delete_check(sq_repo, added_sq_id, results)
+    await _run_channel_toggle_check(copy_db, results)
+    await _run_filter_apply_check(copy_db, results)
+    await _run_filter_reset_check(copy_db, results)
+
+
+async def _run_write_checks(config_path: str) -> list[CheckResult]:
+    results: list[CheckResult] = []
+    copy_db, tmp_path = await _run_write_db_copy_check(config_path, results)
+    if copy_db is None:
+        return results
+
+    try:
+        await _run_write_mutation_checks(copy_db, results)
+    finally:
+        if copy_db:
+            await copy_db.close()
+
+    await _run_write_cleanup_check(tmp_path, results)
     return results
 
 
@@ -802,322 +841,394 @@ def _skip_remaining_tg_checks(results: list, reason: str, names: list[str]) -> N
         results.append(CheckResult(name, Status.SKIP, reason))
 
 
-async def _run_telegram_live_checks(config_path: str) -> list[CheckResult]:
-    from src.search.engine import SearchEngine
-    from src.telegram.collector import Collector
+async def _abort_tg_live_step(state: TelegramLiveCheckState, name: str, exc: BaseException) -> None:
+    state.results.append(CheckResult(name, Status.SKIP, str(exc)))
+    await _cleanup_telegram(state.pool, state.copy_db, state.tmp_path, state.results)
 
-    results: list[CheckResult] = []
-    copy_db: Database | None = None
-    tmp_path: str | None = None
-    pool = None
 
-    async def _abort_skip(name: str, exc: BaseException) -> None:
-        results.append(CheckResult(name, Status.SKIP, str(exc)))
-        await _cleanup_telegram(pool, copy_db, tmp_path, results)
-
-    async def _op_step(name, op, on_success) -> bool:
-        """Run a flood-policy op; append on_success(value) or FAIL. Returns
-        False (→ caller must `return results`) only when a step SKIP aborts the
-        run (cleanup already performed); True to continue."""
-        try:
-            value = await _run_operation_with_flood_policy(op, pool=pool, check_name=name)
-            results.append(on_success(value))
-            return True
-        except TelegramLiveStepSkipError as exc:
-            await _abort_skip(name, exc)
-            return False
-        except Exception as exc:
-            results.append(CheckResult(name, Status.FAIL, _format_exception(exc)))
-            return True
-
-    async def _search_step(name, run) -> bool:
-        """Like _op_step but `run()` directly yields a CheckResult (search ops)."""
-        try:
-            results.append(await run())
-            return True
-        except TelegramLiveStepSkipError as exc:
-            await _abort_skip(name, exc)
-            return False
-        except Exception as exc:
-            results.append(CheckResult(name, Status.FAIL, _format_exception(exc)))
-            return True
-
-    # 1. tg_db_copy
+async def _run_tg_operation_step(state: TelegramLiveCheckState, name, op, on_success) -> bool:
+    """Run a flood-policy op; return False only when cleanup already ran."""
     try:
-        copy_db, tmp_path, config = await _init_db_copy(config_path)
-        results.append(CheckResult("tg_db_copy", Status.PASS, f"Copied to {tmp_path}"))
+        value = await _run_operation_with_flood_policy(op, pool=state.pool, check_name=name)
+        state.results.append(on_success(value))
+        return True
+    except TelegramLiveStepSkipError as exc:
+        await _abort_tg_live_step(state, name, exc)
+        return False
     except Exception as exc:
-        results.append(CheckResult("tg_db_copy", Status.FAIL, str(exc)))
-        return results
+        state.results.append(CheckResult(name, Status.FAIL, _format_exception(exc)))
+        return True
 
-    # 2. tg_pool_init
+
+async def _run_tg_search_step(state: TelegramLiveCheckState, name, run) -> bool:
     try:
-        _, pool = await _tg_call(
-            runtime.init_pool(config, copy_db),
+        state.results.append(await run())
+        return True
+    except TelegramLiveStepSkipError as exc:
+        await _abort_tg_live_step(state, name, exc)
+        return False
+    except Exception as exc:
+        state.results.append(CheckResult(name, Status.FAIL, _format_exception(exc)))
+        return True
+
+
+async def _run_tg_db_copy_step(state: TelegramLiveCheckState) -> bool:
+    try:
+        state.copy_db, state.tmp_path, state.config = await _init_db_copy(state.config_path)
+        state.results.append(CheckResult("tg_db_copy", Status.PASS, f"Copied to {state.tmp_path}"))
+        return True
+    except Exception as exc:
+        state.results.append(CheckResult("tg_db_copy", Status.FAIL, str(exc)))
+        return False
+
+
+async def _run_tg_pool_init_step(state: TelegramLiveCheckState) -> bool:
+    try:
+        _, state.pool = await _tg_call(
+            runtime.init_pool(state.config, state.copy_db),
             check_name="tg_pool_init",
         )
-        clients = pool.clients if hasattr(pool, "clients") else {}
+        clients = state.pool.clients if hasattr(state.pool, "clients") else {}
         if not clients:
-            results.append(CheckResult("tg_pool_init", Status.SKIP, "No accounts connected"))
-            _skip_remaining_tg_checks(results, "pool init skipped", _TG_CHECKS_AFTER_POOL)
-            await _cleanup_telegram(pool, copy_db, tmp_path, results)
-            return results
-        await _disable_flood_auto_sleep(pool)
-        results.append(
+            state.results.append(CheckResult("tg_pool_init", Status.SKIP, "No accounts connected"))
+            _skip_remaining_tg_checks(state.results, "pool init skipped", _TG_CHECKS_AFTER_POOL)
+            await _cleanup_telegram(state.pool, state.copy_db, state.tmp_path, state.results)
+            return False
+        await _disable_flood_auto_sleep(state.pool)
+        state.results.append(
             CheckResult("tg_pool_init", Status.PASS, f"{len(clients)} clients connected"),
         )
+        return True
     except HandledFloodWaitError as exc:
-        results.append(CheckResult("tg_pool_init", Status.SKIP, exc.info.detail))
-        _skip_remaining_tg_checks(results, "pool init skipped", _TG_CHECKS_AFTER_POOL)
-        await _cleanup_telegram(pool, copy_db, tmp_path, results)
-        return results
+        state.results.append(CheckResult("tg_pool_init", Status.SKIP, exc.info.detail))
+        _skip_remaining_tg_checks(state.results, "pool init skipped", _TG_CHECKS_AFTER_POOL)
+        await _cleanup_telegram(state.pool, state.copy_db, state.tmp_path, state.results)
+        return False
     except Exception as exc:
-        results.append(CheckResult("tg_pool_init", Status.FAIL, _format_exception(exc)))
-        _skip_remaining_tg_checks(results, "pool init failed", _TG_CHECKS_AFTER_POOL)
-        await _cleanup_telegram(pool, copy_db, tmp_path, results)
-        return results
+        state.results.append(CheckResult("tg_pool_init", Status.FAIL, _format_exception(exc)))
+        _skip_remaining_tg_checks(state.results, "pool init failed", _TG_CHECKS_AFTER_POOL)
+        await _cleanup_telegram(state.pool, state.copy_db, state.tmp_path, state.results)
+        return False
 
-    engine = SearchEngine(copy_db, pool)
 
-    # 3. tg_users_info
-    if not await _op_step(
-        "tg_users_info",
-        lambda: pool.get_users_info(),
-        lambda users: CheckResult("tg_users_info", Status.PASS, ", ".join(u.phone for u in users)),
-    ):
-        return results
-
-    # 4. tg_get_dialogs
-    if not await _op_step(
-        "tg_get_dialogs",
-        lambda: pool.get_dialogs(),
-        lambda dialogs: CheckResult("tg_get_dialogs", Status.PASS, f"{len(dialogs)} dialogs"),
-    ):
-        return results
-
-    # 5. tg_resolve_channel
-    channels = await copy_db.get_channels(active_only=True)
+async def _run_tg_resolve_channel_step(state: TelegramLiveCheckState, channels) -> bool:
     target_with_username = next((ch for ch in channels if ch.username), None)
     if not target_with_username:
-        results.append(
+        state.results.append(
             CheckResult("tg_resolve_channel", Status.SKIP, "No channels with username"),
         )
-    else:
-        try:
-            entity = await _run_operation_with_flood_policy(
-                lambda: pool.resolve_channel(target_with_username.username),
-                pool=pool,
-                check_name="tg_resolve_channel",
+        return True
+
+    try:
+        entity = await _run_operation_with_flood_policy(
+            lambda: state.pool.resolve_channel(target_with_username.username),
+            pool=state.pool,
+            check_name="tg_resolve_channel",
+        )
+        if entity:
+            state.results.append(
+                CheckResult(
+                    "tg_resolve_channel",
+                    Status.PASS,
+                    f"@{target_with_username.username} resolved OK",
+                )
             )
-            if entity:
-                results.append(
-                    CheckResult(
-                        "tg_resolve_channel",
-                        Status.PASS,
-                        f"@{target_with_username.username} resolved OK",
-                    )
+        else:
+            state.results.append(
+                CheckResult(
+                    "tg_resolve_channel",
+                    Status.FAIL,
+                    f"@{target_with_username.username} not resolved",
                 )
-            else:
-                results.append(
-                    CheckResult(
-                        "tg_resolve_channel",
-                        Status.FAIL,
-                        f"@{target_with_username.username} not resolved",
-                    )
-                )
-        except TelegramLiveStepSkipError as exc:
-            results.append(CheckResult("tg_resolve_channel", Status.SKIP, str(exc)))
-            await _cleanup_telegram(pool, copy_db, tmp_path, results)
-            return results
-        except Exception as exc:
-            results.append(CheckResult("tg_resolve_channel", Status.FAIL, _format_exception(exc)))
+            )
+    except TelegramLiveStepSkipError as exc:
+        state.results.append(CheckResult("tg_resolve_channel", Status.SKIP, str(exc)))
+        await _cleanup_telegram(state.pool, state.copy_db, state.tmp_path, state.results)
+        return False
+    except Exception as exc:
+        state.results.append(CheckResult("tg_resolve_channel", Status.FAIL, _format_exception(exc)))
+    return True
 
-    # Refresh entity cache (StringSession loses it between restarts)
-    warm_result = await _run_warm_dialog_cache_step(pool)
-    results.append(warm_result)
+
+async def _run_tg_warm_dialog_cache_live_step(state: TelegramLiveCheckState) -> bool:
+    warm_result = await _run_warm_dialog_cache_step(state.pool)
+    state.results.append(warm_result)
     if warm_result.status == Status.SKIP:
-        await _cleanup_telegram(pool, copy_db, tmp_path, results)
-        return results
+        await _cleanup_telegram(state.pool, state.copy_db, state.tmp_path, state.results)
+        return False
+    return True
 
-    # 6. tg_iter_messages — single channel, 10 messages
-    active_channels = [ch for ch in channels if ch.is_active]
+
+async def _collect_tg_iter_messages(session, entity, ch, copy_db: Database, collector_cls) -> int:
+    msg_count = 0
+    async for msg in session.stream_messages(entity, limit=10):
+        if msg.text or msg.media:
+            message = Message(
+                channel_id=ch.channel_id,
+                message_id=msg.id,
+                sender_id=msg.sender_id,
+                sender_name=collector_cls._get_sender_name(msg),
+                text=msg.text,
+                media_type=collector_cls._get_media_type(msg),
+                date=(
+                    msg.date.replace(tzinfo=timezone.utc)
+                    if msg.date and msg.date.tzinfo is None
+                    else msg.date
+                ),
+            )
+            await copy_db.insert_message(message)
+            msg_count += 1
+    return msg_count
+
+
+async def _run_tg_iter_messages_for_channel(
+    state: TelegramLiveCheckState,
+    ch,
+    collector_cls,
+) -> bool:
+    while True:
+        client_tuple = await state.pool.get_available_client()
+        if not client_tuple:
+            detail = await _wait_for_available_client_window(state.pool, "tg_iter_messages")
+            if detail is None:
+                continue
+            state.results.append(CheckResult("tg_iter_messages", Status.SKIP, detail))
+            await _cleanup_telegram(state.pool, state.copy_db, state.tmp_path, state.results)
+            return False
+
+        session, phone = client_tuple
+        session = adapt_transport_session(session, disconnect_on_close=False)
+        try:
+            entity = await _tg_call(
+                session.resolve_entity(ch.channel_id),
+                pool=state.pool,
+                phone=phone,
+                check_name="tg_iter_messages",
+            )
+
+            msg_count = await _tg_call(
+                _collect_tg_iter_messages(session, entity, ch, state.copy_db, collector_cls),
+                pool=state.pool,
+                phone=phone,
+                check_name="tg_iter_messages",
+            )
+            state.results.append(
+                CheckResult(
+                    "tg_iter_messages",
+                    Status.PASS,
+                    f"{msg_count} msgs from ch={ch.channel_id}",
+                )
+            )
+            break
+        except HandledFloodWaitError as exc:
+            try:
+                await _handle_live_flood_wait(state.pool, "tg_iter_messages", exc.info)
+            except TelegramLiveStepSkipError as stop_exc:
+                state.results.append(CheckResult("tg_iter_messages", Status.SKIP, str(stop_exc)))
+                await _cleanup_telegram(state.pool, state.copy_db, state.tmp_path, state.results)
+                return False
+            continue
+        except Exception as exc:
+            state.results.append(CheckResult("tg_iter_messages", Status.FAIL, _format_exception(exc)))
+            break
+        finally:
+            await state.pool.release_client(phone)
+    return True
+
+
+async def _run_tg_iter_messages_step(
+    state: TelegramLiveCheckState,
+    active_channels,
+    collector_cls,
+) -> bool:
     if not active_channels:
-        results.append(
+        state.results.append(
             CheckResult("tg_iter_messages", Status.SKIP, "No active channels"),
         )
-    else:
-        ch = active_channels[0]
-        while True:
-            client_tuple = await pool.get_available_client()
-            if not client_tuple:
-                detail = await _wait_for_available_client_window(pool, "tg_iter_messages")
-                if detail is None:
-                    continue
-                results.append(CheckResult("tg_iter_messages", Status.SKIP, detail))
-                await _cleanup_telegram(pool, copy_db, tmp_path, results)
-                return results
+        return True
+    return await _run_tg_iter_messages_for_channel(state, active_channels[0], collector_cls)
 
-            session, phone = client_tuple
-            session = adapt_transport_session(session, disconnect_on_close=False)
-            try:
-                entity = await _tg_call(
-                    session.resolve_entity(ch.channel_id),
-                    pool=pool,
-                    phone=phone,
-                    check_name="tg_iter_messages",
-                )
 
-                async def _collect_messages() -> int:
-                    msg_count = 0
-                    async for msg in session.stream_messages(entity, limit=10):
-                        if msg.text or msg.media:
-                            message = Message(
-                                channel_id=ch.channel_id,
-                                message_id=msg.id,
-                                sender_id=msg.sender_id,
-                                sender_name=Collector._get_sender_name(msg),
-                                text=msg.text,
-                                media_type=Collector._get_media_type(msg),
-                                date=(
-                                    msg.date.replace(tzinfo=timezone.utc)
-                                    if msg.date and msg.date.tzinfo is None
-                                    else msg.date
-                                ),
-                            )
-                            await copy_db.insert_message(message)
-                            msg_count += 1
-                    return msg_count
-
-                msg_count = await _tg_call(
-                    _collect_messages(),
-                    pool=pool,
-                    phone=phone,
-                    check_name="tg_iter_messages",
-                )
-                results.append(
-                    CheckResult(
-                        "tg_iter_messages",
-                        Status.PASS,
-                        f"{msg_count} msgs from ch={ch.channel_id}",
-                    )
-                )
-                break
-            except HandledFloodWaitError as exc:
-                try:
-                    await _handle_live_flood_wait(pool, "tg_iter_messages", exc.info)
-                except TelegramLiveStepSkipError as stop_exc:
-                    results.append(CheckResult("tg_iter_messages", Status.SKIP, str(stop_exc)))
-                    await _cleanup_telegram(pool, copy_db, tmp_path, results)
-                    return results
-                continue
-            except Exception as exc:
-                results.append(CheckResult("tg_iter_messages", Status.FAIL, _format_exception(exc)))
-                break
-            finally:
-                await pool.release_client(phone)
-
-    # 7. tg_channel_stats
+async def _run_tg_channel_stats_step(
+    state: TelegramLiveCheckState,
+    active_channels,
+    collector_cls,
+) -> bool:
     if not active_channels:
-        results.append(
+        state.results.append(
             CheckResult("tg_channel_stats", Status.SKIP, "No active channels"),
         )
-    else:
-        ch = active_channels[0]
-        collector = Collector(pool, copy_db, config.scheduler)
+        return True
+    ch = active_channels[0]
+    collector = collector_cls(state.pool, state.copy_db, state.config.scheduler)
 
-        def _stats_result(stats) -> CheckResult:
-            if stats:
-                return CheckResult(
-                    "tg_channel_stats", Status.PASS, f"ch={ch.channel_id} subs={stats.subscriber_count}"
-                )
+    def _stats_result(stats) -> CheckResult:
+        if stats:
             return CheckResult(
-                "tg_channel_stats", Status.PASS, f"ch={ch.channel_id} stats=None (no data)"
+                "tg_channel_stats",
+                Status.PASS,
+                f"ch={ch.channel_id} subs={stats.subscriber_count}",
             )
-
-        if not await _op_step(
+        return CheckResult(
             "tg_channel_stats",
-            lambda: collector.collect_channel_stats(ch),
-            _stats_result,
-        ):
-            return results
+            Status.PASS,
+            f"ch={ch.channel_id} stats=None (no data)",
+        )
 
-    # 8. tg_search_my_chats
-    if not await _search_step(
+    return await _run_tg_operation_step(
+        state,
+        "tg_channel_stats",
+        lambda: collector.collect_channel_stats(ch),
+        _stats_result,
+    )
+
+
+async def _run_tg_search_my_chats_step(state: TelegramLiveCheckState) -> bool:
+    return await _run_tg_search_step(
+        state,
         "tg_search_my_chats",
         lambda: _run_search_operation(
-            lambda: engine.search_my_chats("test", limit=5),
-            pool=pool,
+            lambda: state.engine.search_my_chats("test", limit=5),
+            pool=state.pool,
             check_name="tg_search_my_chats",
             success_detail_factory=lambda result: f"{result.total} results",
         ),
-    ):
-        return results
+    )
 
-    # 9. tg_search_in_channel
+
+async def _run_tg_search_in_channel_step(state: TelegramLiveCheckState, channels) -> bool:
     if not channels:
-        results.append(
+        state.results.append(
             CheckResult("tg_search_in_channel", Status.SKIP, "No channels"),
         )
-    else:
-        ch = channels[0]
-        if not await _search_step(
-            "tg_search_in_channel",
-            lambda: _run_search_operation(
-                lambda: engine.search_in_channel(ch.channel_id, "test", limit=5),
-                pool=pool,
-                check_name="tg_search_in_channel",
-                success_detail_factory=lambda result: f"ch={ch.channel_id}: {result.total} results",
-            ),
-        ):
-            return results
+        return True
+    ch = channels[0]
+    return await _run_tg_search_step(
+        state,
+        "tg_search_in_channel",
+        lambda: _run_search_operation(
+            lambda: state.engine.search_in_channel(ch.channel_id, "test", limit=5),
+            pool=state.pool,
+            check_name="tg_search_in_channel",
+            success_detail_factory=lambda result: f"ch={ch.channel_id}: {result.total} results",
+        ),
+    )
 
-    # 10. tg_search_premium
-    if not await _search_step(
+
+async def _run_tg_search_premium_step(state: TelegramLiveCheckState) -> bool:
+    return await _run_tg_search_step(
+        state,
         "tg_search_premium",
         lambda: _run_search_operation(
-            lambda: engine.search_telegram("test", limit=5),
-            pool=pool,
+            lambda: state.engine.search_telegram("test", limit=5),
+            pool=state.pool,
             check_name="tg_search_premium",
             success_detail_factory=lambda result: f"{result.total} results",
             premium_error_is_skip=True,
         ),
-    ):
-        return results
+    )
 
-    # 11. tg_search_quota
+
+async def _run_tg_search_quota_step(state: TelegramLiveCheckState) -> bool:
     try:
         while True:
             quota = await _run_operation_with_flood_policy(
-                lambda: engine.check_search_quota("test"),
-                pool=pool,
+                lambda: state.engine.check_search_quota("test"),
+                pool=state.pool,
                 check_name="tg_search_quota",
             )
             if quota is not None:
                 detail = str(quota) if quota else "No quota info"
-                results.append(CheckResult("tg_search_quota", Status.PASS, detail))
+                state.results.append(CheckResult("tg_search_quota", Status.PASS, detail))
                 break
 
             detail = await _wait_for_available_client_window(
-                pool,
+                state.pool,
                 "tg_search_quota",
                 premium=True,
                 base_detail="No premium account or quota unavailable",
             )
             if detail is None:
                 continue
-            results.append(CheckResult("tg_search_quota", Status.SKIP, detail))
+            state.results.append(CheckResult("tg_search_quota", Status.SKIP, detail))
             break
     except TelegramLiveStepSkipError as exc:
-        results.append(CheckResult("tg_search_quota", Status.SKIP, str(exc)))
-        await _cleanup_telegram(pool, copy_db, tmp_path, results)
-        return results
+        state.results.append(CheckResult("tg_search_quota", Status.SKIP, str(exc)))
+        await _cleanup_telegram(state.pool, state.copy_db, state.tmp_path, state.results)
+        return False
     except Exception as exc:
-        results.append(CheckResult("tg_search_quota", Status.FAIL, _format_exception(exc)))
+        state.results.append(CheckResult("tg_search_quota", Status.FAIL, _format_exception(exc)))
+    return True
+
+
+async def _run_telegram_live_checks(config_path: str) -> list[CheckResult]:
+    from src.search.engine import SearchEngine
+    from src.telegram.collector import Collector
+
+    state = TelegramLiveCheckState(config_path=config_path, results=[])
+    if not await _run_tg_db_copy_step(state):
+        return state.results
+    if not await _run_tg_pool_init_step(state):
+        return state.results
+
+    state.engine = SearchEngine(state.copy_db, state.pool)
+
+    # 3. tg_users_info
+    if not await _run_tg_operation_step(
+        state,
+        "tg_users_info",
+        lambda: state.pool.get_users_info(),
+        lambda users: CheckResult("tg_users_info", Status.PASS, ", ".join(u.phone for u in users)),
+    ):
+        return state.results
+
+    # 4. tg_get_dialogs
+    if not await _run_tg_operation_step(
+        state,
+        "tg_get_dialogs",
+        lambda: state.pool.get_dialogs(),
+        lambda dialogs: CheckResult("tg_get_dialogs", Status.PASS, f"{len(dialogs)} dialogs"),
+    ):
+        return state.results
+
+    # 5. tg_resolve_channel
+    channels = await state.copy_db.get_channels(active_only=True)
+    if not await _run_tg_resolve_channel_step(state, channels):
+        return state.results
+
+    # Refresh entity cache (StringSession loses it between restarts)
+    if not await _run_tg_warm_dialog_cache_live_step(state):
+        return state.results
+
+    # 6. tg_iter_messages — single channel, 10 messages
+    active_channels = [ch for ch in channels if ch.is_active]
+    if not await _run_tg_iter_messages_step(state, active_channels, Collector):
+        return state.results
+
+    # 7. tg_channel_stats
+    if not await _run_tg_channel_stats_step(state, active_channels, Collector):
+        return state.results
+
+    # 8. tg_search_my_chats
+    if not await _run_tg_search_my_chats_step(state):
+        return state.results
+
+    # 9. tg_search_in_channel
+    if not await _run_tg_search_in_channel_step(state, channels):
+        return state.results
+
+    # 10. tg_search_premium
+    if not await _run_tg_search_premium_step(state):
+        return state.results
+
+    # 11. tg_search_quota
+    if not await _run_tg_search_quota_step(state):
+        return state.results
 
     # 12. tg_cleanup
-    await _cleanup_telegram(pool, copy_db, tmp_path, results)
+    await _cleanup_telegram(state.pool, state.copy_db, state.tmp_path, state.results)
 
-    return results
+    return state.results
 
 
 async def _cleanup_telegram(pool, copy_db, tmp_path, results) -> None:


### PR DESCRIPTION

## What

#1131 batch 2: behavior-preserving split of two `src/cli/commands/test.py` rank-E functions into private helpers in the same file.

| Function | Before | After |
|---|---:|---:|
| `_run_telegram_live_checks` | E(37) | C(16) |
| `_run_write_checks` | E(31) | A(3) |

`python scripts/code_health.py --top 40`: rank-E count 6 -> 4; target functions dropped out of rank-E/top-40.

## No behavior change proof

AST harness was run as one-off stdin script, not committed. It compared merge-base `1b6a920cff56` original blocks with extracted helper bodies after normalizing wrapper-only state bindings (`state.*`) and return sentinels.

Result: `AST equivalence OK: 26 block/call comparisons against 1b6a920cff56`.

Covered blocks included all write steps (`write_db_copy`, account/search/channel/filter/cleanup) plus Telegram live steps (`tg_db_copy`, pool init, op/search wrappers, resolve, warm dialog cache, iter messages, stats, search calls, quota, cleanup tail).

## Validation

- `python scripts/code_health.py --top 40`
- `python -m radon cc -s src/cli/commands/test.py | rg "_run_telegram_live_checks|_run_write_checks"`
- `pytest tests/test_cli_extended.py -n 0 -q` -> 34 passed
- `pytest tests/test_regression_rw_flood.py::TestWriteChecks -n 0 -q` -> 2 passed
- `pytest tests/test_cli_pipeline_helpers.py::test_cli_test_constants tests/test_cli_pipeline_helpers.py::test_cli_test_check_result -n 0 -q` -> 2 passed
- `pytest tests/test_regression_rw_flood.py -n 0 -q` -> 39 passed
- `pytest tests/test_regression_agent_tools_misc.py::TestAgentManagerEdge -n 0 -q` -> 7 passed
- `ruff check src/ tests/ conftest.py`
- `git diff --check`

Wide `pytest tests/ -n auto` intentionally not run per batch brief due known provider flakes.

Part of #1131
