### PR TITLE
chore(web): clear settings mypy errors

### DIFF
--- a/src/web/routes/settings.py
+++ b/src/web/routes/settings.py
@@ -131,76 +131,76 @@ async def settings_page(request: Request):
 
 @router.post("/save-scheduler")
 async def save_scheduler_settings(request: Request, form: SchedulerFormDep):
-    if response := _form_error_response(form):
-        return response
+    if isinstance(form, SettingsFormError):
+        return _form_error_response(form)
     return settings_flash_response(await handle_save_scheduler_settings(request, form))
 
 
 @router.post("/save-semantic-search")
 async def save_semantic_search_settings(request: Request, form: SemanticSearchFormDep):
-    if response := _form_error_response(form):
-        return response
+    if isinstance(form, SettingsFormError):
+        return _form_error_response(form)
     return settings_flash_response(await handle_save_semantic_search_settings(request, form))
 
 
 @router.post("/semantic-index")
 async def run_semantic_index(request: Request, form: SemanticIndexFormDep):
-    if response := _form_error_response(form):
-        return response
+    if isinstance(form, SettingsFormError):
+        return _form_error_response(form)
     return settings_flash_response(await handle_run_semantic_index(request, form))
 
 
 @router.post("/save-agent")
 async def save_agent_settings(request: Request, form: AgentFormDep):
-    if response := _form_error_response(form):
-        return response
+    if isinstance(form, SettingsFormError):
+        return _form_error_response(form)
     return settings_flash_response(await handle_save_agent_settings(request, form))
 
 
 @router.post("/agent-providers/add")
 async def add_agent_provider(request: Request, form: ProviderAddFormDep):
-    if response := _form_error_response(form):
-        return response
-    return settings_flash_response(await handle_add_agent_provider(request, form))
+    if isinstance(form, SettingsFormError):
+        return _form_error_response(form)
+    return settings_result_response(request, await handle_add_agent_provider(request, form))
 
 
 @router.post("/agent-providers/save")
 async def save_agent_providers(request: Request, form: ProviderConfigFormDep):
-    if response := _form_error_response(form):
-        return response
-    return settings_flash_response(await handle_save_agent_providers(request, form))
+    if isinstance(form, SettingsFormError):
+        return _form_error_response(form)
+    return settings_result_response(request, await handle_save_agent_providers(request, form))
 
 
 @router.post("/agent-providers/{provider_name}/delete")
 async def delete_agent_provider(request: Request, provider_name: str):
-    return settings_flash_response(await handle_delete_agent_provider(request, provider_name))
+    return settings_result_response(request, await handle_delete_agent_provider(request, provider_name))
 
 
 @router.post("/agent-providers/{provider_name}/refresh")
 async def refresh_agent_provider_models(request: Request, provider_name: str, form: ProviderConfigFormDep):
-    if response := _form_error_response(form):
-        return response
-    return settings_json_response(await handle_refresh_agent_provider_models(request, provider_name, form))
+    if isinstance(form, SettingsFormError):
+        return _form_error_response(form)
+    return settings_result_response(request, await handle_refresh_agent_provider_models(request, provider_name, form))
 
 
 @router.post("/agent-providers/refresh-all")
 async def refresh_all_agent_provider_models(request: Request, form: ProviderConfigFormDep):
-    if response := _form_error_response(form):
-        return response
-    return settings_json_response(await handle_refresh_all_agent_provider_models(request, form))
+    if isinstance(form, SettingsFormError):
+        return _form_error_response(form)
+    return settings_result_response(request, await handle_refresh_all_agent_provider_models(request, form))
 
 
 @router.post("/agent-providers/{provider_name}/probe")
 async def probe_agent_provider_model(request: Request, provider_name: str, form: ProviderConfigFormDep):
-    if response := _form_error_response(form):
-        return response
-    return settings_json_response(await handle_probe_agent_provider_model(request, provider_name, form))
+    if isinstance(form, SettingsFormError):
+        return _form_error_response(form)
+    return settings_result_response(request, await handle_probe_agent_provider_model(request, provider_name, form))
 
 
 @router.post("/agent-providers/test-all")
 async def test_all_agent_provider_models(request: Request, form: ProviderConfigFormDep):
-    if response := _form_error_response(form):
-        return response
+    if isinstance(form, SettingsFormError):
+        return _form_error_response(form)
     return settings_json_response(await handle_test_all_agent_provider_models(request, form))
 
 
@@ -211,22 +211,22 @@ async def test_all_agent_provider_models_status(request: Request):
 
 @router.post("/save-filters")
 async def save_filters(request: Request, form: FiltersFormDep):
-    if response := _form_error_response(form):
-        return response
+    if isinstance(form, SettingsFormError):
+        return _form_error_response(form)
     return settings_flash_response(await handle_save_filters(request, form))
 
 
 @router.post("/save-notification-account")
 async def save_notification_account(request: Request, form: NotificationAccountFormDep):
-    if response := _form_error_response(form):
-        return response
+    if isinstance(form, SettingsFormError):
+        return _form_error_response(form)
     return settings_flash_response(await handle_save_notification_account(request, form))
 
 
 @router.post("/save-credentials")
 async def save_credentials(request: Request, form: CredentialsFormDep):
-    if response := _form_error_response(form):
-        return response
+    if isinstance(form, SettingsFormError):
+        return _form_error_response(form)
     return settings_flash_response(await handle_save_credentials(request, form))
 
 
@@ -252,15 +252,15 @@ async def test_notification(request: Request):
 
 @router.post("/image-providers/add")
 async def add_image_provider(request: Request, form: ProviderAddFormDep):
-    if response := _form_error_response(form):
-        return response
+    if isinstance(form, SettingsFormError):
+        return _form_error_response(form)
     return settings_flash_response(await handle_add_image_provider(request, form))
 
 
 @router.post("/image-providers/save")
 async def save_image_providers(request: Request, form: ImageProviderSaveFormDep):
-    if response := _form_error_response(form):
-        return response
+    if isinstance(form, SettingsFormError):
+        return _form_error_response(form)
     return settings_flash_response(await handle_save_image_providers(request, form))
 
 
@@ -271,8 +271,8 @@ async def delete_image_provider(request: Request, provider_name: str):
 
 @router.post("/save-translation")
 async def save_translation_settings(request: Request, form: TranslationFormDep):
-    if response := _form_error_response(form):
-        return response
+    if isinstance(form, SettingsFormError):
+        return _form_error_response(form)
     return settings_flash_response(await handle_save_translation_settings(request, form))
 
 
@@ -283,8 +283,8 @@ async def translation_backfill_lang(request: Request):
 
 @router.post("/translation-run")
 async def translation_run_batch(request: Request, form: TranslationRunFormDep):
-    if response := _form_error_response(form):
-        return response
+    if isinstance(form, SettingsFormError):
+        return _form_error_response(form)
     return settings_flash_response(await handle_translation_run_batch(request, form))
 
 

--- a/src/web/settings/handlers.py
+++ b/src/web/settings/handlers.py
@@ -6,6 +6,7 @@ import os
 from collections import Counter
 from datetime import UTC, datetime
 from types import SimpleNamespace
+from typing import Any
 
 from fastapi import Request
 
@@ -205,7 +206,7 @@ def _bulk_test_lock(request: Request) -> asyncio.Lock:
     return lock
 
 
-def _bulk_test_status_payload(request: Request) -> dict[str, object]:
+def _bulk_test_status_payload(request: Request) -> dict[str, Any]:
     status = getattr(request.app.state, "agent_provider_bulk_test_status", None)
     if status is None:
         status = {
@@ -226,11 +227,11 @@ def _bulk_test_status_payload(request: Request) -> dict[str, object]:
     return status
 
 
-def _replace_bulk_test_status(request: Request, status: dict[str, object]) -> None:
+def _replace_bulk_test_status(request: Request, status: dict[str, Any]) -> None:
     request.app.state.agent_provider_bulk_test_status = status
 
 
-def _bulk_test_recent_event(status: dict[str, object], message: str) -> None:
+def _bulk_test_recent_event(status: dict[str, Any], message: str) -> None:
     events = list(status.get("recent_events", []))
     events.append(f"{datetime.now(UTC).astimezone().strftime('%H:%M:%S')} {message}")
     status["recent_events"] = events[-12:]
@@ -275,7 +276,7 @@ async def _run_bulk_test_job(
         configs = await service.load_provider_configs()
     status_summary_counts: Counter[str] = Counter({"supported": 0, "unsupported": 0, "unknown": 0})
     status_summary = dict(status_summary_counts)
-    status = {
+    status: dict[str, Any] = {
         "running": True,
         "started_at": datetime.now(UTC).isoformat(),
         "finished_at": "",
@@ -788,7 +789,7 @@ async def handle_save_agent_settings(request: Request, form: AgentSettingsForm) 
     return SettingsFlash(msg="agent_saved")
 
 
-async def handle_add_agent_provider(request: Request, form: ProviderAddForm) -> SettingsFlash:
+async def handle_add_agent_provider(request: Request, form: ProviderAddForm) -> SettingsFlash | SettingsJson:
     service = _agent_provider_service(request)
     if not service.writes_enabled:
         return SettingsFlash(error="agent_provider_secret_required")
@@ -811,7 +812,7 @@ async def handle_add_agent_provider(request: Request, form: ProviderAddForm) -> 
     return SettingsFlash(msg="agent_saved")
 
 
-async def handle_save_agent_providers(request: Request, form: ProviderConfigForm) -> SettingsFlash:
+async def handle_save_agent_providers(request: Request, form: ProviderConfigForm) -> SettingsFlash | SettingsJson:
     service = _agent_provider_service(request)
     if not service.writes_enabled:
         return SettingsFlash(error="agent_provider_secret_required")
@@ -853,7 +854,7 @@ async def handle_save_agent_providers(request: Request, form: ProviderConfigForm
     return SettingsFlash(msg="agent_saved")
 
 
-async def handle_delete_agent_provider(request: Request, provider_name: str) -> SettingsFlash:
+async def handle_delete_agent_provider(request: Request, provider_name: str) -> SettingsFlash | SettingsJson:
     service = _agent_provider_service(request)
     if not service.writes_enabled:
         return SettingsFlash(error="agent_provider_secret_required")
@@ -874,7 +875,7 @@ async def handle_delete_agent_provider(request: Request, provider_name: str) -> 
 
 async def _agent_provider_write_guard(
     request: Request, provider_name: str
-) -> tuple[ProviderConfigService | None, SettingsJson | None]:
+) -> tuple[ProviderConfigService | None, SettingsFlash | SettingsJson | None]:
     """Shared write-guard for per-provider agent endpoints.
 
     Requires write access (SESSION_ENCRYPTION_KEY), agent dev-mode, and a known
@@ -899,7 +900,7 @@ async def handle_refresh_agent_provider_models(
     request: Request,
     provider_name: str,
     form: ProviderConfigForm,
-) -> SettingsJson:
+) -> SettingsFlash | SettingsJson:
     service, guard_error = await _agent_provider_write_guard(request, provider_name)
     if guard_error is not None:
         return guard_error
@@ -925,7 +926,7 @@ async def handle_refresh_agent_provider_models(
 async def handle_refresh_all_agent_provider_models(
     request: Request,
     form: ProviderConfigForm,
-) -> SettingsJson:
+) -> SettingsFlash | SettingsJson:
     service = _agent_provider_service(request)
     if not service.writes_enabled:
         return SettingsJson(
@@ -963,7 +964,7 @@ async def handle_probe_agent_provider_model(
     request: Request,
     provider_name: str,
     form: ProviderConfigForm,
-) -> SettingsJson:
+) -> SettingsFlash | SettingsJson:
     service, guard_error = await _agent_provider_write_guard(request, provider_name)
     if guard_error is not None:
         return guard_error
@@ -1049,7 +1050,7 @@ async def handle_test_all_agent_provider_models(
                 },
                 status_code=409,
             )
-        initial_status = {
+        initial_status: dict[str, Any] = {
             "running": True,
             "started_at": datetime.now(UTC).isoformat(),
             "finished_at": "",


### PR DESCRIPTION
Part of #1133.

## What changed
- Changed the agent-provider bulk-test status payload typing from `dict[str, object]` to `dict[str, Any]` where the payload is intentionally nested and indexed.
- Expanded settings handler return annotations to the declared `SettingsFlash | SettingsJson` unions where guard paths can return either response type.
- Rewrote settings form error guards from the walrus helper pattern to explicit `isinstance(form, SettingsFormError)` checks so mypy narrows each form before handler calls.

## Scope note
- No functional behavior changes are intended. A few route response calls now use the existing `settings_result_response` adapter because their handlers are now annotated as `SettingsFlash | SettingsJson`; for the current returned instances this preserves the same response behavior.

## Validation
| Check | Before | After |
| --- | ---: | ---: |
| `python -m mypy src/` total | 268 | 237 |
| `src/web/settings/handlers.py` mypy errors | 14 | 0 |
| `src/web/routes/settings.py` mypy errors | 17 | 0 |

No mypy error category increased in the before/after histogram.

Additional checks:
- `ruff check src/ tests/ conftest.py`
- `python -c "import src.web.routes.settings; import src.web.settings.handlers"`
- `pytest tests/ -k "settings or agent_provider or form" -x -q`