### PR TITLE
chore(database): add ReadConnection protocol

### DIFF
--- a/src/database/__init__.py
+++ b/src/database/__init__.py
@@ -1,3 +1,4 @@
 from src.database.facade import Database, DatabaseBusyError
+from src.database.pool import ReadConnection
 
-__all__ = ["Database", "DatabaseBusyError"]
+__all__ = ["Database", "DatabaseBusyError", "ReadConnection"]

--- a/src/database/pool.py
+++ b/src/database/pool.py
@@ -19,12 +19,23 @@ fetch* calls then read from the buffer, not the (already-released) connection.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Sequence
 from contextlib import asynccontextmanager
-from typing import Any, AsyncIterator
+from typing import Any, AsyncIterator, Protocol
 
 import aiosqlite
 
 from src.database.connection import DEFAULT_TUNING, ConnectionTuning, open_connection
+
+
+class ReadConnection(Protocol):
+    """Structural read-only connection interface used by repositories."""
+
+    async def execute(self, sql: str, params: Sequence[Any] = ()) -> Any:
+        """Return a cursor-like object with async fetchone/fetchall."""
+        ...
+
+    async def create_function(self, name: str, narg: int, func: Any, **kwargs: Any) -> None: ...
 
 
 class BufferedCursor:
@@ -152,14 +163,14 @@ class ReadPoolProxy:
     def __init__(self, pool: ReadConnectionPool):
         self._pool = pool
 
-    async def execute(self, sql: str, params: tuple = ()) -> BufferedCursor:
+    async def execute(self, sql: str, params: Sequence[Any] = ()) -> BufferedCursor:
         _reject_writes(sql)
         async with self._pool.acquire_read() as conn:
             cur = await conn.execute(sql, params)
             # fetchall() returns a fresh owned list, so BufferedCursor can take it directly.
             return BufferedCursor(await cur.fetchall())
 
-    async def execute_fetchall(self, sql: str, params: tuple = ()) -> list[Any]:
+    async def execute_fetchall(self, sql: str, params: Sequence[Any] = ()) -> list[Any]:
         _reject_writes(sql)
         async with self._pool.acquire_read() as conn:
             return await conn.execute_fetchall(sql, params)

--- a/src/database/repositories/accounts.py
+++ b/src/database/repositories/accounts.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING
 
 import aiosqlite
 
+from src.database.pool import ReadConnection
 from src.models import Account, AccountSessionStatus, AccountSummary
 from src.security import SessionCipher, decrypt_failure_status, log_expected_decrypt_failure
 from src.utils.datetime import parse_datetime
@@ -58,7 +59,7 @@ class AccountsRepository:
 
     def __init__(
         self,
-        db: aiosqlite.Connection,
+        db: ReadConnection,
         session_cipher: SessionCipher | None = None,
         *,
         database: "Database | None" = None,

--- a/src/database/repositories/channel_ratings.py
+++ b/src/database/repositories/channel_ratings.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 import aiosqlite
 
+from src.database.pool import ReadConnection
 from src.models import ChannelRating
 
 if TYPE_CHECKING:
@@ -23,7 +24,7 @@ class ChannelRatingsRepository:
     строку с flag_count=0) — ручной аудит важнее.
     """
 
-    def __init__(self, db: aiosqlite.Connection, *, database: "Database | None" = None):
+    def __init__(self, db: ReadConnection, *, database: "Database | None" = None):
         self._db = db
         self._database = database
 

--- a/src/database/repositories/channel_stats.py
+++ b/src/database/repositories/channel_stats.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import aiosqlite
-
+from src.database.pool import ReadConnection
 from src.models import ChannelStats
 from src.utils.datetime import parse_datetime
 
@@ -23,7 +22,7 @@ class ChannelStatsRepository:
 
     def __init__(
         self,
-        db: aiosqlite.Connection,
+        db: ReadConnection,
         *,
         database: "Database | None" = None,
     ):

--- a/src/database/repositories/channels.py
+++ b/src/database/repositories/channels.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 
 import aiosqlite
 
+from src.database.pool import ReadConnection
 from src.models import Channel
 from src.utils.datetime import parse_datetime
 
@@ -28,7 +29,7 @@ class ChannelsRepository:
 
     def __init__(
         self,
-        db: aiosqlite.Connection,
+        db: ReadConnection,
         *,
         database: "Database | None" = None,
     ):

--- a/src/database/repositories/collection_tasks.py
+++ b/src/database/repositories/collection_tasks.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Any
 
 import aiosqlite
 
+from src.database.pool import ReadConnection
 from src.models import (
     CollectionTask,
     CollectionTaskStatus,
@@ -55,7 +56,7 @@ class CollectionTasksRepository:
 
     def __init__(
         self,
-        db: aiosqlite.Connection,
+        db: ReadConnection,
         *,
         database: "Database | None" = None,
     ):

--- a/src/database/repositories/content_pipelines.py
+++ b/src/database/repositories/content_pipelines.py
@@ -11,10 +11,11 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import aiosqlite
 
+from src.database.pool import ReadConnection
 from src.models import (
     ContentPipeline,
     PipelineGenerationBackend,
@@ -36,7 +37,7 @@ class ContentPipelinesRepository:
 
     def __init__(
         self,
-        db: aiosqlite.Connection,
+        db: ReadConnection,
         *,
         database: "Database | None" = None,
     ):
@@ -335,7 +336,7 @@ class ContentPipelinesRepository:
         # Must run on the caller's transaction connection so the DELETE+INSERT
         # stay inside the write-lock; falling back to self._db would commit them
         # autonomously and let another coroutine interleave (#633).
-        executor = conn or self._db
+        executor: Any = conn or self._db
         await executor.execute("DELETE FROM pipeline_sources WHERE pipeline_id = ?", (pipeline_id,))
         if source_channel_ids:
             await executor.executemany(
@@ -349,7 +350,7 @@ class ContentPipelinesRepository:
         targets: list[PipelineTarget],
         conn=None,
     ) -> None:
-        executor = conn or self._db
+        executor: Any = conn or self._db
         await executor.execute("DELETE FROM pipeline_targets WHERE pipeline_id = ?", (pipeline_id,))
         if targets:
             await executor.executemany(

--- a/src/database/repositories/dialog_cache.py
+++ b/src/database/repositories/dialog_cache.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
-import aiosqlite
-
+from src.database.pool import ReadConnection
 from src.utils.datetime import parse_datetime
 
 if TYPE_CHECKING:
@@ -24,7 +23,7 @@ class DialogCacheRepository:
 
     def __init__(
         self,
-        db: aiosqlite.Connection,
+        db: ReadConnection,
         *,
         database: "Database | None" = None,
     ):

--- a/src/database/repositories/filters.py
+++ b/src/database/repositories/filters.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING
 
 import aiosqlite
 
+from src.database.pool import ReadConnection
+
 # Intentionally duplicated from src/filters/criteria.py — UDF layer must not
 # depend on the filters package to keep DB initialisation self-contained.
 _CYRILLIC_RE = re.compile(r"[а-яА-ЯёЁ]")
@@ -182,7 +184,7 @@ class FilterRepository:
 
     def __init__(
         self,
-        db: aiosqlite.Connection,
+        db: ReadConnection,
         *,
         database: "Database | None" = None,
     ):

--- a/src/database/repositories/generated_images.py
+++ b/src/database/repositories/generated_images.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import aiosqlite
 
+from src.database.pool import ReadConnection
 from src.models import GeneratedImage
 
 if TYPE_CHECKING:
@@ -20,7 +21,7 @@ class GeneratedImagesRepository:
 
     def __init__(
         self,
-        db: aiosqlite.Connection,
+        db: ReadConnection,
         *,
         database: "Database | None" = None,
     ):

--- a/src/database/repositories/generation_runs.py
+++ b/src/database/repositories/generation_runs.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 
 import aiosqlite
 
+from src.database.pool import ReadConnection
 from src.models import GenerationRun
 from src.utils.datetime import parse_datetime
 from src.utils.json import safe_json_dumps, safe_json_loads
@@ -26,7 +27,7 @@ class GenerationRunsRepository:
 
     def __init__(
         self,
-        db: aiosqlite.Connection,
+        db: ReadConnection,
         *,
         database: "Database | None" = None,
     ):

--- a/src/database/repositories/messages.py
+++ b/src/database/repositories/messages.py
@@ -23,8 +23,7 @@ from dataclasses import dataclass
 from datetime import date, timedelta
 from typing import TYPE_CHECKING, AsyncIterator
 
-import aiosqlite
-
+from src.database.pool import ReadConnection
 from src.models import Message, SearchParams, SearchQuery
 from src.telegram.reactions import parse_reactions_json
 from src.utils.datetime import parse_datetime, parse_required_datetime
@@ -84,7 +83,7 @@ class MessagesRepository:
 
     def __init__(
         self,
-        db: aiosqlite.Connection,
+        db: ReadConnection,
         *,
         fts_available: bool = True,
         database: "Database | None" = None,

--- a/src/database/repositories/notification_bots.py
+++ b/src/database/repositories/notification_bots.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import aiosqlite
-
+from src.database.pool import ReadConnection
 from src.models import NotificationBot
 from src.utils.datetime import try_parse_datetime
 
@@ -23,7 +22,7 @@ class NotificationBotsRepository:
 
     def __init__(
         self,
-        db: aiosqlite.Connection,
+        db: ReadConnection,
         *,
         database: "Database | None" = None,
     ):

--- a/src/database/repositories/notified_messages.py
+++ b/src/database/repositories/notified_messages.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import aiosqlite
+from src.database.pool import ReadConnection
 
 if TYPE_CHECKING:
     from src.database.facade import Database
@@ -18,7 +18,7 @@ class NotifiedMessagesRepository:
     cursor.
     """
 
-    def __init__(self, db: aiosqlite.Connection, *, database: "Database | None" = None):
+    def __init__(self, db: ReadConnection, *, database: "Database | None" = None):
         self._db = db
         self._database = database
 

--- a/src/database/repositories/photo_loader.py
+++ b/src/database/repositories/photo_loader.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 
 import aiosqlite
 
+from src.database.pool import ReadConnection
 from src.models import (
     PhotoAutoUploadJob,
     PhotoBatch,
@@ -39,7 +40,7 @@ class PhotoLoaderRepository:
 
     def __init__(
         self,
-        db: aiosqlite.Connection,
+        db: ReadConnection,
         *,
         database: "Database | None" = None,
     ):

--- a/src/database/repositories/pipeline_action_log.py
+++ b/src/database/repositories/pipeline_action_log.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import aiosqlite
+from src.database.pool import ReadConnection
 
 if TYPE_CHECKING:
     from src.database.facade import Database
@@ -16,7 +16,7 @@ class PipelineActionLogRepository:
 
     def __init__(
         self,
-        db: aiosqlite.Connection,
+        db: ReadConnection,
         *,
         database: "Database | None" = None,
     ):

--- a/src/database/repositories/pipeline_templates.py
+++ b/src/database/repositories/pipeline_templates.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import aiosqlite
 
+from src.database.pool import ReadConnection
 from src.models import PipelineGraph, PipelineTemplate
 from src.utils.datetime import parse_datetime
 
@@ -23,7 +24,7 @@ class PipelineTemplatesRepository:
 
     def __init__(
         self,
-        db: aiosqlite.Connection,
+        db: ReadConnection,
         *,
         database: "Database | None" = None,
     ):

--- a/src/database/repositories/runtime_snapshots.py
+++ b/src/database/repositories/runtime_snapshots.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 import aiosqlite
 
+from src.database.pool import ReadConnection
 from src.models import RuntimeSnapshot
 from src.utils.datetime import parse_datetime
 from src.utils.json import safe_json_dumps
@@ -37,7 +38,7 @@ class RuntimeSnapshotsRepository:
 
     def __init__(
         self,
-        db: aiosqlite.Connection,
+        db: ReadConnection,
         *,
         database: "Database | None" = None,
     ):

--- a/src/database/repositories/search_log.py
+++ b/src/database/repositories/search_log.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import aiosqlite
+from src.database.pool import ReadConnection
 
 if TYPE_CHECKING:
     from src.database.facade import Database
@@ -19,7 +19,7 @@ class SearchLogRepository:
 
     def __init__(
         self,
-        db: aiosqlite.Connection,
+        db: ReadConnection,
         *,
         database: "Database | None" = None,
     ):

--- a/src/database/repositories/search_queries.py
+++ b/src/database/repositories/search_queries.py
@@ -9,8 +9,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import aiosqlite
-
+from src.database.pool import ReadConnection
 from src.models import SearchQuery, SearchQueryDailyStat
 from src.utils.datetime import parse_datetime
 
@@ -23,7 +22,7 @@ class SearchQueriesRepository:
 
     def __init__(
         self,
-        db: aiosqlite.Connection,
+        db: ReadConnection,
         *,
         database: "Database | None" = None,
     ):

--- a/src/database/repositories/settings.py
+++ b/src/database/repositories/settings.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import aiosqlite
+from src.database.pool import ReadConnection
 
 if TYPE_CHECKING:
     from src.database.facade import Database
@@ -20,7 +20,7 @@ class SettingsRepository:
 
     def __init__(
         self,
-        db: aiosqlite.Connection,
+        db: ReadConnection,
         *,
         database: "Database | None" = None,
     ):

--- a/src/database/repositories/telegram_commands.py
+++ b/src/database/repositories/telegram_commands.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 import aiosqlite
 
+from src.database.pool import ReadConnection
 from src.models import TelegramCommand, TelegramCommandStatus
 from src.utils.datetime import parse_datetime
 from src.utils.json import safe_json_dumps
@@ -38,7 +39,7 @@ class TelegramCommandsRepository:
 
     def __init__(
         self,
-        db: aiosqlite.Connection,
+        db: ReadConnection,
         *,
         database: "Database | None" = None,
     ):


### PR DESCRIPTION
Closes #1207

## What changed
- Added `ReadConnection` Protocol in `src/database/pool.py` for the repository read surface: `execute` and `create_function`.
- Exported `ReadConnection` from `src.database`.
- Replaced the first constructor parameter annotation in 21 database repositories from `aiosqlite.Connection` to `ReadConnection`.
- Kept runtime behavior unchanged; no `type: ignore`, no CI changes, no non-`src/database` changes.

## Mypy delta
| Check | Before | After |
| --- | ---: | ---: |
| `python -m mypy src/` | 343 errors / 86 files | 313 errors / 85 files |
| `src/database/*` `arg-type` | 30 | 5 |
| `facade.py` `ReadPoolProxy` -> `Connection` arg-type | 21 | 0 |

Error-code counts did not increase for any category: `arg-type` 106 -> 81, `index` 15 -> 11, `return-value` 25 -> 24, all other counted categories unchanged.

## Validation
- `ruff check src/`
- `python -c "import src.database; import src.database.facade"`
- `git diff --check`
- `pytest tests/repositories/ tests/test_database.py -x -q` (`463 passed`)
