### PR TITLE
refactor: reduce hot-path cyclomatic complexity

### DIFF
--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -129,6 +129,193 @@ class _ChatStreamState:
         self.streamed = False
 
 
+async def _dispatch_rate_limit_event(
+    msg: RateLimitEvent,
+    *,
+    tracker: _ToolTracker,
+    queue: asyncio.Queue,
+    last_rate_limit: list[str],
+    thread_id: int,
+) -> None:
+    info = msg.rate_limit_info
+    rl_status = info.status if info else "unknown"
+    resets = info.resets_at if info else None
+    utilization = info.utilization if info else None
+    logger.warning(
+        "Rate limit event (thread %d): status=%s, resets_at=%s, utilization=%s",
+        thread_id, rl_status, resets, utilization,
+    )
+    rl_parts = [rl_status]
+    if utilization is not None:
+        rl_parts.append(f"{utilization:.0%}")
+    rl_summary = ", ".join(rl_parts)
+    rl_text = f"Rate limit: {rl_summary}"
+    last_rate_limit[0] = rl_summary
+    if rl_status == "rejected":
+        # Hard reject — surface as warning, not just status
+        await queue.put(_sse({"type": "warning", "text": f"⛔ {rl_text}. API отклоняет запросы."}))
+    else:
+        await tracker.on_status(rl_text)
+
+
+async def _dispatch_content_block_start(
+    event: dict[str, Any],
+    *,
+    tracker: _ToolTracker,
+    last_activity: list[float],
+    thread_id: int,
+) -> None:
+    block = event.get("content_block", {})
+    block_type = block.get("type")
+    if block_type == "tool_use":
+        last_activity[0] = time.monotonic()
+        await tracker.on_tool_start(
+            block.get("name", "unknown"),
+            event.get("index", 0),
+            tool_use_id=block.get("id", ""),
+        )
+    else:
+        logger.debug(
+            "content_block_start type=%s (thread %d)",
+            block_type, thread_id,
+        )
+
+
+async def _dispatch_content_block_delta(
+    event: dict[str, Any],
+    *,
+    tracker: _ToolTracker,
+    queue: asyncio.Queue,
+    state: _ChatStreamState,
+    last_activity: list[float],
+) -> None:
+    delta = event.get("delta", {})
+    delta_type = delta.get("type")
+    if delta_type == "text_delta":
+        text_chunk = delta.get("text", "")
+        if text_chunk:
+            last_activity[0] = time.monotonic()
+            state.full_text += text_chunk
+            state.streamed = True
+            await queue.put(_sse({"text": text_chunk}))
+            await asyncio.sleep(0)
+    elif delta_type == "input_json_delta":
+        last_activity[0] = time.monotonic()
+        tracker.accumulate_input(delta.get("partial_json", ""))
+
+
+async def _dispatch_stream_error_event(
+    event: dict[str, Any],
+    *,
+    thread_id: int,
+) -> None:
+    error_info = event.get("error", {})
+    api_error_type = error_info.get("type", "unknown")
+    api_error_msg = error_info.get("message", str(error_info))
+    logger.warning(
+        "API stream error event (thread %d): type=%s message=%s",
+        thread_id, api_error_type, api_error_msg,
+    )
+    if api_error_type == "overloaded_error":
+        raise CLIConnectionError(f"API overloaded: {api_error_msg}")
+    raise ClaudeSDKError(f"{api_error_type}: {api_error_msg}")
+
+
+async def _dispatch_stream_event(
+    msg: StreamEvent,
+    *,
+    tracker: _ToolTracker,
+    queue: asyncio.Queue,
+    state: _ChatStreamState,
+    last_activity: list[float],
+    thread_id: int,
+) -> None:
+    event = msg.event
+    event_type = event.get("type")
+    await tracker.on_first_event()
+
+    if event_type == "content_block_start":
+        await _dispatch_content_block_start(
+            event,
+            tracker=tracker,
+            last_activity=last_activity,
+            thread_id=thread_id,
+        )
+    elif event_type == "content_block_delta":
+        await _dispatch_content_block_delta(
+            event,
+            tracker=tracker,
+            queue=queue,
+            state=state,
+            last_activity=last_activity,
+        )
+    elif event_type == "content_block_stop":
+        last_activity[0] = time.monotonic()
+        await tracker.on_block_stop(event.get("index", 0))
+    elif event_type == "error":
+        await _dispatch_stream_error_event(event, thread_id=thread_id)
+
+
+async def _dispatch_assistant_message(
+    msg: AssistantMessage,
+    *,
+    tracker: _ToolTracker,
+    queue: asyncio.Queue,
+    state: _ChatStreamState,
+    last_activity: list[float],
+) -> None:
+    last_activity[0] = time.monotonic()
+    for _idx, block in enumerate(msg.content):
+        if isinstance(block, TextBlock) and not state.streamed:
+            state.full_text += block.text
+            await queue.put(_sse({"text": block.text}))
+        elif isinstance(block, ToolUseBlock):
+            # SDK delivers tool calls via AssistantMessage (not
+            # StreamEvent content_block_start), so we must
+            # manually emit tool_start / tool_end events here.
+            await tracker.on_tool_start(
+                block.name, _idx, tool_use_id=block.id
+            )
+            tracker.accumulate_input(
+                safe_json_dumps(block.input or {}, ensure_ascii=False)
+            )
+            await tracker.on_block_stop(_idx)
+        elif isinstance(block, ToolResultBlock):
+            content = block.content if isinstance(block.content, str) else ""
+            await tracker.on_tool_result(
+                block.tool_use_id, content, bool(block.is_error)
+            )
+
+
+async def _dispatch_result_message(
+    msg: ResultMessage,
+    *,
+    queue: asyncio.Queue,
+    state: _ChatStreamState,
+) -> None:
+    done_data: dict = {
+        "done": True,
+        "full_text": state.full_text,
+        "backend": "claude",
+    }
+    _usage = getattr(msg, "usage", None)
+    if isinstance(_usage, dict):
+        done_data["usage"] = _usage
+    _model_usage = getattr(msg, "model_usage", None)
+    if isinstance(_model_usage, dict):
+        done_data["model_usage"] = _model_usage
+    _cost = getattr(msg, "total_cost_usd", None)
+    if isinstance(_cost, (int, float)):
+        done_data["total_cost_usd"] = _cost
+    _turns = getattr(msg, "num_turns", None)
+    if isinstance(_turns, int) and _turns > 0:
+        done_data["num_turns"] = _turns
+    _sid = getattr(msg, "session_id", None)
+    if isinstance(_sid, str) and _sid:
+        done_data["session_id"] = _sid
+    await queue.put(_sse(done_data))
+
+
 async def _dispatch_stream_message(
     msg,
     *,
@@ -144,124 +331,35 @@ async def _dispatch_stream_message(
     / ClaudeSDKError for API stream-error events (the caller's retry loop owns
     them); asyncio.CancelledError propagates for the caller's draining handling."""
     if isinstance(msg, RateLimitEvent):
-        info = msg.rate_limit_info
-        rl_status = info.status if info else "unknown"
-        resets = info.resets_at if info else None
-        utilization = info.utilization if info else None
-        logger.warning(
-            "Rate limit event (thread %d): status=%s, resets_at=%s, utilization=%s",
-            thread_id, rl_status, resets, utilization,
+        await _dispatch_rate_limit_event(
+            msg,
+            tracker=tracker,
+            queue=queue,
+            last_rate_limit=last_rate_limit,
+            thread_id=thread_id,
         )
-        rl_parts = [rl_status]
-        if utilization is not None:
-            rl_parts.append(f"{utilization:.0%}")
-        rl_summary = ", ".join(rl_parts)
-        rl_text = f"Rate limit: {rl_summary}"
-        last_rate_limit[0] = rl_summary
-        if rl_status == "rejected":
-            # Hard reject — surface as warning, not just status
-            await queue.put(_sse({"type": "warning", "text": f"⛔ {rl_text}. API отклоняет запросы."}))
-        else:
-            await tracker.on_status(rl_text)
     elif isinstance(msg, StreamEvent):
-        event = msg.event
-        event_type = event.get("type")
-        await tracker.on_first_event()
-
-        if event_type == "content_block_start":
-            block = event.get("content_block", {})
-            block_type = block.get("type")
-            if block_type == "tool_use":
-                last_activity[0] = time.monotonic()
-                await tracker.on_tool_start(
-                    block.get("name", "unknown"),
-                    event.get("index", 0),
-                    tool_use_id=block.get("id", ""),
-                )
-            else:
-                logger.debug(
-                    "content_block_start type=%s (thread %d)",
-                    block_type, thread_id,
-                )
-
-        elif event_type == "content_block_delta":
-            delta = event.get("delta", {})
-            delta_type = delta.get("type")
-            if delta_type == "text_delta":
-                text_chunk = delta.get("text", "")
-                if text_chunk:
-                    last_activity[0] = time.monotonic()
-                    state.full_text += text_chunk
-                    state.streamed = True
-                    await queue.put(_sse({"text": text_chunk}))
-                    await asyncio.sleep(0)
-            elif delta_type == "input_json_delta":
-                last_activity[0] = time.monotonic()
-                tracker.accumulate_input(delta.get("partial_json", ""))
-
-        elif event_type == "content_block_stop":
-            last_activity[0] = time.monotonic()
-            await tracker.on_block_stop(event.get("index", 0))
-
-        elif event_type == "error":
-            error_info = event.get("error", {})
-            api_error_type = error_info.get("type", "unknown")
-            api_error_msg = error_info.get("message", str(error_info))
-            logger.warning(
-                "API stream error event (thread %d): type=%s message=%s",
-                thread_id, api_error_type, api_error_msg,
-            )
-            if api_error_type == "overloaded_error":
-                raise CLIConnectionError(f"API overloaded: {api_error_msg}")
-            raise ClaudeSDKError(f"{api_error_type}: {api_error_msg}")
-
+        await _dispatch_stream_event(
+            msg,
+            tracker=tracker,
+            queue=queue,
+            state=state,
+            last_activity=last_activity,
+            thread_id=thread_id,
+        )
     elif isinstance(msg, AssistantMessage):
-        last_activity[0] = time.monotonic()
-        for _idx, block in enumerate(msg.content):
-            if isinstance(block, TextBlock) and not state.streamed:
-                state.full_text += block.text
-                await queue.put(_sse({"text": block.text}))
-            elif isinstance(block, ToolUseBlock):
-                # SDK delivers tool calls via AssistantMessage (not
-                # StreamEvent content_block_start), so we must
-                # manually emit tool_start / tool_end events here.
-                await tracker.on_tool_start(
-                    block.name, _idx, tool_use_id=block.id
-                )
-                tracker.accumulate_input(
-                    safe_json_dumps(block.input or {}, ensure_ascii=False)
-                )
-                await tracker.on_block_stop(_idx)
-            elif isinstance(block, ToolResultBlock):
-                content = block.content if isinstance(block.content, str) else ""
-                await tracker.on_tool_result(
-                    block.tool_use_id, content, bool(block.is_error)
-                )
+        await _dispatch_assistant_message(
+            msg,
+            tracker=tracker,
+            queue=queue,
+            state=state,
+            last_activity=last_activity,
+        )
     elif isinstance(msg, UserMessage):
         # Tool results sent back to Claude — real progress.
         last_activity[0] = time.monotonic()
     elif isinstance(msg, ResultMessage):
-        done_data: dict = {
-            "done": True,
-            "full_text": state.full_text,
-            "backend": "claude",
-        }
-        _usage = getattr(msg, "usage", None)
-        if isinstance(_usage, dict):
-            done_data["usage"] = _usage
-        _model_usage = getattr(msg, "model_usage", None)
-        if isinstance(_model_usage, dict):
-            done_data["model_usage"] = _model_usage
-        _cost = getattr(msg, "total_cost_usd", None)
-        if isinstance(_cost, (int, float)):
-            done_data["total_cost_usd"] = _cost
-        _turns = getattr(msg, "num_turns", None)
-        if isinstance(_turns, int) and _turns > 0:
-            done_data["num_turns"] = _turns
-        _sid = getattr(msg, "session_id", None)
-        if isinstance(_sid, str) and _sid:
-            done_data["session_id"] = _sid
-        await queue.put(_sse(done_data))
+        await _dispatch_result_message(msg, queue=queue, state=state)
     else:
         logger.warning(
             "Unhandled SDK message type: %s (thread %d)",

--- a/src/web/bootstrap.py
+++ b/src/web/bootstrap.py
@@ -392,12 +392,12 @@ async def build_container_with_templates(
     )
 
 
-async def start_container(container: AppContainer) -> None:
-    t_start = time.monotonic()
-    runtime_mode = getattr(container, "runtime_mode", "worker")
-    if _is_dev:
-        t1 = time.monotonic()
-
+async def _recover_startup_state(
+    container: AppContainer,
+    *,
+    runtime_mode: str,
+    t_start: float,
+) -> None:
     # Startup recovery resets RUNNING rows on the shared SQLite file. In a split
     # deploy (serve --no-worker + separate worker) a web restart must NOT touch
     # the live worker's in-flight photo/generation/command rows, or it corrupts
@@ -416,6 +416,14 @@ async def start_container(container: AppContainer) -> None:
                 "Reset %d stuck telegram_commands from RUNNING to PENDING on startup", tc_recovered
             )
     logger.info("startup: recovery done (%.1fs)", time.monotonic() - t_start)
+
+
+async def _initialize_startup_telegram_pool(
+    container: AppContainer,
+    *,
+    runtime_mode: str,
+    t_start: float,
+) -> None:
     if _is_dev:
         t1 = time.monotonic()
 
@@ -459,6 +467,13 @@ async def start_container(container: AppContainer) -> None:
     if _is_dev:
         logger.info("startup/start: telegram_pool %.2fs", time.monotonic() - t1)
 
+
+async def _start_collection_queue(
+    container: AppContainer,
+    *,
+    runtime_mode: str,
+    t_start: float,
+) -> None:
     if runtime_mode == "worker" and container.collection_queue is not None:
         if container.auth.is_configured and _connected_pool_count(container.pool) == 0:
             logger.warning(
@@ -477,8 +492,16 @@ async def start_container(container: AppContainer) -> None:
         container.collection_queue.start_db_pull()
     logger.info("startup: collection queue done (%.1fs)", time.monotonic() - t_start)
 
+
+async def _start_dispatchers_ai_and_agent(
+    container: AppContainer,
+    *,
+    runtime_mode: str,
+    t_start: float,
+) -> float | None:
     if _is_dev:
         t1 = time.monotonic()
+
     if runtime_mode == "worker" and container.unified_dispatcher is not None:
         result = container.unified_dispatcher.start()
         if inspect.isawaitable(result):
@@ -500,7 +523,15 @@ async def start_container(container: AppContainer) -> None:
     if _is_dev:
         logger.info("startup/start: dispatcher+ai+agent %.2fs", time.monotonic() - t1)
         t1 = time.monotonic()
+    return t1 if _is_dev else None
 
+
+async def _start_scheduler(
+    container: AppContainer,
+    *,
+    runtime_mode: str,
+    t_start: float,
+) -> None:
     if runtime_mode == "worker":
         await container.scheduler.load_settings()
         autostart = await container.db.get_setting("scheduler_autostart")
@@ -508,9 +539,32 @@ async def start_container(container: AppContainer) -> None:
             logger.info("Auto-starting scheduler (scheduler_autostart=1)")
             await container.scheduler.start()
     logger.info("startup: scheduler done (%.1fs)", time.monotonic() - t_start)
+
+
+async def start_container(container: AppContainer) -> None:
+    t_start = time.monotonic()
+    runtime_mode = getattr(container, "runtime_mode", "worker")
+
+    await _recover_startup_state(container, runtime_mode=runtime_mode, t_start=t_start)
+    await _initialize_startup_telegram_pool(
+        container,
+        runtime_mode=runtime_mode,
+        t_start=t_start,
+    )
+    await _start_collection_queue(container, runtime_mode=runtime_mode, t_start=t_start)
+    scheduler_dev_started_at = await _start_dispatchers_ai_and_agent(
+        container,
+        runtime_mode=runtime_mode,
+        t_start=t_start,
+    )
+    await _start_scheduler(
+        container,
+        runtime_mode=runtime_mode,
+        t_start=t_start,
+    )
     logger.info("startup: READY (total %.1fs)", time.monotonic() - t_start)
-    if _is_dev:
-        logger.info("startup/start: scheduler %.2fs", time.monotonic() - t1)
+    if _is_dev and scheduler_dev_started_at is not None:
+        logger.info("startup/start: scheduler %.2fs", time.monotonic() - scheduler_dev_started_at)
         logger.info("startup/start: TOTAL %.2fs", time.monotonic() - t_start)
 
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -355,6 +356,82 @@ async def test_start_container_continues_when_pool_init_decrypt_fails(tmp_path, 
         container.pool.warm_all_dialogs.assert_not_called()
     finally:
         await db.close()
+
+
+@pytest.mark.anyio
+async def test_start_container_worker_startup_phase_order(tmp_path):
+    """Worker startup keeps the load-bearing service phase order."""
+    db = Database(str(tmp_path / "test.db"))
+    await db.initialize()
+    await db.set_setting("scheduler_autostart", "1")
+
+    order: list[str] = []
+
+    def sync_step(name: str):
+        def _step(*_args, **_kwargs):
+            order.append(name)
+
+        return _step
+
+    def async_step(name: str, result=0):
+        async def _step(*_args, **_kwargs):
+            order.append(name)
+            return result
+
+        return _step
+
+    class OrderedPool:
+        clients = {"connected": object()}
+
+        async def initialize(self):
+            order.append("pool.initialize")
+
+    container = _make_container(db)
+    container.runtime_mode = "worker"
+    container.auth.is_configured = True
+    container.pool = OrderedPool()
+    container.photo_task_service.recover_running = async_step("recover.photo")
+    container.db.repos.generation_runs.reset_running_on_startup = async_step("recover.generation")
+    container.db.repos.telegram_commands.reset_running_on_startup = async_step("recover.commands")
+    container.collection_queue = SimpleNamespace(
+        pause=sync_step("queue.pause"),
+        requeue_startup_tasks=async_step("queue.requeue"),
+        start_db_pull=sync_step("queue.db_pull"),
+    )
+    container.unified_dispatcher = SimpleNamespace(start=async_step("unified_dispatcher.start"))
+    container.telegram_command_dispatcher = SimpleNamespace(
+        start=async_step("telegram_command_dispatcher.start")
+    )
+    container.ai_search = SimpleNamespace(initialize=sync_step("ai_search.initialize"))
+    container.agent_manager = SimpleNamespace(
+        refresh_settings_cache=async_step("agent.preflight"),
+        initialize=sync_step("agent.initialize"),
+    )
+    container.scheduler = SimpleNamespace(
+        load_settings=async_step("scheduler.load_settings"),
+        start=async_step("scheduler.start"),
+    )
+
+    try:
+        await start_container(container)
+    finally:
+        await db.close()
+
+    assert order == [
+        "recover.photo",
+        "recover.generation",
+        "recover.commands",
+        "pool.initialize",
+        "queue.requeue",
+        "queue.db_pull",
+        "unified_dispatcher.start",
+        "telegram_command_dispatcher.start",
+        "ai_search.initialize",
+        "agent.preflight",
+        "agent.initialize",
+        "scheduler.load_settings",
+        "scheduler.start",
+    ]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Part of #1131

## Summary
- Split `start_container` into startup phase helpers for recovery, Telegram pool initialization, collection queue startup, dispatchers/AI/agent startup, and scheduler startup.
- Split `_dispatch_stream_message` into per-message/per-event helpers while keeping the public dispatcher as a thin ordered router.
- Added a worker startup phase-order regression test for the load-bearing web container startup path.

## Complexity
- Before: `E:4`; `start_container E(36)`, `_dispatch_stream_message E(34)`.
- After: `E:2`; `start_container A(3)`, `_dispatch_stream_message B(6)`.
- Extracted helpers stay at `<= C` (`_start_dispatchers_ai_and_agent C(13)`, `_initialize_startup_telegram_pool C(11)`, stream helpers `<= B`).

## Equivalence / Safety
- Ran an in-memory AST verifier against merge-base: extracted bootstrap blocks and stream dispatch branches match the original statement bodies; startup helper order and dispatch branch order are preserved.
- No temporary verify script or artifact is committed.
- Patch-where-used checked: extracted code remains in `src.web.bootstrap` / `src.agent.manager` and continues to resolve module globals at call time; public `start_container` and `_dispatch_stream_message` entrypoints remain in place.

## Validation
- `ruff check src/ tests/ conftest.py`
- `pytest tests/test_bootstrap.py -q -n 0`
- `pytest tests/test_agent.py -q -n 0`
- `pytest tests/test_agent_manager_runtime_paths.py::TestClaudeSdkBackendChatStreamErrors -q -n 0`
- `pytest tests/routes/test_agent_routes_streaming.py -q -n 0`
- `pytest tests/test_web.py::test_startup_continues_after_pool_initialize_timeout -q -n 0`
- `python scripts/code_health.py --top 40`

Wide `pytest -n auto` was intentionally not run per task constraints.
