### PR TITLE
[codex] chore: ignore untyped external imports for mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,26 @@ include = ["*.py"]
 [tool.ruff.lint]
 select = ["E", "F", "I", "N", "W"]
 
+[tool.mypy]
+
+[[tool.mypy.overrides]]
+module = [
+    "apscheduler.*",
+    "boto3",
+    "botocore.*",
+    "google.adk.*",
+    "langdetect",
+    "openpyxl",
+    "openpyxl.*",
+    "sklearn.*",
+    "telethon",
+    "telethon.*",
+    "telethon_cli",
+    "telethon_cli.*",
+    "yaml",
+]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 anyio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"


### PR DESCRIPTION
Part of #1133.

## What changed

Added a targeted `[[tool.mypy.overrides]]` block in `pyproject.toml` for external packages currently reported as `import-untyped`. This keeps `ignore_missing_imports` scoped per package and does not change runtime code or CI.

## Baseline delta

Before:
- `mypy .`: `Found 984 errors in 198 files (checked 877 source files)`
- `mypy src/`: `Found 771 errors in 123 files (checked 366 source files)`
- `src/` `import-untyped`: 48
- full `mypy .` `import-untyped`: 110

After:
- `mypy .`: `Found 874 errors in 145 files (checked 877 source files)`
- `mypy src/`: `Found 723 errors in 108 files (checked 366 source files)`
- `src/` `import-untyped`: 0
- full `mypy .` `import-untyped`: 0

Guard:
- 0 new non-`import-untyped` diagnostics when comparing full `mypy .` output before/after.

## Overrides

- `apscheduler.*`
- `boto3`
- `botocore.*`
- `google.adk.*`
- `langdetect`
- `openpyxl`
- `openpyxl.*`
- `sklearn.*`
- `telethon`
- `telethon.*`
- `telethon_cli`
- `telethon_cli.*`
- `yaml`

## Validation

- `python -c "import tomllib; tomllib.load(open('pyproject.toml', 'rb'))"`
- `ruff check src/ tests/ conftest.py`
- `python -c "import src.main"`
- `git diff --check`
- `mypy .`
- `mypy src/`