### PR TITLE
[codex] Speed up parallel suite bottlenecks

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -852,3 +852,17 @@ async def drain_loop(rounds: int = 3) -> None:
     """
     for _ in range(rounds):
         await asyncio.sleep(0)
+
+
+def fast_llm_error_recovery(max_retries: int = 0):
+    """Return an LLM recovery service without wall-clock retry backoff."""
+    from src.services.error_recovery_service import ErrorRecoveryService, RetryPolicy
+
+    return ErrorRecoveryService(
+        retry_policy=RetryPolicy(
+            max_retries=max_retries,
+            base_delay=0.0,
+            max_delay=0.0,
+            jitter=False,
+        )
+    )

--- a/tests/routes/test_pipelines_routes.py
+++ b/tests/routes/test_pipelines_routes.py
@@ -10,6 +10,11 @@ from httpx import ASGITransport, AsyncClient
 
 from src.models import Account
 
+
+async def _quality_provider(**kwargs):
+    return '{"overall": 0.8, "issues": []}'
+
+
 _ADD_DATA = {
     "name": "Test Pipeline",
     "prompt_template": "Write a summary",
@@ -330,7 +335,7 @@ async def test_generate_stream_success(client):
 
     mock_provider_instance = MagicMock()
     mock_provider_instance.has_providers = MagicMock(return_value=True)
-    mock_provider_instance.get_provider_callable = MagicMock(return_value=lambda: None)
+    mock_provider_instance.get_provider_callable = MagicMock(return_value=_quality_provider)
 
     app = client._transport.app  # type: ignore
     app.state.llm_provider_service = mock_provider_instance
@@ -394,7 +399,6 @@ async def test_generate_stream_pipeline_not_found(client):
     assert "error=pipeline_invalid" in resp.headers["location"]
 
 
-@pytest.mark.slow  # real provider-retry backoff on the failure path (~8s)
 @pytest.mark.anyio
 async def test_generate_stream_scope_error_fails_closed(client):
     """Fail-closed (#1077): a source-scope resolution failure must abort the run
@@ -409,7 +413,7 @@ async def test_generate_stream_scope_error_fails_closed(client):
 
     mock_provider_instance = MagicMock()
     mock_provider_instance.has_providers = MagicMock(return_value=True)
-    mock_provider_instance.get_provider_callable = MagicMock(return_value=lambda: None)
+    mock_provider_instance.get_provider_callable = MagicMock(return_value=_quality_provider)
     app = client._transport.app  # type: ignore
     app.state.llm_provider_service = mock_provider_instance
     db = app.state.db
@@ -440,12 +444,12 @@ async def test_generate_pipeline_success(client):
 
     mock_provider_instance = MagicMock()
     mock_provider_instance.has_providers = MagicMock(return_value=True)
-    mock_provider_instance.get_provider_callable = MagicMock(return_value=lambda: None)
+    mock_provider_instance.get_provider_callable = MagicMock(return_value=_quality_provider)
 
     app = client._transport.app  # type: ignore
     app.state.llm_provider_service = mock_provider_instance
 
-    with patch("src.services.generation_service.GenerationService") as mock_gen:
+    with patch("src.services.content_generation_service.GenerationService") as mock_gen:
         mock_instance = MagicMock()
         mock_instance.generate = AsyncMock(
             return_value={"generated_text": "Test output", "citations": []}
@@ -459,7 +463,6 @@ async def test_generate_pipeline_success(client):
         assert resp.status_code == 200
 
 
-@pytest.mark.slow  # real provider-retry backoff on the failure path (~9s)
 @pytest.mark.anyio
 async def test_generate_pipeline_failure(client):
     """Test non-streaming generation failure."""
@@ -469,12 +472,12 @@ async def test_generate_pipeline_failure(client):
 
     mock_provider_instance = MagicMock()
     mock_provider_instance.has_providers = MagicMock(return_value=True)
-    mock_provider_instance.get_provider_callable = MagicMock(return_value=lambda: None)
+    mock_provider_instance.get_provider_callable = MagicMock(return_value=_quality_provider)
 
     app = client._transport.app  # type: ignore
     app.state.llm_provider_service = mock_provider_instance
 
-    with patch("src.services.generation_service.GenerationService") as mock_gen:
+    with patch("src.services.content_generation_service.GenerationService") as mock_gen:
         mock_instance = MagicMock()
         mock_instance.generate = AsyncMock(side_effect=Exception("Generation error"))
         mock_gen.return_value = mock_instance

--- a/tests/test_agent_manager_runtime_paths.py
+++ b/tests/test_agent_manager_runtime_paths.py
@@ -1628,7 +1628,6 @@ class TestDeepagentsProbeAndRun:
         assert result.status == "supported"
         assert result.model == "gpt-4"
 
-    @pytest.mark.slow  # exercises a real probe timeout (~10s)
     @pytest.mark.anyio
     async def test_probe_config_timeout(self, mock_db):
         """probe_config returns 'unknown' on timeout."""
@@ -1647,12 +1646,12 @@ class TestDeepagentsProbeAndRun:
         import src.agent.manager as mgr_module
 
         original_timeout = mgr_module._DEEPAGENTS_PROBE_TIMEOUT_SECONDS
-        mgr_module._DEEPAGENTS_PROBE_TIMEOUT_SECONDS = 0.5
+        mgr_module._DEEPAGENTS_PROBE_TIMEOUT_SECONDS = 0.01
 
         try:
             # _run_probe runs via asyncio.to_thread, so we need it to block
             # in a real thread to allow the wait_for timeout to fire.
-            with patch.object(backend, "_run_probe", side_effect=lambda cfg: __import__("time").sleep(10)):
+            with patch.object(backend, "_run_probe", side_effect=lambda cfg: __import__("time").sleep(0.05)):
                 result = await backend.probe_config(cfg)
         finally:
             mgr_module._DEEPAGENTS_PROBE_TIMEOUT_SECONDS = original_timeout

--- a/tests/test_content_generation_service_edge_cases.py
+++ b/tests/test_content_generation_service_edge_cases.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -18,6 +18,7 @@ from src.models import (
     SearchResult,
 )
 from src.services.content_generation_service import ContentGenerationService
+from tests.helpers import fast_llm_error_recovery
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -966,7 +967,6 @@ async def test_generate_run_not_found_after_save():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.slow  # real provider-retry backoff on the exception path (~9s)
 @pytest.mark.anyio
 async def test_generate_exception_sets_failed():
     """Any exception during generation should mark run as failed."""
@@ -988,7 +988,9 @@ async def test_generate_exception_sets_failed():
 
     orig = _patch_provider(failing_provider)
     try:
-        with pytest.raises(RuntimeError, match="Provider crashed"):
+        with pytest.raises(RuntimeError, match="Provider crashed"), patch(
+            "src.services.generation_service.for_llm", side_effect=fast_llm_error_recovery
+        ):
             await service.generate(pipeline)
         # The run should have been marked as failed
         # Since we get a new run_id on each call, check the repo

--- a/tests/test_generation_service.py
+++ b/tests/test_generation_service.py
@@ -4,6 +4,7 @@ import pytest
 
 from src.models import Message, SearchResult
 from src.services.generation_service import GenerationService
+from tests.helpers import fast_llm_error_recovery
 
 
 class DummySearchEngine:
@@ -246,7 +247,6 @@ async def test_generation_service_sync_iterator_provider():
     assert chunks[-1]["generated_text"] == "chunk1chunk2chunk3"
 
 
-@pytest.mark.slow  # real provider-retry backoff on the exception path (~8s)
 async def test_generation_service_provider_exception():
     """Test generation handles provider exception."""
 
@@ -254,7 +254,11 @@ async def test_generation_service_provider_exception():
         raise ValueError("Provider error")
 
     engine = DummySearchEngine([])
-    service = GenerationService(search_engine=engine, provider_callable=failing_provider)
+    service = GenerationService(
+        search_engine=engine,
+        provider_callable=failing_provider,
+        error_recovery=fast_llm_error_recovery(),
+    )
 
     with pytest.raises(ValueError, match="Provider error"):
         await service.generate(query="test")

--- a/tests/test_integration_generation.py
+++ b/tests/test_integration_generation.py
@@ -5,7 +5,6 @@ import pytest
 # pipeline_client fixture is shared from tests/conftest.py (deduped).
 
 
-@pytest.mark.slow  # real provider-retry backoff on the success path (~8s)
 @pytest.mark.anyio
 async def test_pipeline_generate_and_publish(pipeline_client, monkeypatch):
     # Mock LLM provider service so the Generate button is shown in the template
@@ -13,7 +12,11 @@ async def test_pipeline_generate_and_publish(pipeline_client, monkeypatch):
 
     mock_llm_service = MagicMock()
     mock_llm_service.has_providers = MagicMock(return_value=True)
-    mock_llm_service.get_provider_callable = MagicMock(return_value=None)
+
+    async def quality_provider(**kwargs):
+        return '{"overall": 0.8, "issues": []}'
+
+    mock_llm_service.get_provider_callable = MagicMock(return_value=quality_provider)
     app = pipeline_client._transport.app  # type: ignore
     app.state.llm_provider_service = mock_llm_service
 

--- a/tests/test_registry_and_quality.py
+++ b/tests/test_registry_and_quality.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
-
 from src.agent.tools._registry import (
     _text_response,
     normalize_phone,
@@ -14,6 +12,7 @@ from src.agent.tools._registry import (
     require_pool,
     resolve_phone,
 )
+from tests.helpers import fast_llm_error_recovery
 
 # --- normalize_phone ---
 
@@ -206,11 +205,10 @@ async def test_quality_scoring_passes():
     assert svc.passes_threshold(score, threshold=0.9) is False
 
 
-@pytest.mark.slow  # real provider-retry backoff on the exception path (~8s)
 async def test_quality_scoring_no_provider():
     from src.services.quality_scoring_service import QualityScoringService
 
-    svc = QualityScoringService(db=MagicMock())
+    svc = QualityScoringService(db=MagicMock(), error_recovery=fast_llm_error_recovery())
     with patch("src.services.quality_scoring_service.RuntimeProviderRegistry", create=True):
         # Provider raises exception
         mock_ps = MagicMock()

--- a/tests/test_regression_services_coverage.py
+++ b/tests/test_regression_services_coverage.py
@@ -803,13 +803,13 @@ class TestQualityScoringServiceCoverage:
             # Should get defaults when no JSON found
             assert score.relevance == 0.5
 
-    @pytest.mark.slow  # real provider-retry backoff on the exception path (~8s)
     async def test_score_content_os_error(self):
         """Lines 117-119: OSError during scoring."""
         from src.services.quality_scoring_service import QualityScoringService
+        from tests.helpers import fast_llm_error_recovery
 
         db = _make_mock_db()
-        svc = QualityScoringService(db)
+        svc = QualityScoringService(db, error_recovery=fast_llm_error_recovery())
 
         mock_provider = AsyncMock(side_effect=OSError("network"))
         with patch(
@@ -819,13 +819,13 @@ class TestQualityScoringServiceCoverage:
             score = await svc.score_content("test text", model="test")
             assert score.overall == 0.5
 
-    @pytest.mark.slow  # real provider-retry backoff on the exception path (~9s)
     async def test_score_content_unexpected_error(self):
         """Lines 120-122: unexpected error during scoring."""
         from src.services.quality_scoring_service import QualityScoringService
+        from tests.helpers import fast_llm_error_recovery
 
         db = _make_mock_db()
-        svc = QualityScoringService(db)
+        svc = QualityScoringService(db, error_recovery=fast_llm_error_recovery())
 
         mock_provider = AsyncMock(side_effect=RuntimeError("unexpected"))
         with patch(
@@ -1538,5 +1538,3 @@ class TestNumpySemanticCoverage:
 
 
 # ---- telegram/auth.py coverage ----
-
-

--- a/tests/test_test_levels.py
+++ b/tests/test_test_levels.py
@@ -9,6 +9,8 @@ nothing unlevelled) via a real collection of the suite.
 from __future__ import annotations
 
 import importlib.util
+import json
+import os
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -159,9 +161,9 @@ def test_ast_scan_flags_only_db_building_tests(tmp_path) -> None:
 # --- structural invariants over the real collection ------------------------
 
 
-@pytest.mark.slow  # forks a full pytest collection in a subprocess (~14s)
+@pytest.mark.slow  # forks one full pytest collection in a subprocess
 @pytest.mark.integration  # forks a full pytest collection in a subprocess
-def test_collection_invariants_hold_over_real_suite() -> None:
+def test_collection_invariants_hold_over_real_suite(tmp_path) -> None:
     """End-to-end gate: every collected test gets exactly one level.
 
     Collects the whole suite in a subprocess and asserts that nothing is left
@@ -172,18 +174,65 @@ def test_collection_invariants_hold_over_real_suite() -> None:
     import sys
 
     repo = Path(__file__).resolve().parents[1]
+    inventory_path = tmp_path / "test_level_inventory.json"
+    plugin_path = tmp_path / "level_inventory_plugin.py"
+    plugin_path.write_text(
+        """
+from __future__ import annotations
 
-    def _count(marker_expr: str) -> int:
-        proc = subprocess.run(
-            [sys.executable, "-m", "pytest", "--co", "-q", "-p", "no:cacheprovider", "-m", marker_expr],
-            cwd=repo,
-            capture_output=True,
-            text=True,
-        )
-        return sum(1 for line in proc.stdout.splitlines() if "::" in line)
+import json
+import os
 
-    unlevelled = _count("not (unit or integration or smoke or e2e)")
-    assert unlevelled == 0, f"{unlevelled} collected tests carry no level marker"
 
-    both = _count("unit and integration")
-    assert both == 0, f"{both} collected tests are both unit and integration"
+LEVEL_MARKERS = {"unit", "integration", "smoke", "e2e"}
+
+
+def pytest_collection_finish(session):
+    inventory = {
+        "total": len(session.items),
+        "unlevelled": [],
+        "multi_level": [],
+        "unit_and_integration": [],
+    }
+    for item in session.items:
+        levels = sorted({marker.name for marker in item.iter_markers() if marker.name in LEVEL_MARKERS})
+        if not levels:
+            inventory["unlevelled"].append(item.nodeid)
+        if len(levels) > 1:
+            inventory["multi_level"].append({"nodeid": item.nodeid, "levels": levels})
+        if {"unit", "integration"}.issubset(levels):
+            inventory["unit_and_integration"].append(item.nodeid)
+    with open(os.environ["TEST_LEVEL_INVENTORY_PATH"], "w", encoding="utf-8") as fh:
+        json.dump(inventory, fh)
+""".lstrip()
+    )
+    env = os.environ.copy()
+    env["TEST_LEVEL_INVENTORY_PATH"] = str(inventory_path)
+    env["PYTHONPATH"] = (
+        str(tmp_path)
+        if not env.get("PYTHONPATH")
+        else f"{tmp_path}{os.pathsep}{env['PYTHONPATH']}"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-m", "pytest", "--co", "-q", "-p", "no:cacheprovider", "-p", "level_inventory_plugin"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    inventory = json.loads(inventory_path.read_text())
+
+    assert inventory["total"] > 0
+    assert inventory["unlevelled"] == [], (
+        f"{len(inventory['unlevelled'])} collected tests carry no level marker: "
+        f"{inventory['unlevelled'][:10]}"
+    )
+    assert inventory["multi_level"] == [], (
+        f"{len(inventory['multi_level'])} collected tests carry multiple level markers: "
+        f"{inventory['multi_level'][:10]}"
+    )
+    assert inventory["unit_and_integration"] == [], (
+        f"{len(inventory['unit_and_integration'])} collected tests are both unit and integration: "
+        f"{inventory['unit_and_integration'][:10]}"
+    )


### PR DESCRIPTION
## Summary
- Replace the test-level invariant's two full-suite `pytest --collect-only` subprocesses with one plugin-backed collect that inventories level markers once.
- Inject fast test-only LLM recovery / valid provider callables into provider, quality, route, and generation exception-path tests so they still assert timeout/error handling without real retry sleeps.
- Remove stale `slow` markers from tests that no longer wait on wall-clock retry/backoff.

## Timing delta (`-n 0 --durations=5`, targeted)
- `test_collection_invariants_hold_over_real_suite`: 31.64s call -> 12.51s call.
- `test_probe_config_timeout`: 10.01s call -> 0.06s call.
- Retry/backoff provider tests: representative 7.80-8.88s calls -> <0.01-0.18s calls; route fixture setup remains ~1.7-2.2s.
- `test_pipeline_generate_and_publish`: 8.30s call -> 0.11s call.
- Deepagents real-init parametrized test remains a real integration guard; measured 4.93s -> 4.96s and was not a retry/sleep path.

## Validation
- `ruff check src/ tests/ conftest.py`
- Targeted `pytest <listed issue tests> -n 0 --durations=5 -q` plus adjacent `test_generate_stream_scope_error_fails_closed`.

Closes #1164