### PR TITLE
Part of #1133: annotate collector mixin self types

### DIFF
--- a/src/telegram/collector_mixins/cancellation.py
+++ b/src/telegram/collector_mixins/cancellation.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 from datetime import datetime
 from inspect import isawaitable
+from typing import TYPE_CHECKING
 
 from src.telegram.collector_types import (
     AllCollectionClientsFloodedError,
@@ -16,17 +17,28 @@ from src.telegram.flood_wait import (
     sleep_for_flood_wait_seconds,
 )
 
+if TYPE_CHECKING:
+    from typing import Any, Protocol, TypeAlias
+
+    from src.telegram.collector import Collector as _RuntimeCollector
+
+    _RuntimeCollectorType: TypeAlias = type[_RuntimeCollector]
+
+    class Collector(Protocol):
+        def __getattribute__(self, name: str) -> Any: ...
+        def __setattr__(self, name: str, value: Any) -> None: ...
+
 logger = logging.getLogger("src.telegram.collector")
 
 
 class CancellationMixin:
-    def _get_resolve_username_backoff_remaining_sec(self, phone: str | None = None) -> int:
+    def _get_resolve_username_backoff_remaining_sec(self: "Collector", phone: str | None = None) -> int:
         # The pool owns the single source of truth for the resolve backoff
         # (#785). With ``phone`` — that account's window; without — the
         # pool-wide aggregate (0 while any connected account is free, #790).
         return self._pool.get_resolve_username_backoff_remaining_sec(phone)
 
-    async def _can_rotate_resolve(self, attempted_phones: set[str]) -> bool:
+    async def _can_rotate_resolve(self: "Collector", attempted_phones: set[str]) -> bool:
         """True if another connected account outside ``attempted_phones`` can
         run a live username resolve right now (#790).
 
@@ -47,7 +59,7 @@ class CancellationMixin:
             return False
         return bool(has_capable(exclude=attempted_phones))
 
-    async def _next_resolve_capable_at(self) -> datetime | None:
+    async def _next_resolve_capable_at(self: "Collector") -> datetime | None:
         """Earliest moment any connected account can live-resolve again (#790).
 
         Prefers the async pool method, which also accounts for *generic*
@@ -64,7 +76,7 @@ class CancellationMixin:
             return result
         return self._pool.get_resolve_username_backoff_until()
 
-    async def get_collection_availability(self):
+    async def get_collection_availability(self: "Collector"):
         availability_fn = getattr(self._pool, "get_stats_availability", None)
         if callable(availability_fn):
             result = availability_fn()
@@ -73,7 +85,7 @@ class CancellationMixin:
         return await self._fallback_collection_availability()
 
     @property
-    def is_running(self) -> bool:
+    def is_running(self: "Collector") -> bool:
         return (
             bool(getattr(self, "_running", False))
             or int(getattr(self, "_active_collection_count", 0) or 0) > 0
@@ -81,16 +93,16 @@ class CancellationMixin:
             or bool(getattr(self, "_stats_all_running", False))
         )
 
-    def _is_collection_cancelled(self, cancel_event: asyncio.Event | None = None) -> bool:
+    def _is_collection_cancelled(self: "Collector", cancel_event: asyncio.Event | None = None) -> bool:
         if cancel_event is not None:
             return cancel_event.is_set() or self._cancel_event.is_set()
         return self._cancel_event.is_set()
 
-    def _should_clear_collection_cancel_on_start(self, cancel_event: asyncio.Event | None) -> bool:
+    def _should_clear_collection_cancel_on_start(self: "Collector", cancel_event: asyncio.Event | None) -> bool:
         return cancel_event is None or not self.is_running
 
     async def _wait_if_live_runtime_paused(
-        self,
+        self: "Collector",
         *,
         stop_event: asyncio.Event | None = None,
     ) -> bool:
@@ -100,7 +112,7 @@ class CancellationMixin:
             stop_event=stop_event or self._cancel_event
         )
 
-    async def _fallback_collection_availability(self):
+    async def _fallback_collection_availability(self: "Collector"):
         connected = bool(getattr(self._pool, "clients", {}))
         if connected:
             return type(
@@ -123,7 +135,7 @@ class CancellationMixin:
         )()
 
     def _log_collection_unavailability_once(
-        self,
+        self: "Collector",
         *,
         state: str,
         retry_after_sec: int | None = None,
@@ -149,10 +161,10 @@ class CancellationMixin:
             return
         logger.error("No available clients for collection: no active connected clients")
 
-    def _reset_collection_unavailability_log(self) -> None:
+    def _reset_collection_unavailability_log(self: "Collector") -> None:
         self._last_unavailability_log = None
 
-    async def _wait_for_transient_collection_flood(self, availability) -> bool:
+    async def _wait_for_transient_collection_flood(self: "Collector", availability) -> bool:
         retry_after_sec = getattr(availability, "retry_after_sec", None)
         if getattr(availability, "state", None) != "all_flooded":
             return False
@@ -166,7 +178,7 @@ class CancellationMixin:
         self._reset_collection_unavailability_log()
         return True
 
-    async def _raise_collection_unavailability(self, availability=None) -> None:
+    async def _raise_collection_unavailability(self: "Collector", availability=None) -> None:
         availability = availability or await self.get_collection_availability()
         self._log_collection_unavailability_once(
             state=availability.state,
@@ -184,18 +196,18 @@ class CancellationMixin:
             )
         raise NoActiveCollectionClientsError("No active connected clients")
 
-    async def cancel(self) -> None:
+    async def cancel(self: "Collector") -> None:
         self._cancel_event.set()
 
-    async def cancel_stats(self) -> None:
+    async def cancel_stats(self: "Collector") -> None:
         """Cancel an in-flight STATS_ALL run without touching channel collection."""
         self._stats_cancel_event.set()
 
-    def _is_stats_cancelled(self) -> bool:
+    def _is_stats_cancelled(self: "Collector") -> bool:
         # Global shutdown (cancel()) also stops stats; a stats-only cancel does not
         # stop channel collection.
         return self._cancel_event.is_set() or self._stats_cancel_event.is_set()
 
     @property
-    def is_cancelled(self) -> bool:
+    def is_cancelled(self: "Collector") -> bool:
         return self._cancel_event.is_set()

--- a/src/telegram/collector_mixins/collection.py
+++ b/src/telegram/collector_mixins/collection.py
@@ -8,6 +8,7 @@ from collections import Counter
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta, timezone
 from inspect import isawaitable
+from typing import TYPE_CHECKING
 
 from telethon.errors import FloodWaitError, UsernameInvalidError, UsernameNotOccupiedError
 from telethon.tl.types import PeerChannel
@@ -52,6 +53,17 @@ from src.telegram.rate_limiter import (
 )
 from src.utils.safe_logging import mask_phone
 
+if TYPE_CHECKING:
+    from typing import Any, Protocol, TypeAlias
+
+    from src.telegram.collector import Collector as _RuntimeCollector
+
+    _RuntimeCollectorType: TypeAlias = type[_RuntimeCollector]
+
+    class Collector(Protocol):
+        def __getattribute__(self, name: str) -> Any: ...
+        def __setattr__(self, name: str, value: Any) -> None: ...
+
 logger = logging.getLogger("src.telegram.collector")
 
 PERSISTED_ID_VERIFY_CHUNK_SIZE = 500
@@ -60,10 +72,10 @@ NOTIFICATION_BACKLOG_LOOKBACK_HOURS = 24.0
 
 class CollectionMixin:
     @property
-    def delay_between_channels_sec(self) -> int:
+    def delay_between_channels_sec(self: "Collector") -> int:
         return self._config.delay_between_channels_sec
 
-    def collection_worker_count(self) -> int:
+    def collection_worker_count(self: "Collector") -> int:
         configured = int(getattr(self._config, "collection_worker_count", 0) or 0)
         connected = len(getattr(self._pool, "clients", {}) or {})
         if configured <= 0:
@@ -72,7 +84,7 @@ class CollectionMixin:
             return max(1, configured)
         return max(1, min(configured, connected))
 
-    async def available_collection_slot_count(self) -> int:
+    async def available_collection_slot_count(self: "Collector") -> int:
         counter = getattr(self._pool, "available_collection_client_count", None)
         if callable(counter):
             try:
@@ -84,7 +96,7 @@ class CollectionMixin:
                 logger.debug("Failed to read available collection client slots", exc_info=True)
         return self.collection_worker_count()
 
-    async def available_collection_worker_count(self) -> int:
+    async def available_collection_worker_count(self: "Collector") -> int:
         configured = int(getattr(self._config, "collection_worker_count", 0) or 0)
         connected = len(getattr(self._pool, "clients", {}) or {})
         available = await self.available_collection_slot_count()
@@ -95,7 +107,7 @@ class CollectionMixin:
             return max(1, configured) if configured > 0 else 1
         return 1
 
-    async def _load_min_subscribers_filter(self) -> int:
+    async def _load_min_subscribers_filter(self: "Collector") -> int:
         return parse_int_setting(
             await self._db.get_setting("min_subscribers_filter"),
             setting_name="min_subscribers_filter",
@@ -103,7 +115,7 @@ class CollectionMixin:
             logger=logger,
         )
 
-    async def _is_auto_delete_enabled(self) -> bool:
+    async def _is_auto_delete_enabled(self: "Collector") -> bool:
         """Check if auto_delete_on_collect is enabled (cached per collection run)."""
         cached = getattr(self, "_auto_delete_cached", None)
         if cached is not None:
@@ -114,7 +126,7 @@ class CollectionMixin:
         return result
 
     async def _handle_meta_change_review(
-        self,
+        self: "Collector",
         channel: Channel,
         new_username: str | None,
         new_title: str | None,
@@ -174,7 +186,7 @@ class CollectionMixin:
         )
         return True
 
-    async def _maybe_auto_delete(self, channel_id: int) -> bool:
+    async def _maybe_auto_delete(self: "Collector", channel_id: int) -> bool:
         """Purge messages from filtered channel if auto_delete_on_collect is enabled."""
         if not await self._is_auto_delete_enabled():
             return False
@@ -191,7 +203,7 @@ class CollectionMixin:
             return False
 
     async def _resolve_channel_input_entity(
-        self,
+        self: "Collector",
         session,
         *,
         channel_id: int,
@@ -250,7 +262,7 @@ class CollectionMixin:
         )
 
     async def collect_single_channel(
-        self,
+        self: "Collector",
         channel: Channel,
         *,
         full: bool = False,
@@ -290,7 +302,7 @@ class CollectionMixin:
         finally:
             self._active_collection_count = max(0, self._active_collection_count - 1)
 
-    async def collect_all_channels(self) -> dict:
+    async def collect_all_channels(self: "Collector") -> dict:
         """Collect messages from all active channels. Returns stats."""
         async with self._lock:
             self._cancel_event.clear()
@@ -357,7 +369,7 @@ class CollectionMixin:
         """Determine media type from a Telethon message."""
         return get_media_type_for(msg)
 
-    async def _acquire_collection_client(self, channel: Channel, attempted_resolve_phones: set[str]):
+    async def _acquire_collection_client(self: "Collector", channel: Channel, attempted_resolve_phones: set[str]):
         """Pick a client for `channel`, adapt its session, decide cache-only resolve
         mode, and warm the PeerChannel dialog cache once per phone.
 
@@ -446,7 +458,7 @@ class CollectionMixin:
         return session, phone, resolve_cache_only
 
     async def _handle_post_collection_flood(
-        self,
+        self: "Collector",
         channel: Channel,
         phone: str,
         flood_wait_sec: int,
@@ -578,7 +590,7 @@ class CollectionMixin:
             return ("continue", total_collected + collected_count, updated)
         return ("return", total_collected, channel)
 
-    async def _verify_persisted_ids(self, channel_id: int, expected_ids: set[int]) -> set[int]:
+    async def _verify_persisted_ids(self: "Collector", channel_id: int, expected_ids: set[int]) -> set[int]:
         """Return which of ``expected_ids`` are actually present in ``messages``.
 
         Queried in ``PERSISTED_ID_VERIFY_CHUNK_SIZE``-sized ``IN (...)`` chunks to
@@ -601,7 +613,7 @@ class CollectionMixin:
         return persisted_ids
 
     async def _finalize_collection_pass(
-        self,
+        self: "Collector",
         *,
         channel_id: int,
         messages_batch: list[Message],
@@ -661,7 +673,7 @@ class CollectionMixin:
         return stop_due_to_persistence_error
 
     async def _collect_channel(
-        self,
+        self: "Collector",
         channel: Channel,
         progress_callback: Callable[[int], Awaitable[None]] | None = None,
         force: bool = False,
@@ -916,7 +928,7 @@ class CollectionMixin:
             return total_collected + collected_count
 
     async def _post_collection_actions(
-        self,
+        self: "Collector",
         channel_id: int,
         *,
         is_first_run: bool,
@@ -962,7 +974,7 @@ class CollectionMixin:
                     )
 
     async def _resolve_channel_entity(
-        self,
+        self: "Collector",
         channel: Channel,
         session,
         phone: str,
@@ -987,7 +999,7 @@ class CollectionMixin:
         )
 
     async def _apply_pre_collection_filters(
-        self,
+        self: "Collector",
         channel: Channel,
         channel_id: int,
         session,
@@ -1100,7 +1112,7 @@ class CollectionMixin:
         return True
 
     async def _discover_phone_for_channel(
-        self, channel_id: int, exclude: str
+        self: "Collector", channel_id: int, exclude: str
     ) -> str | None:
         """Try all connected phones (except `exclude`) to find one with access to channel_id.
 
@@ -1147,7 +1159,7 @@ class CollectionMixin:
         return None
 
     async def _precheck_sample(
-        self,
+        self: "Collector",
         session,
         entity,
         limit: int,
@@ -1167,7 +1179,7 @@ class CollectionMixin:
                 prefixes.append(msg.text[:100])
         return prefixes
 
-    async def _maybe_enqueue_auto_translate(self) -> None:
+    async def _maybe_enqueue_auto_translate(self: "Collector") -> None:
         """Enqueue a TRANSLATE_BATCH after collection if auto-translate is enabled.
 
         The settings toggle was previously inert — nothing read it (audit #836/6).
@@ -1199,7 +1211,7 @@ class CollectionMixin:
         except Exception:
             logger.warning("auto-translate enqueue failed", exc_info=True)
 
-    async def _check_notification_queries(self, messages: list[Message]) -> None:
+    async def _check_notification_queries(self: "Collector", messages: list[Message]) -> None:
         """Check messages against active notification queries and send batched notifications."""
         if not self._notifier:
             return
@@ -1263,10 +1275,10 @@ class CollectionMixin:
         )
         await matcher.match_and_notify(candidates, queries)
 
-    async def _channel_still_exists(self, channel_id: int) -> bool:
+    async def _channel_still_exists(self: "Collector", channel_id: int) -> bool:
         return await self._db.get_channel_by_channel_id(channel_id) is not None
 
-    async def sample_channel(self, channel_id: int, limit: int = 10) -> list[dict]:
+    async def sample_channel(self: "Collector", channel_id: int, limit: int = 10) -> list[dict]:
         """Fetch the last `limit` messages from a channel for preview. No DB writes."""
         result = await self._pool.get_available_client()
         if result is None:

--- a/src/telegram/collector_mixins/stats.py
+++ b/src/telegram/collector_mixins/stats.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 from collections import deque
 from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
 
 from telethon.errors import UsernameInvalidError, UsernameNotOccupiedError
 from telethon.tl.types import PeerChannel
@@ -22,29 +23,40 @@ from src.telegram.rate_limiter import (
     UsernameResolveRateLimitedError,
 )
 
+if TYPE_CHECKING:
+    from typing import Any, Protocol, TypeAlias
+
+    from src.telegram.collector import Collector as _RuntimeCollector
+
+    _RuntimeCollectorType: TypeAlias = type[_RuntimeCollector]
+
+    class Collector(Protocol):
+        def __getattribute__(self, name: str) -> Any: ...
+        def __setattr__(self, name: str, value: Any) -> None: ...
+
 logger = logging.getLogger("src.telegram.collector")
 
 
 class StatsMixin:
     @property
-    def is_stats_running(self) -> bool:
+    def is_stats_running(self: "Collector") -> bool:
         return self._stats_running or self._stats_all_running
 
-    def stats_worker_count(self) -> int:
+    def stats_worker_count(self: "Collector") -> int:
         configured = max(1, int(getattr(self._config, "stats_worker_count", 3) or 1))
         connected = len(getattr(self._pool, "clients", {}) or {})
         if connected <= 0:
             return configured
         return max(1, min(configured, connected))
 
-    def stats_all_worker_count(self) -> int:
+    def stats_all_worker_count(self: "Collector") -> int:
         configured = max(1, int(getattr(self._config, "stats_all_worker_count", 1) or 1))
         connected = len(getattr(self._pool, "clients", {}) or {})
         if connected <= 0:
             return configured
         return max(1, min(configured, connected))
 
-    async def available_stats_worker_count(self) -> int:
+    async def available_stats_worker_count(self: "Collector") -> int:
         configured = max(1, int(getattr(self._config, "stats_worker_count", 3) or 1))
         counter = getattr(self._pool, "available_stats_client_count", None)
         if callable(counter):
@@ -60,7 +72,7 @@ class StatsMixin:
                 logger.debug("Failed to read available stats client count", exc_info=True)
         return self.stats_worker_count()
 
-    async def available_stats_all_worker_count(self) -> int:
+    async def available_stats_all_worker_count(self: "Collector") -> int:
         configured = max(1, int(getattr(self._config, "stats_all_worker_count", 1) or 1))
         counter = getattr(self._pool, "available_stats_client_count", None)
         if callable(counter):
@@ -76,13 +88,13 @@ class StatsMixin:
                 logger.debug("Failed to read available stats-all client count", exc_info=True)
         return self.stats_all_worker_count()
 
-    def set_stats_all_running(self, running: bool) -> None:
+    def set_stats_all_running(self: "Collector", running: bool) -> None:
         self._stats_all_running = running
 
-    async def get_stats_availability(self):
+    async def get_stats_availability(self: "Collector"):
         return await self.get_collection_availability()
 
-    async def collect_channel_stats(self, channel: Channel) -> ChannelStats | None:
+    async def collect_channel_stats(self: "Collector", channel: Channel) -> ChannelStats | None:
         async with self._stats_lock:
             self._stats_running = True
             try:
@@ -96,11 +108,11 @@ class StatsMixin:
             finally:
                 self._stats_running = False
 
-    async def collect_channel_stats_unlocked(self, channel: Channel) -> ChannelStats | None:
+    async def collect_channel_stats_unlocked(self: "Collector", channel: Channel) -> ChannelStats | None:
         return await self._collect_channel_stats(channel)
 
     async def _resolve_stats_entity_or_deactivate(
-        self,
+        self: "Collector",
         session: object,
         phone: str,
         channel: Channel,
@@ -154,7 +166,7 @@ class StatsMixin:
             return None
 
     async def _collect_stats_metrics(
-        self, session, entity, phone: str, channel_id: int
+        self: "Collector", session, entity, phone: str, channel_id: int
     ) -> tuple[list[int], list[int], list[int]]:
         """Stream up to 50 recent messages and accumulate ``(views, reactions,
         forwards)`` totals for stats averaging. Extracted from
@@ -198,7 +210,7 @@ class StatsMixin:
 
         return views_list, reactions_list, forwards_list
 
-    async def _collect_channel_stats(self, channel: Channel) -> ChannelStats | None:
+    async def _collect_channel_stats(self: "Collector", channel: Channel) -> ChannelStats | None:
         while True:
             result = await self._pool.get_available_client()
             if result is None:
@@ -337,14 +349,14 @@ class StatsMixin:
             finally:
                 await self._pool.release_client(phone)
 
-    def _stats_all_channel_limit(self, max_channels: int | None = None) -> int:
+    def _stats_all_channel_limit(self: "Collector", max_channels: int | None = None) -> int:
         configured = max_channels
         if configured is None:
             configured = int(getattr(self._config, "stats_all_max_channels_per_run", 10) or 10)
         return max(1, int(configured))
 
     async def _order_stats_all_channels(
-        self, channels: list[Channel], *, skip_fresh_hours: int = 0
+        self: "Collector", channels: list[Channel], *, skip_fresh_hours: int = 0
     ) -> list[Channel]:
         try:
             latest_stats = await self._db.get_latest_stats_for_all()
@@ -391,7 +403,7 @@ class StatsMixin:
 
         return ordered
 
-    async def collect_all_stats(self, *, max_channels: int | None = None) -> dict:
+    async def collect_all_stats(self: "Collector", *, max_channels: int | None = None) -> dict:
         async with self._stats_all_lock:
             self._stats_all_running = True
             # Fresh run — drop any stale stats-cancel from a previous STATS_ALL.

--- a/src/telegram/collector_mixins/stream.py
+++ b/src/telegram/collector_mixins/stream.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 from inspect import isawaitable
+from typing import TYPE_CHECKING
 
 from src.models import Channel, Message
 from src.telegram.collector_message_parse import (
@@ -20,6 +21,17 @@ from src.telegram.collector_message_parse import (
 )
 from src.telegram.collector_types import _StreamOutcome
 
+if TYPE_CHECKING:
+    from typing import Any, Protocol, TypeAlias
+
+    from src.telegram.collector import Collector as _RuntimeCollector
+
+    _RuntimeCollectorType: TypeAlias = type[_RuntimeCollector]
+
+    class Collector(Protocol):
+        def __getattribute__(self, name: str) -> Any: ...
+        def __setattr__(self, name: str, value: Any) -> None: ...
+
 logger = logging.getLogger("src.telegram.collector")
 
 MESSAGE_FLUSH_BATCH_SIZE = 500
@@ -28,7 +40,7 @@ STREAM_CLEANUP_TIMEOUT_SEC = 10.0
 
 class StreamMixin:
     async def _release_collection_client(
-        self,
+        self: "Collector",
         phone: str,
         session,
         *,
@@ -76,7 +88,7 @@ class StreamMixin:
         await self._pool.release_client(phone)
 
     async def _stream_channel_messages(
-        self,
+        self: "Collector",
         *,
         session,
         entity,


### PR DESCRIPTION
Part of #1133

## What changed
- Added TYPE_CHECKING-only Collector host typing in the four collector mixin files.
- Annotated mixin instance methods as `self: "Collector"`.
- Kept runtime behavior unchanged: no runtime `Collector` import, no `type: ignore`, no method-body changes, no `ci.yml` changes.

## Mypy measurements

| Check | Before | After |
| --- | ---: | ---: |
| `python -m mypy src/ 2>/dev/null | tail -1` | 723 errors | 560 errors |
| `collector_mixins` `[attr-defined]` | 159 | 0 |

Error-code counts did not increase:

| code | before | after |
| --- | ---: | ---: |
| annotation-unchecked | 10 | 10 |
| arg-type | 108 | 108 |
| assignment | 25 | 22 |
| attr-defined | 245 | 86 |
| call-arg | 12 | 12 |
| call-overload | 10 | 10 |
| dict-item | 5 | 5 |
| has-type | 2 | 1 |
| import-not-found | 1 | 1 |
| index | 15 | 15 |
| int | 1 | 1 |
| misc | 4 | 4 |
| no-redef | 3 | 3 |
| operator | 3 | 3 |
| return-value | 26 | 26 |
| str | 4 | 4 |
| type-var | 12 | 12 |
| union-attr | 232 | 232 |
| valid-type | 18 | 18 |
| var-annotated | 2 | 2 |

## Confirmed host surface

Confirmed on `Collector.__init__` / composed mixins:

- Attributes/state: `_pool`, `_db`, `_config`, `_notifier`, `_cancel_event`, `_stats_cancel_event`, `_live_runtime_pause_gate`, `_lock`, `_stats_lock`, `_stats_all_lock`, `_active_collection_count`, `_stats_running`, `_stats_all_running`, `_last_unavailability_log`.
- Methods: `_stream_channel_messages`, `_release_collection_client`, `_can_rotate_resolve`, `_handle_meta_change_review`, `_channel_still_exists`, `_wait_if_live_runtime_paused`, `_wait_for_transient_collection_flood`, `_next_resolve_capable_at`, `_get_resolve_username_backoff_remaining_sec`, `_should_clear_collection_cancel_on_start`, `_reset_collection_unavailability_log`, `_raise_collection_unavailability`, `get_collection_availability`.

## Validation

- `ruff check src/telegram/collector_mixins/` passed.
- `python -c "import src.telegram.collector"` passed without `ImportError`.
- `pytest tests/ -k "collector" -x -q` passed: 497 passed, 9718 deselected.
- `git diff --stat`: only the 4 `src/telegram/collector_mixins/*.py` files changed.