### PR TITLE
Part of #1133: clear database union-attr

### DIFF
--- a/src/database/facade.py
+++ b/src/database/facade.py
@@ -300,10 +300,11 @@ class Database:
         open BEGIN IMMEDIATE block on the same connection (issue #569).
         """
         assert self._db is not None
+        db = self._db
         async with self._write_lock:
             async def _write_once() -> aiosqlite.Cursor:
-                cur = await self._db.execute(sql, params)
-                await self._db.commit()
+                cur = await db.execute(sql, params)
+                await db.commit()
                 return cur
 
             cur = await self._with_busy_retry("execute_write", _write_once)
@@ -318,10 +319,11 @@ class Database:
         Returns the cursor (callers may read ``rowcount``).
         """
         assert self._db is not None
+        db = self._db
         async with self._write_lock:
             async def _write_once() -> aiosqlite.Cursor:
-                cur = await self._db.executemany(sql, seq)
-                await self._db.commit()
+                cur = await db.executemany(sql, seq)
+                await db.commit()
                 return cur
 
             cur = await self._with_busy_retry("executemany_write", _write_once)
@@ -374,102 +376,168 @@ class Database:
 
     async def add_account(self, account: Account) -> int:
         self._require()
+        assert self._accounts is not None, (
+            "Database.add_account requires initialized AccountsRepository"
+        )
         return await self._accounts.add_account(account)
 
     async def get_accounts(self, active_only: bool = False) -> list[Account]:
         self._require()
+        assert self._accounts is not None, (
+            "Database.get_accounts requires initialized AccountsRepository"
+        )
         return await self._accounts.get_accounts(active_only)
 
     async def get_live_usable_accounts(self, active_only: bool = False) -> list[Account]:
         self._require()
+        assert self._accounts is not None, (
+            "Database.get_live_usable_accounts requires initialized AccountsRepository"
+        )
         return await self._accounts.get_live_usable_accounts(active_only)
 
     async def get_account_summaries(self, active_only: bool = False) -> list[AccountSummary]:
         self._require()
+        assert self._accounts is not None, (
+            "Database.get_account_summaries requires initialized AccountsRepository"
+        )
         return await self._accounts.get_account_summaries(active_only)
 
     async def update_account_flood(self, phone: str, until) -> None:
         self._require()
+        assert self._accounts is not None, (
+            "Database.update_account_flood requires initialized AccountsRepository"
+        )
         await self._accounts.update_account_flood(phone, until)
 
     async def update_account_premium(self, phone: str, is_premium: bool) -> None:
         self._require()
+        assert self._accounts is not None, (
+            "Database.update_account_premium requires initialized AccountsRepository"
+        )
         await self._accounts.update_account_premium(phone, is_premium)
 
     async def set_account_active(self, account_id: int, active: bool) -> None:
         self._require()
+        assert self._accounts is not None, (
+            "Database.set_account_active requires initialized AccountsRepository"
+        )
         await self._accounts.set_account_active(account_id, active)
 
     async def delete_account(self, account_id: int) -> None:
         self._require()
+        assert self._accounts is not None, (
+            "Database.delete_account requires initialized AccountsRepository"
+        )
         await self._accounts.delete_account(account_id)
 
     async def add_channel(self, channel: Channel) -> int:
         self._require()
+        assert self._channels is not None, (
+            "Database.add_channel requires initialized ChannelsRepository"
+        )
         return await self._channels.add_channel(channel)
 
     async def get_channels(
         self, active_only: bool = False, include_filtered: bool = True
     ) -> list[Channel]:
         self._require()
+        assert self._channels is not None, (
+            "Database.get_channels requires initialized ChannelsRepository"
+        )
         return await self._channels.get_channels(active_only, include_filtered)
 
     async def get_channel_by_pk(self, pk: int) -> Channel | None:
         self._require()
+        assert self._channels is not None, (
+            "Database.get_channel_by_pk requires initialized ChannelsRepository"
+        )
         return await self._channels.get_channel_by_pk(pk)
 
     async def get_channel_by_channel_id(self, channel_id: int) -> Channel | None:
         self._require()
+        assert self._channels is not None, (
+            "Database.get_channel_by_channel_id requires initialized ChannelsRepository"
+        )
         return await self._channels.get_channel_by_channel_id(channel_id)
 
     async def get_channels_with_counts(
         self, active_only: bool = False, include_filtered: bool = True
     ) -> list[Channel]:
         self._require()
+        assert self._channels is not None, (
+            "Database.get_channels_with_counts requires initialized ChannelsRepository"
+        )
         return await self._channels.get_channels_with_counts(active_only, include_filtered)
 
     async def update_channel_last_id(self, channel_id: int, last_id: int) -> None:
         self._require()
+        assert self._channels is not None, (
+            "Database.update_channel_last_id requires initialized ChannelsRepository"
+        )
         await self._channels.update_channel_last_id(channel_id, last_id)
 
     async def set_channel_active(self, pk: int, active: bool) -> None:
         self._require()
+        assert self._channels is not None, (
+            "Database.set_channel_active requires initialized ChannelsRepository"
+        )
         await self._channels.set_channel_active(pk, active)
 
     async def set_channel_filtered(self, pk: int, filtered: bool) -> None:
         self._require()
+        assert self._channels is not None, (
+            "Database.set_channel_filtered requires initialized ChannelsRepository"
+        )
         await self._channels.set_channel_filtered(pk, filtered)
 
     async def set_channels_filtered_bulk(
         self, updates: list[tuple[int, str]], *, commit: bool = True
     ) -> int:
         self._require()
+        assert self._channels is not None, (
+            "Database.set_channels_filtered_bulk requires initialized ChannelsRepository"
+        )
         return await self._channels.set_filtered_bulk(updates, commit=commit)
 
     async def reset_all_channel_filters(self, *, commit: bool = True) -> int:
         self._require()
+        assert self._channels is not None, (
+            "Database.reset_all_channel_filters requires initialized ChannelsRepository"
+        )
         return await self._channels.reset_all_filters(commit=commit)
 
     async def reset_channel_filters_for_pks(
         self, pks: list[int], *, commit: bool = True
     ) -> int:
         self._require()
+        assert self._channels is not None, (
+            "Database.reset_channel_filters_for_pks requires initialized ChannelsRepository"
+        )
         return await self._channels.reset_filters_for_pks(pks, commit=commit)
 
     async def set_channel_type(self, channel_id: int, channel_type: str) -> None:
         self._require()
+        assert self._channels is not None, (
+            "Database.set_channel_type requires initialized ChannelsRepository"
+        )
         await self._channels.set_channel_type(channel_id, channel_type)
 
     async def update_channel_preferred_phone(
         self, channel_id: int, phone: str | None
     ) -> None:
         self._require()
+        assert self._channels is not None, (
+            "Database.update_channel_preferred_phone requires initialized ChannelsRepository"
+        )
         await self._channels.update_channel_preferred_phone(channel_id, phone)
 
     async def update_channel_meta(
         self, channel_id: int, *, username: str | None, title: str | None
     ) -> None:
         self._require()
+        assert self._channels is not None, (
+            "Database.update_channel_meta requires initialized ChannelsRepository"
+        )
         await self._channels.update_channel_meta(channel_id, username=username, title=title)
 
     async def update_channel_full_meta(
@@ -481,6 +549,9 @@ class Database:
         has_comments: bool,
     ) -> None:
         self._require()
+        assert self._channels is not None, (
+            "Database.update_channel_full_meta requires initialized ChannelsRepository"
+        )
         await self._channels.update_channel_full_meta(
             channel_id, about=about, linked_chat_id=linked_chat_id, has_comments=has_comments
         )
@@ -593,6 +664,9 @@ class Database:
         regardless of prior manual changes to the channel.
         """
         self._require()
+        assert self._channels is not None, (
+            "Database.ensure_channel_filtered requires initialized ChannelsRepository"
+        )
         channel = await self._channels.get_channel_by_channel_id(channel_id)
         if channel is None:
             return
@@ -608,22 +682,37 @@ class Database:
 
     async def get_forum_topics(self, channel_id: int) -> list[dict]:
         self._require()
+        assert self._channels is not None, (
+            "Database.get_forum_topics requires initialized ChannelsRepository"
+        )
         return await self._channels.get_forum_topics(channel_id)
 
     async def upsert_forum_topics(self, channel_id: int, topics: list[dict]) -> None:
         self._require()
+        assert self._channels is not None, (
+            "Database.upsert_forum_topics requires initialized ChannelsRepository"
+        )
         await self._channels.upsert_forum_topics(channel_id, topics)
 
     async def delete_channel(self, pk: int) -> None:
         self._require()
+        assert self._channels is not None, (
+            "Database.delete_channel requires initialized ChannelsRepository"
+        )
         await self._channels.delete_channel(pk)
 
     async def insert_message(self, msg: Message) -> bool:
         self._require()
+        assert self._messages is not None, (
+            "Database.insert_message requires initialized MessagesRepository"
+        )
         return await self._messages.insert_message(msg)
 
     async def insert_messages_batch(self, messages: list[Message]) -> int:
         self._require()
+        assert self._messages is not None, (
+            "Database.insert_messages_batch requires initialized MessagesRepository"
+        )
         return await self._messages.insert_messages_batch(messages)
 
     async def search_messages_for_query(
@@ -632,6 +721,9 @@ class Database:
         limit: int = 1,
     ) -> tuple[list[Message], int]:
         self._require()
+        assert self._messages is not None, (
+            "Database.search_messages_for_query requires initialized MessagesRepository"
+        )
         return await self._messages.search_messages_for_query(sq, limit)
 
     async def search_messages_for_query_since(
@@ -641,6 +733,9 @@ class Database:
         limit: int = 3,
     ) -> tuple[list[Message], int]:
         self._require()
+        assert self._messages is not None, (
+            "Database.search_messages_for_query_since requires initialized MessagesRepository"
+        )
         return await self._messages.search_messages_for_query_since(sq, since, limit)
 
     async def search_messages(
@@ -658,6 +753,9 @@ class Database:
         include_filtered: bool = False,
     ) -> MessageSearchPage:
         self._require()
+        assert self._messages is not None, (
+            "Database.search_messages requires initialized MessagesRepository"
+        )
         return await self._messages.search_messages(
             SearchParams(
                 query=query,
@@ -689,6 +787,9 @@ class Database:
         include_filtered: bool = False,
     ) -> tuple[list[Message], int]:
         self._require()
+        assert self._messages is not None, (
+            "Database.search_semantic_messages requires initialized MessagesRepository"
+        )
         return await self._messages.search_semantic_messages(
             query_embedding=query_embedding,
             channel_id=channel_id,
@@ -719,6 +820,9 @@ class Database:
         include_filtered: bool = False,
     ) -> tuple[list[Message], int]:
         self._require()
+        assert self._messages is not None, (
+            "Database.search_hybrid_messages requires initialized MessagesRepository"
+        )
         return await self._messages.search_hybrid_messages(
             query=query,
             query_embedding=query_embedding,
@@ -736,14 +840,23 @@ class Database:
 
     async def delete_messages_for_channel(self, channel_id: int) -> int:
         self._require()
+        assert self._messages is not None, (
+            "Database.delete_messages_for_channel requires initialized MessagesRepository"
+        )
         return await self._messages.delete_messages_for_channel(channel_id)
 
     async def get_stats(self) -> dict:
         self._require()
+        assert self._messages is not None, (
+            "Database.get_stats requires initialized MessagesRepository"
+        )
         return await self._messages.get_stats()
 
     async def get_trending_emojis(self, limit: int = 10, days: int | None = None) -> list[dict]:
         self._require()
+        assert self._messages is not None, (
+            "Database.get_trending_emojis requires initialized MessagesRepository"
+        )
         return await self._messages.get_trending_emojis(limit=limit, days=days)
 
     async def get_top_reacted_messages(
@@ -753,6 +866,9 @@ class Database:
         days: int | None = None,
     ) -> list[Message]:
         self._require()
+        assert self._messages is not None, (
+            "Database.get_top_reacted_messages requires initialized MessagesRepository"
+        )
         return await self._messages.get_top_reacted_messages(
             limit=limit, channel_id=channel_id, days=days
         )
@@ -764,6 +880,9 @@ class Database:
         date_to: str | None = None,
     ) -> list[dict]:
         self._require()
+        assert self._messages is not None, (
+            "Database.get_top_messages requires initialized MessagesRepository"
+        )
         return await self._messages.get_top_messages(limit, date_from, date_to)
 
     async def get_engagement_by_media_type(
@@ -772,6 +891,9 @@ class Database:
         date_to: str | None = None,
     ) -> list[dict]:
         self._require()
+        assert self._messages is not None, (
+            "Database.get_engagement_by_media_type requires initialized MessagesRepository"
+        )
         return await self._messages.get_engagement_by_media_type(date_from, date_to)
 
     async def get_hourly_activity(
@@ -780,10 +902,16 @@ class Database:
         date_to: str | None = None,
     ) -> list[dict]:
         self._require()
+        assert self._messages is not None, (
+            "Database.get_hourly_activity requires initialized MessagesRepository"
+        )
         return await self._messages.get_hourly_activity(date_from, date_to)
 
     async def get_notification_queries(self, active_only: bool = True) -> list[SearchQuery]:
         self._require()
+        assert self._search_queries is not None, (
+            "Database.get_notification_queries requires initialized SearchQueriesRepository"
+        )
         return await self._search_queries.get_notification_queries(active_only)
 
     async def create_collection_task(
@@ -797,6 +925,9 @@ class Database:
         parent_task_id: int | None = None,
     ) -> int:
         self._require()
+        assert self._tasks is not None, (
+            "Database.create_collection_task requires initialized CollectionTasksRepository"
+        )
         return await self._tasks.create_collection_task(
             channel_id,
             channel_title,
@@ -808,6 +939,9 @@ class Database:
 
     async def update_collection_task_progress(self, task_id: int, messages_collected: int) -> None:
         self._require()
+        assert self._tasks is not None, (
+            "Database.update_collection_task_progress requires initialized CollectionTasksRepository"
+        )
         await self._tasks.update_collection_task_progress(task_id, messages_collected)
 
     async def persist_stats_progress(
@@ -818,6 +952,9 @@ class Database:
         messages_collected: int,
     ) -> None:
         self._require()
+        assert self._tasks is not None, (
+            "Database.persist_stats_progress requires initialized CollectionTasksRepository"
+        )
         await self._tasks.persist_stats_progress(task_id, payload=payload, messages_collected=messages_collected)
 
     async def update_collection_task(
@@ -830,6 +967,9 @@ class Database:
         run_after: datetime | None = None,
     ) -> None:
         self._require()
+        assert self._tasks is not None, (
+            "Database.update_collection_task requires initialized CollectionTasksRepository"
+        )
         await self._tasks.update_collection_task(
             task_id,
             status,
@@ -848,6 +988,9 @@ class Database:
         messages_collected: int = 0,
     ) -> None:
         self._require()
+        assert self._tasks is not None, (
+            "Database.reschedule_collection_task requires initialized CollectionTasksRepository"
+        )
         await self._tasks.reschedule_collection_task(
             task_id,
             run_after=run_after,
@@ -862,24 +1005,39 @@ class Database:
         note: str | None = None,
     ) -> None:
         self._require()
+        assert self._tasks is not None, (
+            "Database.reset_collection_task_to_pending requires initialized CollectionTasksRepository"
+        )
         await self._tasks.reset_collection_task_to_pending(task_id, note=note)
 
     async def get_collection_task(self, task_id: int) -> CollectionTask | None:
         self._require()
+        assert self._tasks is not None, (
+            "Database.get_collection_task requires initialized CollectionTasksRepository"
+        )
         return await self._tasks.get_collection_task(task_id)
 
     async def get_collection_tasks(self, limit: int = 20) -> list[CollectionTask]:
         self._require()
+        assert self._tasks is not None, (
+            "Database.get_collection_tasks requires initialized CollectionTasksRepository"
+        )
         return await self._tasks.get_collection_tasks(limit)
 
     async def count_collection_tasks(self, status_filter: str | None = None) -> int:
         self._require()
+        assert self._tasks is not None, (
+            "Database.count_collection_tasks requires initialized CollectionTasksRepository"
+        )
         return await self._tasks.count_collection_tasks(status_filter)
 
     async def get_collection_tasks_paginated(
         self, limit: int = 20, offset: int = 0, status_filter: str | None = None
     ) -> tuple[list[CollectionTask], int]:
         self._require()
+        assert self._tasks is not None, (
+            "Database.get_collection_tasks_paginated requires initialized CollectionTasksRepository"
+        )
         return await self._tasks.get_collection_tasks_paginated(limit, offset, status_filter)
 
     async def get_active_collection_tasks_for_channel(
@@ -887,14 +1045,23 @@ class Database:
         channel_id: int,
     ) -> list[CollectionTask]:
         self._require()
+        assert self._tasks is not None, (
+            "Database.get_active_collection_tasks_for_channel requires initialized CollectionTasksRepository"
+        )
         return await self._tasks.get_active_collection_tasks_for_channel(channel_id)
 
     async def get_channel_ids_with_active_tasks(self) -> set[int]:
         self._require()
+        assert self._tasks is not None, (
+            "Database.get_channel_ids_with_active_tasks requires initialized CollectionTasksRepository"
+        )
         return await self._tasks.get_channel_ids_with_active_tasks()
 
     async def get_active_stats_task(self) -> CollectionTask | None:
         self._require()
+        assert self._tasks is not None, (
+            "Database.get_active_stats_task requires initialized CollectionTasksRepository"
+        )
         return await self._tasks.get_active_stats_task()
 
     async def create_stats_task(
@@ -905,6 +1072,9 @@ class Database:
         parent_task_id: int | None = None,
     ) -> int:
         self._require()
+        assert self._tasks is not None, (
+            "Database.create_stats_task requires initialized CollectionTasksRepository"
+        )
         return await self._tasks.create_stats_task(
             payload,
             run_after=run_after,
@@ -920,6 +1090,9 @@ class Database:
         messages_collected: int,
     ) -> None:
         self._require()
+        assert self._tasks is not None, (
+            "Database.reschedule_stats_task requires initialized CollectionTasksRepository"
+        )
         return await self._tasks.reschedule_stats_task(
             task_id,
             payload=payload,
@@ -929,69 +1102,114 @@ class Database:
 
     async def get_pending_channel_tasks(self) -> list[CollectionTask]:
         self._require()
+        assert self._tasks is not None, (
+            "Database.get_pending_channel_tasks requires initialized CollectionTasksRepository"
+        )
         return await self._tasks.get_pending_channel_tasks()
 
     async def delete_pending_channel_tasks(self) -> int:
         self._require()
+        assert self._tasks is not None, (
+            "Database.delete_pending_channel_tasks requires initialized CollectionTasksRepository"
+        )
         return await self._tasks.delete_pending_channel_tasks()
 
     async def fail_running_collection_tasks_on_startup(self) -> int:
         self._require()
+        assert self._tasks is not None, (
+            "Database.fail_running_collection_tasks_on_startup requires initialized CollectionTasksRepository"
+        )
         return await self._tasks.fail_running_collection_tasks_on_startup()
 
     async def reset_orphaned_running_tasks(self) -> int:
         self._require()
+        assert self._tasks is not None, (
+            "Database.reset_orphaned_running_tasks requires initialized CollectionTasksRepository"
+        )
         return await self._tasks.reset_orphaned_running_tasks()
 
     async def cancel_collection_task(self, task_id: int, note: str | None = None) -> bool:
         self._require()
+        assert self._tasks is not None, (
+            "Database.cancel_collection_task requires initialized CollectionTasksRepository"
+        )
         return await self._tasks.cancel_collection_task(task_id, note=note)
 
     async def log_search(self, phone: str, query: str, results_count: int) -> None:
         self._require()
+        assert self._search_log is not None, (
+            "Database.log_search requires initialized SearchLogRepository"
+        )
         await self._search_log.log_search(phone, query, results_count)
 
     async def get_recent_searches(self, limit: int = 20) -> list[dict]:
         self._require()
+        assert self._search_log is not None, (
+            "Database.get_recent_searches requires initialized SearchLogRepository"
+        )
         return await self._search_log.get_recent_searches(limit)
 
     async def save_channel_stats(self, stats: ChannelStats) -> int:
         self._require()
+        assert self._channel_stats is not None, (
+            "Database.save_channel_stats requires initialized ChannelStatsRepository"
+        )
         return await self._channel_stats.save_channel_stats(stats)
 
     async def get_channel_stats(self, channel_id: int, limit: int = 1) -> list[ChannelStats]:
         self._require()
+        assert self._channel_stats is not None, (
+            "Database.get_channel_stats requires initialized ChannelStatsRepository"
+        )
         return await self._channel_stats.get_channel_stats(channel_id, limit)
 
     async def get_latest_stats_for_all(self) -> dict[int, ChannelStats]:
         self._require()
+        assert self._channel_stats is not None, (
+            "Database.get_latest_stats_for_all requires initialized ChannelStatsRepository"
+        )
         return await self._channel_stats.get_latest_stats_for_all()
 
     async def get_previous_subscriber_counts(self) -> dict[int, int | None]:
         self._require()
+        assert self._channel_stats is not None, (
+            "Database.get_previous_subscriber_counts requires initialized ChannelStatsRepository"
+        )
         return await self._channel_stats.get_previous_subscriber_counts()
 
     async def get_setting(self, key: str) -> str | None:
         self._require()
+        assert self._settings is not None, (
+            "Database.get_setting requires initialized SettingsRepository"
+        )
         return await self._settings.get_setting(key)
 
     async def set_setting(self, key: str, value: str) -> None:
         self._require()
+        assert self._settings is not None, (
+            "Database.set_setting requires initialized SettingsRepository"
+        )
         await self._settings.set_setting(key, value)
 
     async def get_notification_bot(self, tg_user_id: int) -> NotificationBot | None:
         self._require()
-        assert self._notification_bots is not None
+        assert self._notification_bots is not None, (
+            "Database.get_notification_bot requires initialized NotificationBotsRepository"
+        )
         return await self._notification_bots.get_bot(tg_user_id)
 
     async def save_notification_bot(self, bot: NotificationBot) -> int:
         self._require()
-        assert self._notification_bots is not None
+        assert self._notification_bots is not None, (
+            "Database.save_notification_bot requires initialized NotificationBotsRepository"
+        )
         return await self._notification_bots.save_bot(bot)
 
     async def delete_notification_bot(self, tg_user_id: int) -> None:
         self._require()
-        assert self._notification_bots is not None
+        assert self._notification_bots is not None, (
+            "Database.delete_notification_bot requires initialized NotificationBotsRepository"
+        )
         await self._notification_bots.delete_bot(tg_user_id)
 
     # ── Agent chat ─────────────────────────────────────────────────────────────

--- a/src/database/repositories/accounts.py
+++ b/src/database/repositories/accounts.py
@@ -79,6 +79,9 @@ class AccountsRepository:
         запрошенный ``is_primary`` срабатывает, только если primary-аккаунта ещё
         нет (#733), иначе сохраняется 0.
         """
+        assert self._database is not None, (
+            "AccountsRepository.add_account requires a Database reference"
+        )
         session_string = account.session_string
         if self._session_cipher:
             session_string = self._session_cipher.encrypt(session_string)
@@ -122,6 +125,9 @@ class AccountsRepository:
         source of truth for "already exists" (#1146 review). Session is encrypted as
         usual; is_primary is still derived atomically (#733).
         """
+        assert self._database is not None, (
+            "AccountsRepository.add_account_if_absent requires a Database reference"
+        )
         session_string = account.session_string
         if self._session_cipher:
             session_string = self._session_cipher.encrypt(session_string)
@@ -470,6 +476,9 @@ class AccountsRepository:
 
         `ClientPool` пропускает аккаунты, у которых ``flood_wait_until`` ещё в будущем.
         """
+        assert self._database is not None, (
+            "AccountsRepository.update_account_flood requires a Database reference"
+        )
         await self._database.execute_write(
             "UPDATE accounts SET flood_wait_until = ? WHERE phone = ?",
             (until.isoformat() if until else None, phone),
@@ -477,6 +486,9 @@ class AccountsRepository:
 
     async def update_account_premium(self, phone: str, is_premium: bool) -> None:
         """Обновить флаг Telegram Premium у аккаунта (нужен для premium-only операций)."""
+        assert self._database is not None, (
+            "AccountsRepository.update_account_premium requires a Database reference"
+        )
         await self._database.execute_write(
             "UPDATE accounts SET is_premium = ? WHERE phone = ?",
             (int(is_premium), phone),

--- a/src/database/repositories/channel_ratings.py
+++ b/src/database/repositories/channel_ratings.py
@@ -53,6 +53,9 @@ class ChannelRatingsRepository:
         `flag_count` сохраняется из существующей строки, а не из переданного
         рейтинга — машинная переклассификация не должна сбрасывать ручные флаги.
         """
+        assert self._database is not None, (
+            "ChannelRatingsRepository.upsert requires a Database reference"
+        )
         now = (rating.updated_at or datetime.now(tz=timezone.utc)).isoformat()
         await self._database.execute_write(
             "INSERT INTO channel_ratings "

--- a/src/database/repositories/channel_stats.py
+++ b/src/database/repositories/channel_stats.py
@@ -32,6 +32,9 @@ class ChannelStatsRepository:
 
     async def save_channel_stats(self, stats: ChannelStats) -> int:
         """Добавить новое измерение метрик канала. Возвращает id новой строки."""
+        assert self._database is not None, (
+            "ChannelStatsRepository.save_channel_stats requires a Database reference"
+        )
         cur = await self._database.execute_write(
             """INSERT INTO channel_stats
                (channel_id, subscriber_count, avg_views, avg_reactions, avg_forwards)

--- a/src/database/repositories/channels.py
+++ b/src/database/repositories/channels.py
@@ -47,6 +47,9 @@ class ChannelsRepository:
         соединении — для гарантированного pk существующего канала читайте его по
         ``channel_id`` (например `get_channel_by_channel_id`).
         """
+        assert self._database is not None, (
+            "ChannelsRepository.add_channel requires a Database reference"
+        )
         cur = await self._database.execute_write(
             """INSERT INTO channels (channel_id, title, username, channel_type, is_active,
                                      about, linked_chat_id, has_comments, created_at)
@@ -193,6 +196,9 @@ class ChannelsRepository:
 
     async def update_channel_last_id(self, channel_id: int, last_id: int) -> None:
         """Продвинуть курсор инкрементального сбора (`last_collected_id`) — только вперёд (монотонно)."""
+        assert self._database is not None, (
+            "ChannelsRepository.update_channel_last_id requires a Database reference"
+        )
         await self._database.execute_write(
             """
             UPDATE channels
@@ -207,10 +213,16 @@ class ChannelsRepository:
 
     async def set_channel_active(self, pk: int, active: bool) -> None:
         """Включить/выключить отслеживание канала (неактивный не собирается)."""
+        assert self._database is not None, (
+            "ChannelsRepository.set_channel_active requires a Database reference"
+        )
         await self._database.execute_write("UPDATE channels SET is_active = ? WHERE id = ?", (int(active), pk))
 
     async def set_channel_review(self, pk: int, reason: str) -> None:
         """Flag a channel for human review (quarantine) — stays active until resolved."""
+        assert self._database is not None, (
+            "ChannelsRepository.set_channel_review requires a Database reference"
+        )
         await self._database.execute_write(
             "UPDATE channels SET needs_review = 1, review_reason = ? WHERE id = ?",
             (reason, pk),
@@ -218,6 +230,9 @@ class ChannelsRepository:
 
     async def clear_channel_review(self, pk: int) -> None:
         """Clear the review flag (operator decided, or the channel resolved live again)."""
+        assert self._database is not None, (
+            "ChannelsRepository.clear_channel_review requires a Database reference"
+        )
         await self._database.execute_write(
             "UPDATE channels SET needs_review = 0, review_reason = '' WHERE id = ?",
             (pk,),
@@ -256,6 +271,9 @@ class ChannelsRepository:
         на write-соединение внутри уже открытой транзакции вызывающего — см.
         комментарий в теле о write- против read-пула (#760).
         """
+        assert self._database is not None, (
+            "ChannelsRepository.set_filtered_bulk requires a Database reference"
+        )
         if not updates:
             return 0
         # When commit=False, the caller already holds a Database.transaction()
@@ -281,19 +299,23 @@ class ChannelsRepository:
                     if rowcount > 0:
                         updated_rows += rowcount
             return updated_rows
-        assert self._database is not None
+        db = self._database
+        write_conn = db.db
+        assert write_conn is not None, (
+            "ChannelsRepository.set_filtered_bulk requires an active Database connection"
+        )
         # Enforce the #569 invariant: the only safe caller is one that already
         # owns a Database.transaction() block (holding _write_lock transitively).
         # Without this guard a future commit=False caller outside any transaction
         # would write through the shared connection with no lock and resurrect the
         # race that execute_write/transaction exist to close (#1182).
-        assert self._database.db.in_transaction, (
+        assert write_conn.in_transaction, (
             "ChannelsRepository.set_filtered_bulk(commit=False) must run inside a "
             "caller-owned Database.transaction() block (write-lock invariant #569)"
         )
         updated_rows = 0
         for channel_id, flags_csv in updates:
-            cur = await self._database.db.execute(
+            cur = await write_conn.execute(
                 "UPDATE channels SET is_filtered = 1, filter_flags = ? WHERE channel_id = ?",
                 (flags_csv, channel_id),
             )
@@ -315,18 +337,28 @@ class ChannelsRepository:
             rowcount = cur.rowcount if cur.rowcount is not None else 0
             return rowcount if rowcount > 0 else 0
         # commit=False: write on the caller's open write transaction (see set_filtered_bulk).
-        assert self._database is not None
+        assert self._database is not None, (
+            "ChannelsRepository.reset_all_filters requires a Database reference"
+        )
+        db = self._database
+        write_conn = db.db
+        assert write_conn is not None, (
+            "ChannelsRepository.reset_all_filters requires an active Database connection"
+        )
         # Enforce the #569 invariant — see set_filtered_bulk(commit=False) (#1182).
-        assert self._database.db.in_transaction, (
+        assert write_conn.in_transaction, (
             "ChannelsRepository.reset_all_filters(commit=False) must run inside a "
             "caller-owned Database.transaction() block (write-lock invariant #569)"
         )
-        cur = await self._database.db.execute("UPDATE channels SET is_filtered = 0, filter_flags = ''")
+        cur = await write_conn.execute("UPDATE channels SET is_filtered = 0, filter_flags = ''")
         rowcount = cur.rowcount if cur.rowcount is not None else 0
         return rowcount if rowcount > 0 else 0
 
     async def reset_filters_for_pks(self, pks: list[int], *, commit: bool = True) -> int:
         """Снять фильтрацию только с указанных pk; вернуть число снятых. ``commit`` как в :meth:`set_filtered_bulk`."""
+        assert self._database is not None, (
+            "ChannelsRepository.reset_filters_for_pks requires a Database reference"
+        )
         if not pks:
             return 0
         placeholders = ",".join("?" * len(pks))
@@ -343,18 +375,25 @@ class ChannelsRepository:
             rowcount = cur.rowcount if cur.rowcount is not None else 0
             return rowcount if rowcount > 0 else 0
         # commit=False: write on the caller's open write transaction (see set_filtered_bulk).
-        assert self._database is not None
+        db = self._database
+        write_conn = db.db
+        assert write_conn is not None, (
+            "ChannelsRepository.reset_filters_for_pks requires an active Database connection"
+        )
         # Enforce the #569 invariant — see set_filtered_bulk(commit=False) (#1182).
-        assert self._database.db.in_transaction, (
+        assert write_conn.in_transaction, (
             "ChannelsRepository.reset_filters_for_pks(commit=False) must run inside a "
             "caller-owned Database.transaction() block (write-lock invariant #569)"
         )
-        cur = await self._database.db.execute(sql, tuple(pks))
+        cur = await write_conn.execute(sql, tuple(pks))
         rowcount = cur.rowcount if cur.rowcount is not None else 0
         return rowcount if rowcount > 0 else 0
 
     async def set_channel_type(self, channel_id: int, channel_type: str) -> None:
         """Обновить тип канала (channel/supergroup/group/…) по Telegram ``channel_id``."""
+        assert self._database is not None, (
+            "ChannelsRepository.set_channel_type requires a Database reference"
+        )
         await self._database.execute_write(
             "UPDATE channels SET channel_type=? WHERE channel_id=?",
             (channel_type, channel_id),
@@ -364,6 +403,9 @@ class ChannelsRepository:
         self, channel_id: int, *, username: str | None, title: str | None
     ) -> None:
         """Обновить username и title канала (после переименования/смены @username)."""
+        assert self._database is not None, (
+            "ChannelsRepository.update_channel_meta requires a Database reference"
+        )
         await self._database.execute_write(
             "UPDATE channels SET username = ?, title = ? WHERE channel_id = ?",
             (username, title, channel_id),
@@ -373,6 +415,9 @@ class ChannelsRepository:
         self, channel_id: int, *, about: str | None, linked_chat_id: int | None, has_comments: bool
     ) -> None:
         """Обновить расширенные метаданные канала: описание, привязанный чат и наличие комментариев."""
+        assert self._database is not None, (
+            "ChannelsRepository.update_channel_full_meta requires a Database reference"
+        )
         await self._database.execute_write(
             "UPDATE channels SET about = ?, linked_chat_id = ?, has_comments = ? WHERE channel_id = ?",
             (about, linked_chat_id, int(has_comments), channel_id),
@@ -382,6 +427,9 @@ class ChannelsRepository:
         self, channel_id: int, phone: str | None
     ) -> None:
         """Set or clear the preferred Telegram account phone for collecting this channel."""
+        assert self._database is not None, (
+            "ChannelsRepository.update_channel_preferred_phone requires a Database reference"
+        )
         await self._database.execute_write(
             "UPDATE channels SET preferred_phone = ? WHERE channel_id = ?",
             (phone, channel_id),
@@ -398,6 +446,9 @@ class ChannelsRepository:
 
     async def update_channel_created_at(self, channel_id: int, created_at) -> None:
         """Set created_at only if currently NULL (backfill from entity.date)."""
+        assert self._database is not None, (
+            "ChannelsRepository.update_channel_created_at requires a Database reference"
+        )
         iso = created_at.isoformat() if hasattr(created_at, "isoformat") else created_at
         await self._database.execute_write(
             "UPDATE channels SET created_at = ? WHERE channel_id = ? AND created_at IS NULL",
@@ -526,6 +577,9 @@ class ChannelsRepository:
 
     async def create_tag(self, name: str) -> None:
         """Создать тег по имени (пустое игнорируется, дубликат — no-op через INSERT OR IGNORE)."""
+        assert self._database is not None, (
+            "ChannelsRepository.create_tag requires a Database reference"
+        )
         name = name.strip()
         if not name:
             return
@@ -533,6 +587,9 @@ class ChannelsRepository:
 
     async def delete_tag(self, name: str) -> None:
         """Удалить тег по имени (связи каналов с ним уходят каскадом по FK)."""
+        assert self._database is not None, (
+            "ChannelsRepository.delete_tag requires a Database reference"
+        )
         await self._database.execute_write("DELETE FROM tags WHERE name = ?", (name,))
 
     async def get_channel_tags(self, channel_pk: int) -> list[str]:

--- a/src/database/repositories/collection_tasks.py
+++ b/src/database/repositories/collection_tasks.py
@@ -174,6 +174,9 @@ class CollectionTasksRepository:
         ``run_after`` откладывает запуск (хранится в UTC); если нужна дедупликация
         по уже активной задаче канала — см. :meth:`create_collection_task_if_not_active`.
         """
+        assert self._database is not None, (
+            "CollectionTasksRepository.create_collection_task requires a Database reference"
+        )
         run_after_iso = run_after.astimezone(timezone.utc).isoformat() if run_after else None
         payload_json = self._serialize_payload(payload)
         cur = await self._database.execute_write(
@@ -207,6 +210,9 @@ class CollectionTasksRepository:
 
         Returns the new task ID, or ``None`` if an active task already exists.
         """
+        assert self._database is not None, (
+            "CollectionTasksRepository.create_collection_task_if_not_active requires a Database reference"
+        )
         run_after_iso = run_after.astimezone(timezone.utc).isoformat() if run_after else None
         payload_json = self._serialize_payload(payload)
         cur = await self._database.execute_write(
@@ -244,6 +250,9 @@ class CollectionTasksRepository:
         parent_task_id: int | None = None,
     ) -> int:
         """Поставить задачу обновления статистики всех каналов (STATS_ALL); вернуть её id."""
+        assert self._database is not None, (
+            "CollectionTasksRepository.create_stats_task requires a Database reference"
+        )
         run_after_iso = run_after.astimezone(timezone.utc).isoformat() if run_after else None
         cur = await self._database.execute_write(
             "INSERT INTO collection_tasks "
@@ -269,6 +278,9 @@ class CollectionTasksRepository:
         concurrent POSTs (review on #823). Returns the new task id, or ``None``
         when a pending/running task already exists.
         """
+        assert self._database is not None, (
+            "CollectionTasksRepository.create_filter_analyze_task requires a Database reference"
+        )
         cur = await self._database.execute_write(
             "INSERT INTO collection_tasks "
             "(channel_id, channel_title, channel_username, task_type, payload) "
@@ -321,6 +333,9 @@ class CollectionTasksRepository:
 
     async def update_collection_task_progress(self, task_id: int, messages_collected: int) -> None:
         """Записать прогресс задачи (число собранных сообщений) и обновить «часы прогресса» (`last_progress_at`)."""
+        assert self._database is not None, (
+            "CollectionTasksRepository.update_collection_task_progress requires a Database reference"
+        )
         now = datetime.now(tz=timezone.utc).isoformat()
         await self._database.execute_write(
             "UPDATE collection_tasks SET messages_collected = ?, last_progress_at = ? WHERE id = ?",
@@ -335,6 +350,9 @@ class CollectionTasksRepository:
         messages_collected: int,
     ) -> None:
         """Persist current cursor/counters into the DB row for crash-safe resume."""
+        assert self._database is not None, (
+            "CollectionTasksRepository.persist_stats_progress requires a Database reference"
+        )
         await self._database.execute_write(
             "UPDATE collection_tasks SET messages_collected = ?, payload = ? WHERE id = ?",
             (messages_collected, self._serialize_payload(payload), task_id),
@@ -356,6 +374,9 @@ class CollectionTasksRepository:
         CANCELLED row protected by the guard below, or a ``required_status``
         mismatch). ``required_status`` adds ``AND status = ?`` so e.g. the interop
         complete/fail API only mutates a task that is actually RUNNING (#961)."""
+        assert self._database is not None, (
+            "CollectionTasksRepository.update_collection_task requires a Database reference"
+        )
         status_value = status.value if isinstance(status, CollectionTaskStatus) else status
         now = datetime.now(tz=timezone.utc).isoformat()
         sets = ["status = ?"]
@@ -415,6 +436,9 @@ class CollectionTasksRepository:
 
         Терминальный CANCELLED не трогается (#633).
         """
+        assert self._database is not None, (
+            "CollectionTasksRepository.reschedule_collection_task requires a Database reference"
+        )
         sets = [
             "status = ?",
             "run_after = ?",
@@ -448,6 +472,9 @@ class CollectionTasksRepository:
         note: str | None = None,
     ) -> None:
         """Сбросить задачу в PENDING немедленно, очистив отметки выполнения; CANCELLED не трогается."""
+        assert self._database is not None, (
+            "CollectionTasksRepository.reset_collection_task_to_pending requires a Database reference"
+        )
         sets = [
             "status = ?",
             "started_at = NULL",
@@ -592,6 +619,9 @@ class CollectionTasksRepository:
         messages_collected: int,
     ) -> None:
         """Return an in-progress stats task to PENDING with updated payload/run_after."""
+        assert self._database is not None, (
+            "CollectionTasksRepository.reschedule_stats_task requires a Database reference"
+        )
         await self._database.execute_write(
             "UPDATE collection_tasks "
             "SET status = ?, payload = ?, run_after = ?, messages_collected = ?, "
@@ -622,6 +652,9 @@ class CollectionTasksRepository:
 
     async def delete_pending_channel_tasks(self) -> int:
         """Удалить все ожидающие задачи сбора (очистить очередь); вернуть число удалённых."""
+        assert self._database is not None, (
+            "CollectionTasksRepository.delete_pending_channel_tasks requires a Database reference"
+        )
         cur = await self._database.execute_write(
             "DELETE FROM collection_tasks "
             "WHERE task_type = ? AND status = ?",
@@ -638,6 +671,9 @@ class CollectionTasksRepository:
         Вариант, требующий ручного перезапуска; см. :meth:`reset_orphaned_running_tasks`,
         который вместо этого возвращает их в PENDING для авто-восстановления.
         """
+        assert self._database is not None, (
+            "CollectionTasksRepository.fail_running_collection_tasks_on_startup requires a Database reference"
+        )
         now = datetime.now(tz=timezone.utc).isoformat()
         cur = await self._database.execute_write(
             "UPDATE collection_tasks "
@@ -657,6 +693,9 @@ class CollectionTasksRepository:
         Called on startup to recover from ungraceful shutdowns where RUNNING
         tasks were not properly completed or failed.
         """
+        assert self._database is not None, (
+            "CollectionTasksRepository.reset_orphaned_running_tasks requires a Database reference"
+        )
         cur = await self._database.execute_write(
             "UPDATE collection_tasks "
             "SET status = ?, started_at = NULL, completed_at = NULL, error = NULL "
@@ -689,6 +728,9 @@ class CollectionTasksRepository:
         parent_task_id: int | None = None,
     ) -> int:
         """Поставить «генерическую» задачу диспетчера (PIPELINE_RUN, CONTENT_*, EXPORT…); вернуть её id."""
+        assert self._database is not None, (
+            "CollectionTasksRepository.create_generic_task requires a Database reference"
+        )
         tt = task_type
         task_type_value = tt.value if isinstance(tt, CollectionTaskType) else tt
         run_after_iso = run_after.astimezone(timezone.utc).isoformat() if run_after else None
@@ -746,6 +788,9 @@ class CollectionTasksRepository:
         self, now: datetime, handled_types: list[str]
     ) -> int:
         """На старте вернуть зависшие RUNNING генерические задачи в PENDING (авто-восстановление); вернуть число."""
+        assert self._database is not None, (
+            "CollectionTasksRepository.requeue_running_generic_tasks_on_startup requires a Database reference"
+        )
         if not handled_types:
             return 0
         now_iso = now.astimezone(timezone.utc).isoformat()
@@ -767,6 +812,9 @@ class CollectionTasksRepository:
         note: str | None = None,
     ) -> int:
         """На старте пометить зависшие RUNNING генерические задачи как failed с заданным ``error``; вернуть число."""
+        assert self._database is not None, (
+            "CollectionTasksRepository.fail_running_generic_tasks_on_startup requires a Database reference"
+        )
         if not handled_types:
             return 0
         now_iso = now.astimezone(timezone.utc).isoformat()
@@ -827,6 +875,9 @@ class CollectionTasksRepository:
         Терминальные задачи не трогаются (WHERE по статусу), поэтому ``False``
         означает «нечего было отменять».
         """
+        assert self._database is not None, (
+            "CollectionTasksRepository.cancel_collection_task requires a Database reference"
+        )
         now = datetime.now(tz=timezone.utc).isoformat()
         sets = ["status = 'cancelled'", "completed_at = ?"]
         params: list[Any] = [now]

--- a/src/database/repositories/content_pipelines.py
+++ b/src/database/repositories/content_pipelines.py
@@ -176,6 +176,9 @@ class ContentPipelinesRepository:
 
     async def update_generate_interval(self, pipeline_id: int, minutes: int) -> None:
         """Изменить интервал автогенерации (в минутах) для пайплайна."""
+        assert self._database is not None, (
+            "ContentPipelinesRepository.update_generate_interval requires a Database reference"
+        )
         await self._database.execute_write(
             "UPDATE content_pipelines SET generate_interval_minutes = ? WHERE id = ?",
             (minutes, pipeline_id),
@@ -239,6 +242,9 @@ class ContentPipelinesRepository:
 
     async def set_refinement_steps(self, pipeline_id: int, steps: list[dict]) -> None:
         """Сохранить шаги доработки текста (список ``{name, prompt}``) для пайплайна как JSON."""
+        assert self._database is not None, (
+            "ContentPipelinesRepository.set_refinement_steps requires a Database reference"
+        )
         await self._database.execute_write(
             "UPDATE content_pipelines SET refinement_steps = ? WHERE id = ?",
             (json.dumps(steps, ensure_ascii=False), pipeline_id),
@@ -246,6 +252,9 @@ class ContentPipelinesRepository:
 
     async def set_pipeline_json(self, pipeline_id: int, graph: PipelineGraph | None) -> None:
         """Сохранить (или очистить через ``None``) DAG-конфигурацию пайплайна (issue #343)."""
+        assert self._database is not None, (
+            "ContentPipelinesRepository.set_pipeline_json requires a Database reference"
+        )
         value = graph.to_json() if graph else None
         await self._database.execute_write(
             "UPDATE content_pipelines SET pipeline_json = ? WHERE id = ?",
@@ -254,6 +263,9 @@ class ContentPipelinesRepository:
 
     async def set_active(self, pipeline_id: int, active: bool) -> None:
         """Включить/выключить пайплайн (неактивный не запускается планировщиком)."""
+        assert self._database is not None, (
+            "ContentPipelinesRepository.set_active requires a Database reference"
+        )
         await self._database.execute_write(
             "UPDATE content_pipelines SET is_active = ? WHERE id = ?",
             (int(active), pipeline_id),
@@ -261,6 +273,9 @@ class ContentPipelinesRepository:
 
     async def set_last_generated_id(self, pipeline_id: int, value: int) -> None:
         """Сдвинуть курсор последнего обработанного сообщения-источника (инкрементальная генерация)."""
+        assert self._database is not None, (
+            "ContentPipelinesRepository.set_last_generated_id requires a Database reference"
+        )
         await self._database.execute_write(
             "UPDATE content_pipelines SET last_generated_id = ? WHERE id = ?",
             (value, pipeline_id),
@@ -268,6 +283,9 @@ class ContentPipelinesRepository:
 
     async def delete(self, pipeline_id: int) -> None:
         """Удалить пайплайн по id (источники/цели уходят каскадом по FK)."""
+        assert self._database is not None, (
+            "ContentPipelinesRepository.delete requires a Database reference"
+        )
         await self._database.execute_write("DELETE FROM content_pipelines WHERE id = ?", (pipeline_id,))
 
     async def list_sources(self, pipeline_id: int) -> list[PipelineSource]:

--- a/src/database/repositories/dialog_cache.py
+++ b/src/database/repositories/dialog_cache.py
@@ -116,6 +116,9 @@ class DialogCacheRepository:
 
     async def clear_dialogs(self, phone: str) -> None:
         """Удалить кэш диалогов одного аккаунта."""
+        assert self._database is not None, (
+            "DialogCacheRepository.clear_dialogs requires a Database reference"
+        )
         await self._database.execute_write("DELETE FROM dialog_cache WHERE phone = ?", (phone,))
 
     async def has_dialogs(self, phone: str) -> bool:
@@ -154,4 +157,7 @@ class DialogCacheRepository:
 
     async def clear_all_dialogs(self) -> None:
         """Delete all entries from dialog_cache regardless of phone."""
+        assert self._database is not None, (
+            "DialogCacheRepository.clear_all_dialogs requires a Database reference"
+        )
         await self._database.execute_write("DELETE FROM dialog_cache")

--- a/src/database/repositories/filters.py
+++ b/src/database/repositories/filters.py
@@ -348,6 +348,9 @@ class FilterRepository:
 
     async def _open_readonly_conn(self) -> aiosqlite.Connection:
         """Open a temporary read-only connection for parallel queries."""
+        assert self._database is not None, (
+            "FilterRepository._open_readonly_conn requires a Database reference"
+        )
         db_path = self._database._db_path  # noqa: SLF001
         conn = await aiosqlite.connect(
             f"file:{db_path}?mode=ro",

--- a/src/database/repositories/generated_images.py
+++ b/src/database/repositories/generated_images.py
@@ -40,6 +40,9 @@ class GeneratedImagesRepository:
 
     async def save(self, prompt: str, model: str | None, image_url: str | None, local_path: str | None) -> int:
         """Сохранить запись о сгенерированном изображении. Возвращает id новой строки."""
+        assert self._database is not None, (
+            "GeneratedImagesRepository.save requires a Database reference"
+        )
         cur = await self._database.execute_write(
             "INSERT INTO generated_images (prompt, model, image_url, local_path) VALUES (?, ?, ?, ?)",
             (prompt, model, image_url, local_path),

--- a/src/database/repositories/generation_runs.py
+++ b/src/database/repositories/generation_runs.py
@@ -62,6 +62,9 @@ class GenerationRunsRepository:
 
     async def create_run(self, pipeline_id: int | None, prompt: str) -> int:
         """Создать запуск в статусе ``pending`` для пайплайна и промпта; вернуть его id."""
+        assert self._database is not None, (
+            "GenerationRunsRepository.create_run requires a Database reference"
+        )
         cur = await self._database.execute_write(
             ("INSERT INTO generation_runs (pipeline_id, status, prompt, created_at) "
              "VALUES (?, 'pending', ?, datetime('now'))"),
@@ -71,6 +74,9 @@ class GenerationRunsRepository:
 
     async def set_status(self, run_id: int, status: str, metadata: dict | None = None) -> None:
         """Обновить статус выполнения запуска; при переданном ``metadata`` — заодно перезаписать JSON-метаданные."""
+        assert self._database is not None, (
+            "GenerationRunsRepository.set_status requires a Database reference"
+        )
         if metadata is not None:
             await self._database.execute_write(
                 ("UPDATE generation_runs SET status = ?, metadata = ?, "
@@ -87,6 +93,9 @@ class GenerationRunsRepository:
         self, run_id: int, generated_text: str, metadata: dict | None = None
     ) -> None:
         """Сохранить сгенерированный текст и метаданные, переводя запуск в статус ``completed``."""
+        assert self._database is not None, (
+            "GenerationRunsRepository.save_result requires a Database reference"
+        )
         await self._database.execute_write(
             ("UPDATE generation_runs SET generated_text = ?, metadata = ?, status = 'completed', "
              "updated_at = datetime('now') WHERE id = ?"),
@@ -112,6 +121,9 @@ class GenerationRunsRepository:
         ``published_at``. ``list_pending_moderation`` surfaces ``pending`` +
         ``approved`` (drafts and approved-but-not-yet-delivered runs).
         """
+        assert self._database is not None, (
+            "GenerationRunsRepository.set_moderation_status requires a Database reference"
+        )
         await self._database.execute_write(
             "UPDATE generation_runs SET moderation_status = ?, updated_at = datetime('now') WHERE id = ?",
             (status, run_id),
@@ -128,6 +140,9 @@ class GenerationRunsRepository:
         mid-batch error rolls the whole update back and propagates so the
         caller can surface the failure instead of a partial-success message.
         """
+        assert self._database is not None, (
+            "GenerationRunsRepository.set_moderation_status_bulk requires a Database reference"
+        )
         if not run_ids:
             return
         async with self._database.transaction() as conn:
@@ -138,6 +153,9 @@ class GenerationRunsRepository:
 
     async def set_image_url(self, run_id: int, image_url: str) -> None:
         """Привязать к запуску URL/путь сгенерированной картинки."""
+        assert self._database is not None, (
+            "GenerationRunsRepository.set_image_url requires a Database reference"
+        )
         await self._database.execute_write(
             "UPDATE generation_runs SET image_url = ?, updated_at = datetime('now') WHERE id = ?",
             (image_url, run_id),
@@ -203,6 +221,9 @@ class GenerationRunsRepository:
         (the publish path gates on ``status='completed'``), so its ``image_url`` is
         dead bookkeeping once the live retry owns the picture.
         """
+        assert self._database is not None, (
+            "GenerationRunsRepository.claim_orphan_image requires a Database reference"
+        )
         async with self._database.transaction() as conn:
             await conn.execute(
                 "UPDATE generation_runs SET image_url = ?, updated_at = datetime('now') WHERE id = ?",
@@ -222,6 +243,9 @@ class GenerationRunsRepository:
         статуса и ``published_at`` не трогает), иначе получите published-запуск
         без отметки времени.
         """
+        assert self._database is not None, (
+            "GenerationRunsRepository.set_published_at requires a Database reference"
+        )
         await self._database.execute_write(
             ("UPDATE generation_runs SET published_at = datetime('now'), "
              "moderation_status = 'published', updated_at = datetime('now') WHERE id = ?"),
@@ -234,6 +258,9 @@ class GenerationRunsRepository:
         Used to record incremental publish progress (per-target delivery) so a
         retry does not re-send to targets already published.
         """
+        assert self._database is not None, (
+            "GenerationRunsRepository.set_metadata requires a Database reference"
+        )
         await self._database.execute_write(
             "UPDATE generation_runs SET metadata = ?, updated_at = datetime('now') WHERE id = ?",
             (safe_json_dumps(metadata, ensure_ascii=False), run_id),
@@ -243,6 +270,9 @@ class GenerationRunsRepository:
         self, run_id: int, score: float, issues: list[str] | None = None
     ) -> None:
         """Сохранить оценку качества запуска и (опционально) список выявленных проблем."""
+        assert self._database is not None, (
+            "GenerationRunsRepository.set_quality_score requires a Database reference"
+        )
         issues_json = safe_json_dumps(issues, ensure_ascii=False) if issues else None
         await self._database.execute_write(
             ("UPDATE generation_runs SET quality_score = ?, quality_issues = ?, "
@@ -252,6 +282,9 @@ class GenerationRunsRepository:
 
     async def set_variants(self, run_id: int, variants: list[str]) -> None:
         """Сохранить список A/B-вариантов текста запуска (issue #1068)."""
+        assert self._database is not None, (
+            "GenerationRunsRepository.set_variants requires a Database reference"
+        )
         await self._database.execute_write(
             "UPDATE generation_runs SET variants = ?, updated_at = datetime('now') WHERE id = ?",
             (safe_json_dumps(variants, ensure_ascii=False), run_id),
@@ -263,6 +296,9 @@ class GenerationRunsRepository:
         Заодно обнуляет ``quality_score``/``quality_issues`` — они относились к
         прежнему тексту и были бы устаревшими (см. комментарий ниже).
         """
+        assert self._database is not None, (
+            "GenerationRunsRepository.select_variant requires a Database reference"
+        )
         # Selecting a variant changes generated_text, so any existing
         # quality_score/quality_issues belong to the PREVIOUS text and would be
         # stale — a low-quality selected variant could otherwise hide behind a
@@ -305,6 +341,9 @@ class GenerationRunsRepository:
 
     async def reset_running_on_startup(self) -> int:
         """Reset generation_runs stuck in 'running' state to 'failed' on server startup."""
+        assert self._database is not None, (
+            "GenerationRunsRepository.reset_running_on_startup requires a Database reference"
+        )
         cur = await self._database.execute_write(
             "UPDATE generation_runs SET status = 'failed', updated_at = datetime('now') WHERE status = 'running'",
         )

--- a/src/database/repositories/messages.py
+++ b/src/database/repositories/messages.py
@@ -131,6 +131,9 @@ class MessagesRepository:
         return row["value"] if row else None
 
     async def _set_setting(self, key: str, value: str) -> None:
+        assert self._database is not None, (
+            "MessagesRepository._set_setting requires a Database reference"
+        )
         await self._database.execute_write(
             """
             INSERT INTO settings (key, value)
@@ -184,6 +187,9 @@ class MessagesRepository:
         пробрасывает наружу (не маскирует под «не сохранилось»), чтобы вызывающий
         пересобрал заново.
         """
+        assert self._database is not None, (
+            "MessagesRepository.insert_message requires a Database reference"
+        )
         # Local import — see insert_messages_batch for the partial-init rationale.
         from src.database import DatabaseBusyError
 
@@ -255,6 +261,9 @@ class MessagesRepository:
         ``message_date`` is the parent message's ISO date, stored on each reaction
         row so analytics can filter by recency without joining messages (#760).
         """
+        assert self._database is not None, (
+            "MessagesRepository._upsert_reactions requires a Database reference"
+        )
         items = _parse_reactions_json(reactions_json)
         data = [(channel_id, message_id, r["emoji"], r.get("count", 0), message_date) for r in items]
         try:
@@ -286,6 +295,9 @@ class MessagesRepository:
         строки, добытые Premium-поиском (для последующей очистки). Транзиентная
         блокировка пробрасывается наружу, как и в :meth:`insert_message`.
         """
+        assert self._database is not None, (
+            "MessagesRepository.insert_messages_batch requires a Database reference"
+        )
         if not messages:
             return 0
         data = [
@@ -422,6 +434,9 @@ class MessagesRepository:
         clear_premium_search_query: bool = False,
     ) -> None:
         """Refresh mutable fields for already-known Telegram messages."""
+        assert self._database is not None, (
+            "MessagesRepository._refresh_existing_messages requires a Database reference"
+        )
         if not messages:
             return
         data = [
@@ -496,6 +511,9 @@ class MessagesRepository:
 
         Все векторы должны быть одной размерности (она фиксируется индексом).
         """
+        assert self._database is not None, (
+            "MessagesRepository.upsert_message_embeddings requires a Database reference"
+        )
         if not embeddings:
             return 0
         dimensions = len(embeddings[0][1])
@@ -518,6 +536,9 @@ class MessagesRepository:
         self, embeddings: list[tuple[int, list[float]]]
     ) -> int:
         """Store embeddings in the portable JSON table (issue #173)."""
+        assert self._database is not None, (
+            "MessagesRepository.upsert_message_embedding_json requires a Database reference"
+        )
         if not embeddings:
             return 0
         dimensions = len(embeddings[0][1])
@@ -1581,6 +1602,9 @@ class MessagesRepository:
 
     async def update_detected_lang(self, message_db_id: int, lang: str) -> None:
         """Update detected_lang for a message."""
+        assert self._database is not None, (
+            "MessagesRepository.update_detected_lang requires a Database reference"
+        )
         await self._database.execute_write("UPDATE messages SET detected_lang = ? WHERE id = ?", (lang, message_db_id))
 
     # ── translation helpers ──────────────────────────────────────────
@@ -1634,6 +1658,9 @@ class MessagesRepository:
 
     async def update_translation(self, message_db_id: int, target: str, translated_text: str) -> None:
         """Update translation_en or translation_custom for a message."""
+        assert self._database is not None, (
+            "MessagesRepository.update_translation requires a Database reference"
+        )
         col = "translation_en" if target == "en" else "translation_custom"
         await self._database.execute_write(
             f"UPDATE messages SET {col} = ? WHERE id = ?",

--- a/src/database/repositories/notification_bots.py
+++ b/src/database/repositories/notification_bots.py
@@ -48,6 +48,9 @@ class NotificationBotsRepository:
         конфликте-обновлении lastrowid остаётся от последней вставки в
         соединении, для точного id читайте строку по `tg_user_id`.
         """
+        assert self._database is not None, (
+            "NotificationBotsRepository.save_bot requires a Database reference"
+        )
         cur = await self._database.execute_write(
             """
             INSERT INTO notification_bots (tg_user_id, tg_username, bot_id, bot_username, bot_token)
@@ -70,6 +73,9 @@ class NotificationBotsRepository:
 
     async def delete_bot(self, tg_user_id: int) -> None:
         """Удалить бота пользователя по его Telegram id."""
+        assert self._database is not None, (
+            "NotificationBotsRepository.delete_bot requires a Database reference"
+        )
         await self._database.execute_write(
             "DELETE FROM notification_bots WHERE tg_user_id = ?",
             (tg_user_id,),

--- a/src/database/repositories/photo_loader.py
+++ b/src/database/repositories/photo_loader.py
@@ -104,6 +104,9 @@ class PhotoLoaderRepository:
 
     async def create_batch(self, batch: PhotoBatch) -> int:
         """Создать фото-батч (общая цель/режим отправки); вернуть его id."""
+        assert self._database is not None, (
+            "PhotoLoaderRepository.create_batch requires a Database reference"
+        )
         cur = await self._database.execute_write(
             """
             INSERT INTO photo_batches (
@@ -133,6 +136,9 @@ class PhotoLoaderRepository:
         last_run_at: datetime | None = None,
     ) -> None:
         """Частично обновить батч (статус/ошибку/время запуска); ни одного поля — no-op."""
+        assert self._database is not None, (
+            "PhotoLoaderRepository.update_batch requires a Database reference"
+        )
         sets: list[str] = []
         params: list[object] = []
         if status is not None:
@@ -203,6 +209,9 @@ class PhotoLoaderRepository:
 
     async def create_item(self, item: PhotoBatchItem) -> int:
         """Создать элемент батча (одна отправка с файлами и опциональным расписанием); вернуть id."""
+        assert self._database is not None, (
+            "PhotoLoaderRepository.create_item requires a Database reference"
+        )
         cur = await self._database.execute_write(
             """
             INSERT INTO photo_batch_items (
@@ -278,6 +287,9 @@ class PhotoLoaderRepository:
         completed_at: datetime | None = None,
     ) -> None:
         """Частично обновить элемент батча (статус, ошибка, id отправленных сообщений, тайминги); пусто — no-op."""
+        assert self._database is not None, (
+            "PhotoLoaderRepository.update_item requires a Database reference"
+        )
         sets: list[str] = []
         params: list[object] = []
         if status is not None:
@@ -305,6 +317,9 @@ class PhotoLoaderRepository:
 
     async def cancel_item(self, item_id: int) -> bool:
         """Отменить ещё не завершённый элемент (held/pending/scheduled/running); вернуть ``True``, если отменили."""
+        assert self._database is not None, (
+            "PhotoLoaderRepository.cancel_item requires a Database reference"
+        )
         cur = await self._database.execute_write(
             """
             UPDATE photo_batch_items
@@ -390,6 +405,9 @@ class PhotoLoaderRepository:
 
     async def requeue_running_items_on_startup(self, now: datetime) -> int:
         """На старте вернуть зависшие RUNNING-элементы в PENDING (авто-восстановление после сбоя); вернуть число."""
+        assert self._database is not None, (
+            "PhotoLoaderRepository.requeue_running_items_on_startup requires a Database reference"
+        )
         cur = await self._database.execute_write(
             """
             UPDATE photo_batch_items
@@ -406,6 +424,9 @@ class PhotoLoaderRepository:
 
     async def create_auto_job(self, job: PhotoAutoUploadJob) -> int:
         """Создать задание авто-загрузки новых файлов из папки по интервалу; вернуть id."""
+        assert self._database is not None, (
+            "PhotoLoaderRepository.create_auto_job requires a Database reference"
+        )
         cur = await self._database.execute_write(
             """
             INSERT INTO photo_auto_upload_jobs (
@@ -445,6 +466,9 @@ class PhotoLoaderRepository:
         last_seen_marker: str | None = None,
     ) -> None:
         """Частично обновить задание авто-загрузки (папка, режим, интервал, активность, маркер…); пусто — no-op."""
+        assert self._database is not None, (
+            "PhotoLoaderRepository.update_auto_job requires a Database reference"
+        )
         sets: list[str] = []
         params: list[object] = []
         if folder_path is not None:
@@ -520,6 +544,9 @@ class PhotoLoaderRepository:
 
     async def mark_auto_file_sent(self, job_id: int, file_path: str) -> None:
         """Отметить файл отправленным в леджере задания (идемпотентно, INSERT OR IGNORE)."""
+        assert self._database is not None, (
+            "PhotoLoaderRepository.mark_auto_file_sent requires a Database reference"
+        )
         await self._database.execute_write(
             """
             INSERT OR IGNORE INTO photo_auto_upload_files (job_id, file_path, sent_at)

--- a/src/database/repositories/pipeline_action_log.py
+++ b/src/database/repositories/pipeline_action_log.py
@@ -68,6 +68,9 @@ class PipelineActionLogRepository:
         message_id: int,
     ) -> None:
         """Record that (pipeline, node, action) acted on a message. Idempotent."""
+        assert self._database is not None, (
+            "PipelineActionLogRepository.log_action requires a Database reference"
+        )
         await self._database.execute_write(
             "INSERT OR IGNORE INTO pipeline_action_log "
             "(pipeline_id, node_id, action, channel_id, message_id) VALUES (?, ?, ?, ?, ?)",

--- a/src/database/repositories/pipeline_templates.py
+++ b/src/database/repositories/pipeline_templates.py
@@ -73,6 +73,9 @@ class PipelineTemplatesRepository:
 
     async def add(self, template: PipelineTemplate) -> int:
         """Сохранить шаблон (граф сериализуется в JSON). Возвращает id новой строки."""
+        assert self._database is not None, (
+            "PipelineTemplatesRepository.add requires a Database reference"
+        )
         cur = await self._database.execute_write(
             """
             INSERT INTO pipeline_templates (name, description, category, template_json, is_builtin)
@@ -90,6 +93,9 @@ class PipelineTemplatesRepository:
 
     async def delete(self, template_id: int) -> None:
         """Удалить шаблон по id."""
+        assert self._database is not None, (
+            "PipelineTemplatesRepository.delete requires a Database reference"
+        )
         await self._database.execute_write("DELETE FROM pipeline_templates WHERE id = ?", (template_id,))
 
     async def ensure_builtins(self, builtins: list[PipelineTemplate]) -> None:

--- a/src/database/repositories/runtime_snapshots.py
+++ b/src/database/repositories/runtime_snapshots.py
@@ -58,6 +58,9 @@ class RuntimeSnapshotsRepository:
 
         `updated_at` берётся из снимка либо проставляется текущим временем БД.
         """
+        assert self._database is not None, (
+            "RuntimeSnapshotsRepository.upsert_snapshot requires a Database reference"
+        )
         await self._database.execute_write(
             """
             INSERT INTO runtime_snapshots (snapshot_type, scope, payload, updated_at)

--- a/src/database/repositories/search_log.py
+++ b/src/database/repositories/search_log.py
@@ -28,6 +28,9 @@ class SearchLogRepository:
 
     async def log_search(self, phone: str, query: str, results_count: int) -> None:
         """Записать факт поиска: телефон, запрос и число найденных результатов."""
+        assert self._database is not None, (
+            "SearchLogRepository.log_search requires a Database reference"
+        )
         await self._database.execute_write(
             "INSERT INTO search_log (phone, query, results_count) VALUES (?, ?, ?)",
             (phone, query, results_count),

--- a/src/database/repositories/search_queries.py
+++ b/src/database/repositories/search_queries.py
@@ -32,6 +32,9 @@ class SearchQueriesRepository:
 
     async def add(self, sq: SearchQuery) -> int:
         """Создать сохранённый запрос; вернуть его новый id."""
+        assert self._database is not None, (
+            "SearchQueriesRepository.add requires a Database reference"
+        )
         cur = await self._database.execute_write(
             "INSERT INTO search_queries "
             "(name, query, is_regex, is_fts, is_active, notify_on_collect, "
@@ -71,12 +74,18 @@ class SearchQueriesRepository:
 
     async def set_active(self, sq_id: int, active: bool) -> None:
         """Включить/выключить запрос (неактивный не запускается планировщиком)."""
+        assert self._database is not None, (
+            "SearchQueriesRepository.set_active requires a Database reference"
+        )
         await self._database.execute_write(
             "UPDATE search_queries SET is_active = ? WHERE id = ?", (int(active), sq_id)
         )
 
     async def update(self, sq_id: int, sq: SearchQuery) -> None:
         """Перезаписать редактируемые поля запроса (флаг is_active не трогается — для него есть set_active)."""
+        assert self._database is not None, (
+            "SearchQueriesRepository.update requires a Database reference"
+        )
         await self._database.execute_write(
             "UPDATE search_queries SET name = ?, query = ?, is_regex = ?, is_fts = ?, "
             "notify_on_collect = ?, track_stats = ?, interval_minutes = ?, "

--- a/src/database/repositories/settings.py
+++ b/src/database/repositories/settings.py
@@ -51,6 +51,9 @@ class SettingsRepository:
 
     async def set_setting(self, key: str, value: str) -> None:
         """Записать/обновить настройку (upsert по ключу)."""
+        assert self._database is not None, (
+            "SettingsRepository.set_setting requires a Database reference"
+        )
         await self._database.execute_write(
             "INSERT INTO settings (key, value) VALUES (?, ?) "
             "ON CONFLICT(key) DO UPDATE SET value = excluded.value",

--- a/src/database/repositories/telegram_commands.py
+++ b/src/database/repositories/telegram_commands.py
@@ -63,6 +63,9 @@ class TelegramCommandsRepository:
 
     async def create_command(self, command: TelegramCommand) -> int:
         """Поставить команду в очередь воркеру. Возвращает id новой строки."""
+        assert self._database is not None, (
+            "TelegramCommandsRepository.create_command requires a Database reference"
+        )
         cur = await self._database.execute_write(
             """
             INSERT INTO telegram_commands (
@@ -212,6 +215,9 @@ class TelegramCommandsRepository:
         middle of a Telegram API call and the row would be overwritten when
         it finishes; cancel from the UI is only safe for not-yet-claimed work.
         """
+        assert self._database is not None, (
+            "TelegramCommandsRepository.cancel_command requires a Database reference"
+        )
         finished_at = datetime.now(timezone.utc).isoformat()
         cur = await self._database.execute_write(
             """
@@ -235,6 +241,9 @@ class TelegramCommandsRepository:
         phone: str | None = None,
     ) -> int:
         """Bulk-cancel PENDING commands matching the filters. Returns count."""
+        assert self._database is not None, (
+            "TelegramCommandsRepository.cancel_pending_commands requires a Database reference"
+        )
         finished_at = datetime.now(timezone.utc).isoformat()
         where = ["status = ?"]
         params: list[Any] = [TelegramCommandStatus.PENDING.value]
@@ -267,6 +276,9 @@ class TelegramCommandsRepository:
         they would stay claimed forever, since claim_next_command only picks
         PENDING rows.
         """
+        assert self._database is not None, (
+            "TelegramCommandsRepository.reset_running_on_startup requires a Database reference"
+        )
         cur = await self._database.execute_write(
             """
             UPDATE telegram_commands
@@ -338,6 +350,9 @@ class TelegramCommandsRepository:
         и `finished_at` пишутся через COALESCE — терминальный апдейт без свежего payload
         сохраняет прежнюю диагностику, а не затирает её в NULL (audit #835/15).
         """
+        assert self._database is not None, (
+            "TelegramCommandsRepository.update_command requires a Database reference"
+        )
         finished_at = None
         if status in {
             TelegramCommandStatus.SUCCEEDED,


### PR DESCRIPTION
Part of #1133

## What changed
- Added explicit assertion guards for optional database facade delegates before `self._<repo>` calls.
- Added explicit assertion guards for repository write helpers before `self._database` calls.
- Used local `db` / `write_conn` bindings where mypy needed narrowing for nested closures or `Database.db` property access.

## Mypy delta
| Metric | Before | After | Delta |
| --- | ---: | ---: | ---: |
| `python -m mypy src/` total | 723 | 547 | -176 |
| `src/database/` `[union-attr]` | 175 | 0 | -175 |
| total `[union-attr]` | 232 | 57 | -175 |
| new non-union errors | 0 | 0 | 0 |

Non-union code counts did not increase. `arg-type` stayed 108, `assignment` stayed 25, `attr-defined` stayed 245. Existing `return-value` dropped 26 -> 25 as a side-effect of the facade narrowing.

## Scope guardrails
- Did not change Optional field declarations to non-Optional.
- Did not add `type: ignore`.
- Did not touch CI workflow files.
- Did not address #1207 `arg-type` backlog.

## Validation
- `python -m mypy src/`
- `ruff check src/database/`
- `ruff check src/ tests/ conftest.py`
- `pytest tests/repositories/ tests/test_database.py -x -q` (`463 passed`)
- `pytest tests/ -k "database or facade" -x -q` (`229 passed, 9986 deselected`)
- `git diff --check`
