### PR TITLE
chore: clear dispatcher queue mypy errors

### DIFF
--- a/src/collection_queue.py
+++ b/src/collection_queue.py
@@ -5,6 +5,7 @@ import inspect
 import logging
 import time
 from datetime import datetime, timedelta, timezone
+from typing import Any, cast
 
 from src.database import Database
 from src.database.bundles import ChannelBundle
@@ -681,8 +682,9 @@ class CollectionQueue:
                     task.channel_id,
                 )
                 continue
-            force = bool((task.payload or {}).get("force", False))
-            full = bool((task.payload or {}).get("full", False))
+            payload = cast(dict[str, Any], task.payload or {})
+            force = bool(payload.get("force", False))
+            full = bool(payload.get("full", False))
             if resolve_backoff_remaining > 0 and channel.username:
                 run_after = datetime.now(timezone.utc) + timedelta(
                     seconds=resolve_backoff_remaining + RESOLVE_USERNAME_BACKOFF_BUFFER_SEC

--- a/src/services/unified_dispatcher.py
+++ b/src/services/unified_dispatcher.py
@@ -17,7 +17,6 @@ from src.services.task_handlers import (
     PhotoTaskHandler,
     PipelineTaskHandler,
     StatsTaskHandler,
-    TaskHandler,
     TaskHandlerContext,
     TranslationTaskHandler,
 )
@@ -33,7 +32,8 @@ if TYPE_CHECKING:
     from src.telegram.notifier import Notifier
 
 logger = logging.getLogger(__name__)
-TTaskHandler = TypeVar("TTaskHandler", bound=TaskHandler)
+TTaskHandler = TypeVar("TTaskHandler")
+_TaskDispatchHandler = Callable[[CollectionTask], Awaitable[None]]
 
 _HANDLER_CLASSES = (
     StatsTaskHandler,
@@ -71,6 +71,8 @@ _DB_BUSY_NON_RETRY_NOTE = "Not retried after transient database lock"
 
 class UnifiedDispatcher:
     """Polls DB for non-CHANNEL_COLLECT tasks and dispatches them to task handlers."""
+
+    __handler_map: dict[CollectionTaskType, _TaskDispatchHandler]
 
     def __init__(
         self,
@@ -131,7 +133,7 @@ class UnifiedDispatcher:
             llm_provider_service=self._llm_provider_service,
         )
 
-    def _handler(self, handler_cls: type[TTaskHandler]) -> TTaskHandler:
+    def _handler(self, handler_cls: Callable[[TaskHandlerContext], TTaskHandler]) -> TTaskHandler:
         return handler_cls(self._handler_context())
 
     async def _build_image_service(self) -> "ImageGenerationService":
@@ -253,7 +255,7 @@ class UnifiedDispatcher:
         except Exception:
             logger.exception("Failed to mark DB-busy side-effecting task %s as failed", task.id)
 
-    def _handler_map(self) -> dict[CollectionTaskType, Callable[[CollectionTask], Awaitable[None]]]:
+    def _handler_map(self) -> dict[CollectionTaskType, _TaskDispatchHandler]:
         try:
             return self.__handler_map
         except AttributeError:
@@ -274,6 +276,7 @@ class UnifiedDispatcher:
     async def _dispatch(self, task: CollectionTask) -> None:
         handler = self._handler_map().get(task.task_type)
         if handler is None:
+            assert task.id is not None, "Claimed collection task id must be set"
             await self._tasks.update_collection_task(
                 task.id,
                 CollectionTaskStatus.FAILED,


### PR DESCRIPTION
Part of #1133

## Summary
- Cleared the first wave outside `src/cli/`: `src/services/unified_dispatcher.py` and `src/collection_queue.py`.
- Kept the patch typing-only: handler factory typing, dispatch handler alias, assert-narrowing for claimed task ids, and local payload cast to `dict[str, Any]`.
- No `src/cli/` changes, no `# type: ignore`, no CI changes.

## Measurements
| Measurement | Before | After |
| --- | ---: | ---: |
| `python -m mypy src/` total | 237 errors / 82 files | 207 errors / 80 files |
| `src/services/unified_dispatcher.py` file-prefixed lines | 16 | 0 |
| `src/collection_queue.py` file-prefixed lines | 16 | 0 |

Error-code deltas only decreased: `arg-type` 62 -> 61, `call-arg` 9 -> 8, `has-type` 1 -> 0, `return-value` 19 -> 18, `type-var` 11 -> 1, `union-attr` 24 -> 8. All other codes are unchanged; no new error types.

## Checks
- `python -m mypy src/` (expected remaining baseline: 207 unrelated errors)
- `ruff check src/ tests/`
- `ruff check src/ tests/ conftest.py`
- `python -c "import src.services.unified_dispatcher; import src.collection_queue"`
- `pytest tests/test_unified_dispatcher.py tests/test_unified_dispatcher_tasks.py tests/test_unified_dispatcher_pipeline_runs.py tests/test_collection_queue_db_pull.py tests/test_collection_queue_strand.py tests/test_parallel_collection.py -v` (167 passed)
- `git diff --check`