### PR TITLE
[codex] Split remaining rank-E functions

### DIFF
--- a/src/cli/commands/pipeline.py
+++ b/src/cli/commands/pipeline.py
@@ -207,141 +207,199 @@ async def _pipeline_show(args: argparse.Namespace, db, config, svc: PipelineServ
 
 
 
-async def _pipeline_add(args: argparse.Namespace, db, config, svc: PipelineService) -> None:
+async def _pipeline_add_from_json(
+    args: argparse.Namespace,
+    svc: PipelineService,
+    json_file: str,
+) -> int | None:
+    import json as _json
+
+    with open(json_file) as _f:
+        graph_data = _json.load(_f)
+    data = {
+        "name": args.name,
+        "prompt_template": args.prompt_template or ".",
+        "llm_model": args.llm_model,
+        "source_ids": args.source or [],
+        "target_refs": (
+            [{"phone": r.phone, "dialog_id": r.dialog_id} for r in _parse_target_refs(args.target)]
+            if args.target
+            else []
+        ),
+        "generate_interval_minutes": args.interval,
+        "pipeline_json": graph_data,
+    }
+    return await svc.import_json(data)
+
+
+def _build_pipeline_add_node_specs(node_specs_raw: list[str]) -> tuple[list, bool]:
+    from src.cli.node_dsl import NodeSpecError, parse_node_spec
+
+    specs = []
+    for raw in node_specs_raw:
+        try:
+            specs.append(parse_node_spec(raw))
+        except NodeSpecError as exc:
+            print(f"Invalid node spec '{raw}': {exc}")
+            return specs, False
+    return specs, True
+
+
+def _apply_pipeline_add_edges(args: argparse.Namespace, builder) -> bool:
+    if getattr(args, "edge", None):
+        for edge_str in args.edge:
+            from_id, _, to_id = edge_str.partition("->")
+            if not to_id:
+                print(f"Invalid edge format '{edge_str}'; use FROM->TO")
+                return False
+            builder.add_explicit_edge(from_id.strip(), to_id.strip())
+    return True
+
+
+def _apply_pipeline_add_node_configs(args: argparse.Namespace, builder) -> bool:
+    if getattr(args, "node_configs", None):
+        import json as _json
+
+        for nc_str in args.node_configs:
+            node_id, _, json_str = nc_str.partition("=")
+            try:
+                config = _json.loads(json_str)
+            except _json.JSONDecodeError as exc:
+                print(f"Invalid JSON in --node-config for {node_id}: {exc}")
+                return False
+            builder.set_node_config_override(node_id.strip(), config)
+    return True
+
+
+def _build_pipeline_add_graph(args: argparse.Namespace, node_specs_raw: list[str]):
+    from src.cli.graph_builder import GraphBuilder, GraphBuilderError
+
+    specs, ok = _build_pipeline_add_node_specs(node_specs_raw)
+    if not ok:
+        return None
+
+    builder = GraphBuilder()
+    for spec in specs:
+        builder.add_node_spec(spec)
+
+    if args.source:
+        builder.set_sources(args.source)
+
+    if args.target:
+        target_refs_list = [{"phone": t.phone, "dialog_id": t.dialog_id} for t in _parse_target_refs(args.target)]
+        builder.set_targets(target_refs_list)
+
+    if not _apply_pipeline_add_edges(args, builder):
+        return None
+    if not _apply_pipeline_add_node_configs(args, builder):
+        return None
+
+    try:
+        return builder.build()
+    except GraphBuilderError as exc:
+        print(f"Graph build error: {exc}")
+        return None
+
+
+async def _pipeline_add_from_nodes(
+    args: argparse.Namespace,
+    svc: PipelineService,
+    node_specs_raw: list[str],
+) -> tuple[int | None, bool]:
+    import json as _json
+
+    graph = _build_pipeline_add_graph(args, node_specs_raw)
+    if graph is None:
+        return None, False
+
+    pipeline_id = await svc.import_json(
+        {
+            "name": args.name,
+            "prompt_template": args.prompt_template or ".",
+            "llm_model": args.llm_model,
+            "image_model": args.image_model,
+            "generation_backend": args.generation_backend,
+            "publish_mode": args.publish_mode,
+            "generate_interval_minutes": args.interval,
+            "pipeline_json": _json.loads(graph.to_json()),
+            "source_ids": args.source or [],
+            "target_refs": (
+                [f"{t.phone}|{t.dialog_id}" for t in _parse_target_refs(args.target)]
+                if args.target
+                else []
+            ),
+        },
+    )
+
+    # Activate if --inactive was not passed
+    if not args.inactive and pipeline_id:
+        await svc._bundle.set_active(pipeline_id, True)
+    return pipeline_id, True
+
+
+async def _pipeline_add_legacy(
+    args: argparse.Namespace,
+    svc: PipelineService,
+) -> tuple[int | None, bool]:
+    # Legacy mode: --prompt-template + --source + --target required
+    if not args.prompt_template:
+        print("Error: --prompt-template is required when --json-file/--node is not used")
+        return None, False
+    if not args.source:
+        print("Error: --source is required")
+        return None, False
+    if not args.target:
+        print("Error: --target is required")
+        return None, False
+    pipeline_id = await svc.add(
+        name=args.name,
+        prompt_template=args.prompt_template,
+        source_channel_ids=args.source,
+        target_refs=_parse_target_refs(args.target),
+        llm_model=args.llm_model,
+        image_model=args.image_model,
+        publish_mode=args.publish_mode,
+        generation_backend=args.generation_backend,
+        generate_interval_minutes=args.interval,
+        is_active=not args.inactive,
+        ab_num_variants=getattr(args, "ab_variants", 1) or 1,
+        ab_auto_select=getattr(args, "ab_auto_select", False),
+    )
+    return pipeline_id, True
+
+
+async def _pipeline_add_pipeline(args: argparse.Namespace, svc: PipelineService) -> tuple[int | None, bool]:
     json_file = getattr(args, "json_file", None)
     node_specs_raw = getattr(args, "node_specs", None)
+    if json_file:
+        return await _pipeline_add_from_json(args, svc, json_file), True
+    if node_specs_raw:
+        # DAG mode: build graph from --node specs
+        return await _pipeline_add_from_nodes(args, svc, node_specs_raw)
+    return await _pipeline_add_legacy(args, svc)
+
+
+async def _pipeline_enqueue_run_after(args: argparse.Namespace, db, pipeline_id: int | None) -> None:
+    from src.services.task_enqueuer import TaskEnqueuer
+
+    since_h = to_since_hours(args.since_value, args.since_unit)
+    enqueuer = TaskEnqueuer(db)
+    await enqueuer.enqueue_pipeline_run(pipeline_id, since_hours=since_h)
+    print(f"Enqueued pipeline run (since={args.since_value}{args.since_unit})")
+
+
+async def _pipeline_add(args: argparse.Namespace, db, config, svc: PipelineService) -> None:
     try:
-        if json_file:
-            import json as _json
-
-            with open(json_file) as _f:
-                graph_data = _json.load(_f)
-            data = {
-                "name": args.name,
-                "prompt_template": args.prompt_template or ".",
-                "llm_model": args.llm_model,
-                "source_ids": args.source or [],
-                "target_refs": (
-                    [{"phone": r.phone, "dialog_id": r.dialog_id}
-                     for r in _parse_target_refs(args.target)]
-                    if args.target else []
-                ),
-                "generate_interval_minutes": args.interval,
-                "pipeline_json": graph_data,
-            }
-            pipeline_id = await svc.import_json(data)
-        elif node_specs_raw:
-            # DAG mode: build graph from --node specs
-            import json as _json
-
-            from src.cli.graph_builder import GraphBuilder, GraphBuilderError
-            from src.cli.node_dsl import NodeSpecError, parse_node_spec
-
-            specs = []
-            for raw in node_specs_raw:
-                try:
-                    specs.append(parse_node_spec(raw))
-                except NodeSpecError as exc:
-                    print(f"Invalid node spec '{raw}': {exc}")
-                    return
-
-            builder = GraphBuilder()
-            for spec in specs:
-                builder.add_node_spec(spec)
-
-            if args.source:
-                builder.set_sources(args.source)
-
-            target_refs_list = []
-            if args.target:
-                target_refs_list = [
-                    {"phone": t.phone, "dialog_id": t.dialog_id}
-                    for t in _parse_target_refs(args.target)
-                ]
-                builder.set_targets(target_refs_list)
-
-            if getattr(args, "edge", None):
-                for edge_str in args.edge:
-                    from_id, _, to_id = edge_str.partition("->")
-                    if not to_id:
-                        print(f"Invalid edge format '{edge_str}'; use FROM->TO")
-                        return
-                    builder.add_explicit_edge(from_id.strip(), to_id.strip())
-
-            if getattr(args, "node_configs", None):
-                for nc_str in args.node_configs:
-                    node_id, _, json_str = nc_str.partition("=")
-                    try:
-                        config = _json.loads(json_str)
-                    except _json.JSONDecodeError as exc:
-                        print(f"Invalid JSON in --node-config for {node_id}: {exc}")
-                        return
-                    builder.set_node_config_override(node_id.strip(), config)
-
-            try:
-                graph = builder.build()
-            except GraphBuilderError as exc:
-                print(f"Graph build error: {exc}")
-                return
-
-            pipeline_id = await svc.import_json(
-                {
-                    "name": args.name,
-                    "prompt_template": args.prompt_template or ".",
-                    "llm_model": args.llm_model,
-                    "image_model": args.image_model,
-                    "generation_backend": args.generation_backend,
-                    "publish_mode": args.publish_mode,
-                    "generate_interval_minutes": args.interval,
-                    "pipeline_json": _json.loads(graph.to_json()),
-                    "source_ids": args.source or [],
-                    "target_refs": (
-                        [f"{t.phone}|{t.dialog_id}" for t in _parse_target_refs(args.target)]
-                        if args.target
-                        else []
-                    ),
-                },
-            )
-
-            # Activate if --inactive was not passed
-            if not args.inactive and pipeline_id:
-                await svc._bundle.set_active(pipeline_id, True)
-        else:
-            # Legacy mode: --prompt-template + --source + --target required
-            if not args.prompt_template:
-                print("Error: --prompt-template is required when --json-file/--node is not used")
-                return
-            if not args.source:
-                print("Error: --source is required")
-                return
-            if not args.target:
-                print("Error: --target is required")
-                return
-            pipeline_id = await svc.add(
-                name=args.name,
-                prompt_template=args.prompt_template,
-                source_channel_ids=args.source,
-                target_refs=_parse_target_refs(args.target),
-                llm_model=args.llm_model,
-                image_model=args.image_model,
-                publish_mode=args.publish_mode,
-                generation_backend=args.generation_backend,
-                generate_interval_minutes=args.interval,
-                is_active=not args.inactive,
-                ab_num_variants=getattr(args, "ab_variants", 1) or 1,
-                ab_auto_select=getattr(args, "ab_auto_select", False),
-            )
+        pipeline_id, should_print = await _pipeline_add_pipeline(args, svc)
     except PipelineValidationError as exc:
         print(f"Error: {exc}")
         return
+
+    if not should_print:
+        return
     print(f"Added pipeline id={pipeline_id}: {args.name}")
     if getattr(args, "run_after", False):
-        from src.services.task_enqueuer import TaskEnqueuer
-
-        since_h = to_since_hours(args.since_value, args.since_unit)
-        enqueuer = TaskEnqueuer(db)
-        await enqueuer.enqueue_pipeline_run(pipeline_id, since_hours=since_h)
-        print(f"Enqueued pipeline run (since={args.since_value}{args.since_unit})")
+        await _pipeline_enqueue_run_after(args, db, pipeline_id)
 
 
 

--- a/src/services/content_generation_service.py
+++ b/src/services/content_generation_service.py
@@ -110,6 +110,22 @@ class ContentGenerationService:
         If dry_run=True: skips image generation and draft notifications; marks
         metadata with dry_run=True so callers can distinguish test runs.
         """
+        run_id = await self._create_running_run(pipeline)
+        try:
+            return await self._generate_run(
+                run_id=run_id,
+                pipeline=pipeline,
+                model=model,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                dry_run=dry_run,
+                since_hours=since_hours,
+            )
+        except Exception as exc:
+            await self._mark_generation_failed(run_id, pipeline, exc)
+            raise
+
+    async def _create_running_run(self, pipeline: ContentPipeline) -> int:
         run_id = await self._db.repos.generation_runs.create_run(
             pipeline_id=pipeline.id,
             prompt=pipeline.prompt_template,
@@ -119,154 +135,290 @@ class ContentGenerationService:
         except Exception:
             await self._db.repos.generation_runs.set_status(run_id, "failed")
             raise
+        return run_id
 
-        try:
-            result = await self._run_generation(
-                pipeline=pipeline,
-                model=model,
-                max_tokens=max_tokens,
-                temperature=temperature,
-                since_hours=since_hours,
-                run_id=run_id,
-                dry_run=dry_run,
+    async def _generate_run(
+        self,
+        run_id: int,
+        pipeline: ContentPipeline,
+        model: str | None,
+        max_tokens: int,
+        temperature: float,
+        dry_run: bool,
+        since_hours: float,
+    ) -> GenerationRun:
+        result = await self._run_generation(
+            pipeline=pipeline,
+            model=model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            since_hours=since_hours,
+            run_id=run_id,
+            dry_run=dry_run,
+        )
+        generated_text, effective_publish_mode, metadata = self._prepare_generation_result(
+            result,
+            pipeline,
+            dry_run=dry_run,
+        )
+        generated_text = await self._maybe_apply_generation_refinement(
+            generated_text,
+            metadata,
+            pipeline,
+            model,
+            max_tokens,
+            temperature,
+        )
+
+        # Persist the base text first, then run A/B selection, THEN generate
+        # the image — so the image is rendered from the finally-selected
+        # text, not a discarded base variant (review: Codex). Quality scoring
+        # below likewise sees the final text.
+        await self._db.repos.generation_runs.save_result(run_id, generated_text, metadata)
+
+        generated_text = await self._maybe_run_generation_ab_testing(
+            run_id,
+            pipeline,
+            generated_text,
+            dry_run=dry_run,
+        )
+        await self._maybe_attach_generation_image(
+            run_id,
+            pipeline,
+            generated_text,
+            result,
+            dry_run=dry_run,
+        )
+        await self._maybe_score_generated_content(run_id, pipeline, generated_text)
+        await self._maybe_approve_auto_publish(run_id, effective_publish_mode, dry_run=dry_run)
+        run = await self._get_generation_run_after_save(run_id)
+        await self._maybe_notify_new_draft(
+            run,
+            pipeline,
+            effective_publish_mode,
+            dry_run=dry_run,
+        )
+        return run
+
+    def _prepare_generation_result(
+        self,
+        result: dict[str, Any],
+        pipeline: ContentPipeline,
+        *,
+        dry_run: bool,
+    ) -> tuple[str, str, dict[str, Any]]:
+        generated_text = result.get("generated_text", "")
+        effective_publish_mode = result.get("publish_mode") or pipeline.publish_mode.value
+        metadata = self._build_metadata(
+            {**result, "publish_mode": effective_publish_mode},
+            dry_run=dry_run,
+        )
+        return generated_text, effective_publish_mode, metadata
+
+    async def _maybe_apply_generation_refinement(
+        self,
+        generated_text: str,
+        metadata: dict[str, Any],
+        pipeline: ContentPipeline,
+        model: str | None,
+        max_tokens: int,
+        temperature: float,
+    ) -> str:
+        if pipeline.refinement_steps and generated_text and pipeline.pipeline_json is None:
+            # Refinement steps are only applied for legacy pipelines (graph-based ones encode them as nodes)
+            generated_text = await self._apply_refinement_steps(
+                generated_text, pipeline, model, max_tokens, temperature
             )
-            generated_text = result.get("generated_text", "")
-            effective_publish_mode = result.get("publish_mode") or pipeline.publish_mode.value
-            metadata = self._build_metadata(
-                {**result, "publish_mode": effective_publish_mode},
-                dry_run=dry_run,
+            metadata["refinement_steps_applied"] = len(pipeline.refinement_steps)
+        return generated_text
+
+    async def _maybe_run_generation_ab_testing(
+        self,
+        run_id: int,
+        pipeline: ContentPipeline,
+        generated_text: str,
+        *,
+        dry_run: bool,
+    ) -> str:
+        # A/B variant generation (issue #1068). Runs after the base text is
+        # persisted and before image generation + quality scoring so both the
+        # image and the score reflect the finally-selected text. Skipped for
+        # dry runs (×N token cost) and when disabled (ab_num_variants <= 1).
+        # A failure here must not lose the already-saved base run, so it
+        # degrades gracefully. It runs before the AUTO moderation_status
+        # alignment below (#1036), so an AUTO run publishes the selected
+        # variant (and its matching image), not the base text.
+        if (
+            not dry_run
+            and generated_text
+            and pipeline.ab_num_variants
+            and pipeline.ab_num_variants > 1
+        ):
+            return await self._run_ab_testing(run_id, pipeline, generated_text)
+        return generated_text
+
+    async def _maybe_attach_generation_image(
+        self,
+        run_id: int,
+        pipeline: ContentPipeline,
+        generated_text: str,
+        result: dict[str, Any],
+        *,
+        dry_run: bool,
+    ) -> None:
+        # Use image_url from graph executor if available, otherwise fall back to legacy image gen
+        # Image generation is skipped for dry runs to save time and cost
+        if dry_run:
+            return
+        image_url_from_graph = result.get("image_url")
+        if image_url_from_graph:
+            await self._db.repos.generation_runs.set_image_url(run_id, image_url_from_graph)
+            return
+        await self._maybe_attach_legacy_image(run_id, pipeline, generated_text)
+
+    async def _maybe_attach_legacy_image(
+        self,
+        run_id: int,
+        pipeline: ContentPipeline,
+        generated_text: str,
+    ) -> None:
+        image_model = pipeline.image_model
+        if not image_model:
+            image_model = await self._db.get_setting("default_image_model") or ""
+        if not image_model or pipeline.pipeline_json is not None:
+            return
+
+        orphan = await self._find_generation_orphan_image(run_id, pipeline)
+        if orphan is not None:
+            await self._claim_generation_orphan_image(run_id, pipeline, orphan)
+            return
+
+        image_url = await self._generate_image(pipeline, generated_text, model=image_model)
+        if image_url:
+            await self._db.repos.generation_runs.set_image_url(run_id, image_url)
+
+    async def _find_generation_orphan_image(
+        self,
+        run_id: int,
+        pipeline: ContentPipeline,
+    ) -> tuple[int, str] | None:
+        # Idempotency guard against double-billing on retry (#1117).
+        # The paid image POST happens before the fallible post-image
+        # steps below (quality scoring, AUTO moderation alignment). If
+        # one of those raised, the run was marked 'failed' and the
+        # periodic content_generate job creates a fresh run on its next
+        # tick — a new run_id that an in-run image_url check can't
+        # dedupe. So before issuing a new billed POST, reuse the image
+        # an earlier *failed* run of this pipeline already paid for, and
+        # consume it (transfer, not copy) so it cannot be re-inherited
+        # by a later scheduled post. Same category as #958, different
+        # call site (the generation service, not the adapter).
+        if pipeline.id is None:
+            return None
+        return await self._db.repos.generation_runs.find_orphan_image(
+            pipeline.id, exclude_run_id=run_id
+        )
+
+    async def _claim_generation_orphan_image(
+        self,
+        run_id: int,
+        pipeline: ContentPipeline,
+        orphan: tuple[int, str],
+    ) -> None:
+        source_run_id, reusable_url = orphan
+        logger.info(
+            "Reusing already-paid image from failed run_id=%s for "
+            "pipeline_id=%s run_id=%s instead of re-billing the provider (#1117)",
+            source_run_id,
+            pipeline.id,
+            run_id,
+        )
+        await self._db.repos.generation_runs.claim_orphan_image(
+            source_run_id, run_id, reusable_url
+        )
+
+    async def _maybe_score_generated_content(
+        self,
+        run_id: int,
+        pipeline: ContentPipeline,
+        generated_text: str,
+    ) -> None:
+        if self._quality_service and generated_text:
+            quality = await self._quality_service.score_content(
+                generated_text,
+                model=pipeline.llm_model,
             )
-
-            if pipeline.refinement_steps and generated_text and pipeline.pipeline_json is None:
-                # Refinement steps are only applied for legacy pipelines (graph-based ones encode them as nodes)
-                generated_text = await self._apply_refinement_steps(
-                    generated_text, pipeline, model, max_tokens, temperature
-                )
-                metadata["refinement_steps_applied"] = len(pipeline.refinement_steps)
-
-            # Persist the base text first, then run A/B selection, THEN generate
-            # the image — so the image is rendered from the finally-selected
-            # text, not a discarded base variant (review: Codex). Quality scoring
-            # below likewise sees the final text.
-            await self._db.repos.generation_runs.save_result(run_id, generated_text, metadata)
-
-            # A/B variant generation (issue #1068). Runs after the base text is
-            # persisted and before image generation + quality scoring so both the
-            # image and the score reflect the finally-selected text. Skipped for
-            # dry runs (×N token cost) and when disabled (ab_num_variants <= 1).
-            # A failure here must not lose the already-saved base run, so it
-            # degrades gracefully. It runs before the AUTO moderation_status
-            # alignment below (#1036), so an AUTO run publishes the selected
-            # variant (and its matching image), not the base text.
-            if (
-                not dry_run
-                and generated_text
-                and pipeline.ab_num_variants
-                and pipeline.ab_num_variants > 1
-            ):
-                generated_text = await self._run_ab_testing(
-                    run_id, pipeline, generated_text
-                )
-
-            # Use image_url from graph executor if available, otherwise fall back to legacy image gen
-            # Image generation is skipped for dry runs to save time and cost
-            if not dry_run:
-                image_url_from_graph = result.get("image_url")
-                if image_url_from_graph:
-                    await self._db.repos.generation_runs.set_image_url(run_id, image_url_from_graph)
-                else:
-                    image_model = pipeline.image_model
-                    if not image_model:
-                        image_model = await self._db.get_setting("default_image_model") or ""
-                    if image_model and pipeline.pipeline_json is None:
-                        # Idempotency guard against double-billing on retry (#1117).
-                        # The paid image POST happens before the fallible post-image
-                        # steps below (quality scoring, AUTO moderation alignment). If
-                        # one of those raised, the run was marked 'failed' and the
-                        # periodic content_generate job creates a fresh run on its next
-                        # tick — a new run_id that an in-run image_url check can't
-                        # dedupe. So before issuing a new billed POST, reuse the image
-                        # an earlier *failed* run of this pipeline already paid for, and
-                        # consume it (transfer, not copy) so it cannot be re-inherited
-                        # by a later scheduled post. Same category as #958, different
-                        # call site (the generation service, not the adapter).
-                        orphan = None
-                        if pipeline.id is not None:
-                            orphan = await self._db.repos.generation_runs.find_orphan_image(
-                                pipeline.id, exclude_run_id=run_id
-                            )
-                        if orphan is not None:
-                            source_run_id, reusable_url = orphan
-                            logger.info(
-                                "Reusing already-paid image from failed run_id=%s for "
-                                "pipeline_id=%s run_id=%s instead of re-billing the provider (#1117)",
-                                source_run_id,
-                                pipeline.id,
-                                run_id,
-                            )
-                            await self._db.repos.generation_runs.claim_orphan_image(
-                                source_run_id, run_id, reusable_url
-                            )
-                        else:
-                            image_url = await self._generate_image(pipeline, generated_text, model=image_model)
-                            if image_url:
-                                await self._db.repos.generation_runs.set_image_url(run_id, image_url)
-
-            if self._quality_service and generated_text:
-                quality = await self._quality_service.score_content(
-                    generated_text,
-                    model=pipeline.llm_model,
-                )
-                await self._db.repos.generation_runs.set_quality_score(
-                    run_id,
-                    quality.overall,
-                    quality.issues,
-                )
-
-            # Single point that aligns moderation_status with the effective
-            # publish mode (issue #1036). AUTO content has no human review, so it
-            # must skip 'pending' the instant generation completes: a 'pending'
-            # AUTO run would surface in the moderation queue and, if the later
-            # publish fails, stay stranded there forever. 'approved' is the
-            # publish-eligible state PublishService expects; a successful delivery
-            # then advances it to 'published'. MODERATED stays 'pending' (the
-            # create_run / DB default) until a human approves it. dry_run never
-            # publishes, so its status is left untouched.
-            #
-            # This runs only AFTER every fallible post-save step above (quality
-            # scoring / set_quality_score) has succeeded. If any of them raises,
-            # the except below sets status='failed' and the run keeps its
-            # non-publishable 'pending' moderation_status — so the background
-            # CONTENT_PUBLISH handler (which selects moderation_status='approved')
-            # can never deliver a failed generation to Telegram (review: Codex).
-            if not dry_run and effective_publish_mode == PipelinePublishMode.AUTO.value:
-                await self._db.repos.generation_runs.set_moderation_status(run_id, "approved")
-
-            run = await self._db.repos.generation_runs.get(run_id)
-            if run is None:
-                raise RuntimeError(f"Generation run {run_id} not found after save")
-
-            if (
-                not dry_run
-                and self._notification_service
-                and run.moderation_status == "pending"
-                and effective_publish_mode == PipelinePublishMode.MODERATED.value
-            ):
-                try:
-                    await self._notification_service.notify_new_draft(run, pipeline)
-                except Exception:
-                    logger.warning("Failed to send draft notification", exc_info=True)
-            return run
-        except Exception as exc:
-            logger.exception(
-                "Content generation failed for pipeline_id=%s run_id=%s",
-                pipeline.id,
+            await self._db.repos.generation_runs.set_quality_score(
                 run_id,
+                quality.overall,
+                quality.issues,
             )
-            node_errors = getattr(exc, "node_errors", None)
-            meta = {"node_errors": node_errors} if node_errors else None
-            await self._db.repos.generation_runs.set_status(run_id, "failed", metadata=meta)
-            raise
+
+    async def _maybe_approve_auto_publish(
+        self,
+        run_id: int,
+        effective_publish_mode: str,
+        *,
+        dry_run: bool,
+    ) -> None:
+        # Single point that aligns moderation_status with the effective
+        # publish mode (issue #1036). AUTO content has no human review, so it
+        # must skip 'pending' the instant generation completes: a 'pending'
+        # AUTO run would surface in the moderation queue and, if the later
+        # publish fails, stay stranded there forever. 'approved' is the
+        # publish-eligible state PublishService expects; a successful delivery
+        # then advances it to 'published'. MODERATED stays 'pending' (the
+        # create_run / DB default) until a human approves it. dry_run never
+        # publishes, so its status is left untouched.
+        #
+        # This runs only AFTER every fallible post-save step above (quality
+        # scoring / set_quality_score) has succeeded. If any of them raises,
+        # the except below sets status='failed' and the run keeps its
+        # non-publishable 'pending' moderation_status — so the background
+        # CONTENT_PUBLISH handler (which selects moderation_status='approved')
+        # can never deliver a failed generation to Telegram (review: Codex).
+        if not dry_run and effective_publish_mode == PipelinePublishMode.AUTO.value:
+            await self._db.repos.generation_runs.set_moderation_status(run_id, "approved")
+
+    async def _get_generation_run_after_save(self, run_id: int) -> GenerationRun:
+        run = await self._db.repos.generation_runs.get(run_id)
+        if run is None:
+            raise RuntimeError(f"Generation run {run_id} not found after save")
+        return run
+
+    async def _maybe_notify_new_draft(
+        self,
+        run: GenerationRun,
+        pipeline: ContentPipeline,
+        effective_publish_mode: str,
+        *,
+        dry_run: bool,
+    ) -> None:
+        if (
+            not dry_run
+            and self._notification_service
+            and run.moderation_status == "pending"
+            and effective_publish_mode == PipelinePublishMode.MODERATED.value
+        ):
+            try:
+                await self._notification_service.notify_new_draft(run, pipeline)
+            except Exception:
+                logger.warning("Failed to send draft notification", exc_info=True)
+
+    async def _mark_generation_failed(
+        self,
+        run_id: int,
+        pipeline: ContentPipeline,
+        exc: Exception,
+    ) -> None:
+        logger.exception(
+            "Content generation failed for pipeline_id=%s run_id=%s",
+            pipeline.id,
+            run_id,
+        )
+        node_errors = getattr(exc, "node_errors", None)
+        meta = {"node_errors": node_errors} if node_errors else None
+        await self._db.repos.generation_runs.set_status(run_id, "failed", metadata=meta)
 
     async def _run_generation(
         self,


### PR DESCRIPTION
## Summary

Batch 4/4 for the #1131 cyclomatic-complexity axis. This refactors the final two rank-E functions into focused private helpers without changing behavior:

- `src/cli/commands/pipeline.py`: split `_pipeline_add` into json-file, DAG-node, legacy, and run-after helpers.
- `src/services/content_generation_service.py`: split `ContentGenerationService.generate` into run creation, generation post-processing, refinement, A/B, image reuse/generation, quality scoring, moderation alignment, draft notification, and failure-status helpers.

Closes #1131

## Complexity Delta

Before `python scripts/code_health.py --top 40`:

- `E(32) _pipeline_add`
- `E(31) ContentGenerationService.generate`
- Distribution: `A:3532 B:520 C:224 D:34 E:2 F:0`

After:

- `_pipeline_add` is `A(4)` by `radon cc -s`
- `ContentGenerationService.generate` is `A(2)` by `radon cc -s`
- Distribution: `A:3554 B:523 C:224 D:34 E:0 F:0`

This finishes the axis: rank-E `2 -> 0` in this PR, full #1131 axis `8 -> 0` across batches.

## Equivalence / Guardrails

- Temporary AST harness expanded the new helper calls and compared external call sequences against `HEAD` for both original functions:
  - `_pipeline_add`: 47 external calls preserved.
  - `ContentGenerationService.generate`: 29 external calls preserved.
- `generate` keeps the text -> A/B selection -> image -> quality -> moderation -> draft notification ordering.
- Billing-sensitive image generation was not moved into a duplicate call site: `_generate_image()` remains the only legacy paid-image call, graph `image_url` reuse still short-circuits legacy image generation, and orphan image reuse still claims instead of re-billing.
- Patch-where-used checked: existing module/class patches still target stable public methods (`ContentGenerationService`, `ContentGenerationService.generate`, `_run_generation`, `PipelineService`, CLI runtime init). New helpers are only internal steps under those same call paths.

## Validation

- `ruff check src/ tests/ conftest.py`
- `python scripts/code_health.py --top 40`
- `radon cc -s src/cli/commands/pipeline.py src/services/content_generation_service.py`
- `pytest -q -n 0 tests/test_content_generation_service.py tests/test_content_generation_service_edge_cases.py tests/test_pipeline_cli.py::test_pipeline_add_dag_with_node tests/test_pipeline_cli.py::test_pipeline_add_dag_invalid_spec tests/test_pipeline_cli.py::test_pipeline_add_legacy_requires_prompt_template tests/test_pipeline_cli.py::test_pipeline_add_dag_with_edges tests/test_pipeline_cli.py::test_pipeline_add_node_dsl_integration tests/test_pipeline_cli.py::test_pipeline_add_legacy_integration tests/test_pipeline_cli.py::test_pipeline_add_legacy_requires_source tests/test_pipeline_cli.py::test_pipeline_add_legacy_requires_target tests/test_pipeline_cli.py::test_pipeline_add_inactive_flag tests/test_pipeline_cli.py::test_pipeline_add_run_after tests/test_pipeline_cli.py::test_pipeline_add_json_file tests/test_cli_pipeline_commands.py::TestPipelineAbAddRW::test_add_persists_ab_fields` -> 57 passed