### PR TITLE
Part of #1133: clear CLI mypy errors

### DIFF
--- a/src/cli/commands/account.py
+++ b/src/cli/commands/account.py
@@ -94,6 +94,7 @@ async def _run_export_session(args: argparse.Namespace, db: Database) -> None:
         match = next((s for s in summaries if s.id == account_id), None)
         target = f"id={account_id}"
     else:
+        assert phone is not None
         match = next((s for s in summaries if s.phone == phone), None)
         target = phone
     if match is None:

--- a/src/cli/commands/agent_tui.py
+++ b/src/cli/commands/agent_tui.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 import uuid
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from textual import events, on
 from textual.app import App, ComposeResult
@@ -21,6 +21,9 @@ from textual.widgets import Button, Footer, Header, Label, ListItem, ListView, M
 from textual.worker import WorkerState
 
 if TYPE_CHECKING:
+    from textual.timer import Timer
+    from textual.worker import Worker
+
     from src.agent.manager import AgentManager
     from src.config import AppConfig
     from src.database import Database
@@ -96,7 +99,7 @@ class StreamingMessage(Static):
         self._log_lines: list[str] = []
         self._pending_status: str = ""
         self._last_log_time: float = 0.0
-        self._tick_timer = None
+        self._tick_timer: Timer | None = None
         self._start_time: float = 0.0
         self._render_timer: asyncio.TimerHandle | None = None
         self._pending_render = False
@@ -241,7 +244,7 @@ class ChatInput(TextArea):
         if event.key == "enter":
             event.prevent_default()
             event.stop()
-            await self.app.action_send_message()
+            await cast("AgentTuiApp", self.app).action_send_message()
         elif event.key in ("shift+enter", "meta+enter", "alt+enter", "escape+enter"):
             event.prevent_default()
             event.stop()
@@ -424,7 +427,7 @@ class AgentTuiApp(App):
         self.db = db
         self.config = config
         self.agent_manager = agent_manager
-        self._stream_worker = None
+        self._stream_worker: Worker[None] | None = None
         self._session_id = str(uuid.uuid4())
 
     def compose(self) -> ComposeResult:

--- a/src/cli/commands/dialogs.py
+++ b/src/cli/commands/dialogs.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import time
+from collections.abc import Awaitable, Callable
 
 import typer
 
@@ -851,7 +852,7 @@ async def _dialogs_queue(args, db, pool) -> None:
 
 # action -> (handler, needs_channel_service_cls). Depth-2 `queue` dispatches on
 # args.queue_action inside its own handler.
-_DIALOGS_HANDLERS = {
+_DIALOGS_HANDLERS: dict[str, tuple[Callable[..., Awaitable[None]], bool]] = {
     "refresh": (_dialogs_refresh, True),
     "list": (_dialogs_list, True),
     "resolve": (_dialogs_resolve, False),

--- a/src/cli/commands/export.py
+++ b/src/cli/commands/export.py
@@ -8,6 +8,7 @@ import json
 import sys
 from datetime import datetime, timezone
 from email.utils import format_datetime
+from typing import Literal, cast
 
 import typer
 
@@ -18,6 +19,8 @@ from src.cli.commands.common import (
     run_async,
 )
 from src.utils.text_safety import csv_safe_cell, escape_xml_text
+
+ExportMediaFormat = Literal["json", "html", "both"]
 
 
 def _rfc822(dt: datetime | None) -> str:
@@ -150,7 +153,7 @@ async def _enqueue_media_export(
 
     payload = ExportTaskPayload(
         channel_id=channel_id,
-        fmt=export_format,
+        fmt=cast(ExportMediaFormat, export_format),
         with_media=True,
         max_file_size_mb=max_file_size,
         date_from=date_from,

--- a/src/cli/commands/filter.py
+++ b/src/cli/commands/filter.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+from typing import TYPE_CHECKING, cast
 
 import typer
 
@@ -24,10 +25,13 @@ from src.filters.criteria import DEFAULT_QUICK_SAMPLE_SIZE
 from src.services.channel_service import ChannelService
 from src.services.filter_deletion_service import FilterDeletionService
 
+if TYPE_CHECKING:
+    from src.telegram.client_pool import ClientPool
+
 
 def _build_deletion_service(db) -> FilterDeletionService:
     channel_bundle = ChannelBundle.from_database(db)
-    channel_service = ChannelService(channel_bundle, None, queue=None)
+    channel_service = ChannelService(channel_bundle, cast("ClientPool", None), queue=None)
     return FilterDeletionService(db, channel_service)
 
 

--- a/src/cli/commands/pipeline.py
+++ b/src/cli/commands/pipeline.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import os
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, cast
 
 import typer
 
@@ -138,9 +138,9 @@ async def _upsert_filter_node(svc: PipelineService, pipeline_id: int, config: di
         upstream_id = graph.nodes[0].id
 
     downstream_ids = [edge.to_node for edge in graph.edges if edge.from_node == upstream_id] if upstream_id else []
-    for downstream_id in downstream_ids:
-        await svc.remove_edge(pipeline_id, upstream_id, downstream_id)
     if upstream_id:
+        for downstream_id in downstream_ids:
+            await svc.remove_edge(pipeline_id, upstream_id, downstream_id)
         await _safe_add_edge(svc, pipeline_id, upstream_id, "filter_1")
     for downstream_id in downstream_ids:
         if downstream_id != "filter_1":
@@ -393,8 +393,9 @@ async def _pipeline_enqueue_run_after(args: argparse.Namespace, db, pipeline_id:
     from src.services.task_enqueuer import TaskEnqueuer
 
     since_h = to_since_hours(args.since_value, args.since_unit)
-    enqueuer = TaskEnqueuer(db)
-    await enqueuer.enqueue_pipeline_run(pipeline_id, since_hours=since_h)
+    enqueuer_factory = cast(Callable[[object], TaskEnqueuer], TaskEnqueuer)
+    enqueuer = enqueuer_factory(db)
+    await enqueuer.enqueue_pipeline_run(cast(int, pipeline_id), since_hours=since_h)
     print(f"Enqueued pipeline run (since={args.since_value}{args.since_unit})")
 
 
@@ -488,7 +489,7 @@ async def _pipeline_run(args: argparse.Namespace, db, config, svc: PipelineServi
     pipeline = await svc.get(args.id)
     if pipeline is None:
         print(f"Pipeline id={args.id} not found")
-        return
+        return None
     engine = SearchEngine(db)
 
     from src.services.provider_service import build_provider_service
@@ -502,7 +503,7 @@ async def _pipeline_run(args: argparse.Namespace, db, config, svc: PipelineServi
             "LLM provider is not configured. Add one in /settings or set an API key "
             "env var (e.g. OPENAI_API_KEY). Non-LLM pipelines run without a provider."
         )
-        return
+        return None
 
     _, pool = await runtime.init_pool(config, db)
     client_pool = pool
@@ -545,7 +546,7 @@ async def _pipeline_generate(args: argparse.Namespace, db, config, svc: Pipeline
     pipeline = await svc.get(args.id)
     if pipeline is None:
         print(f"Pipeline id={args.id} not found")
-        return
+        return None
     # Per-run A/B overrides (issue #1068): --ab-variants / --auto-select
     # override the pipeline's stored A/B config for this single run only.
     ab_overrides: dict[str, object] = {}
@@ -567,7 +568,7 @@ async def _pipeline_generate(args: argparse.Namespace, db, config, svc: Pipeline
             "LLM provider is not configured. Add one in /settings or set an API key "
             "env var (e.g. OPENAI_API_KEY). Non-LLM pipelines run without a provider."
         )
-        return
+        return None
     _, pool = await runtime.init_pool(config, db)
     client_pool = pool
     agent_manager = None
@@ -922,15 +923,15 @@ async def _pipeline_publish(args: argparse.Namespace, db, config, svc: PipelineS
     run = await db.repos.generation_runs.get(args.run_id)
     if run is None:
         print(f"Run id={args.run_id} not found")
-        return
+        return None
     if run.pipeline_id is None:
         print(f"Run id={args.run_id} has no pipeline")
-        return
+        return None
 
     pipeline = await svc.get(run.pipeline_id)
     if pipeline is None:
         print(f"Pipeline id={run.pipeline_id} not found")
-        return
+        return None
 
     _, pool = await runtime.init_pool(config, db)
     if not pool.clients:

--- a/src/cli/commands/search_query.py
+++ b/src/cli/commands/search_query.py
@@ -13,6 +13,7 @@ import argparse
 import asyncio
 import inspect
 import logging
+from typing import Any, cast
 
 import typer
 from pydantic import ValidationError
@@ -24,6 +25,7 @@ from src.cli.commands.common import (
     run_async,
 )
 from src.database.bundles import SearchQueryBundle
+from src.models import SearchQueryDailyStat
 from src.services.search_query_service import SearchQueryService
 
 logger = logging.getLogger(__name__)
@@ -51,7 +53,7 @@ async def list_impl(config_path: str) -> None:
     _, db = await runtime.init_db(config_path)
     try:
         svc = SearchQueryService(SearchQueryBundle.from_database(db))
-        items = await svc.get_with_stats()
+        items = cast(list[dict[str, Any]], await svc.get_with_stats())
         if not items:
             print("No search queries found.")
             return
@@ -249,7 +251,7 @@ async def stats_impl(config_path: str, *, query_id: int, days: int = 30) -> None
     _, db = await runtime.init_db(config_path)
     try:
         svc = SearchQueryService(SearchQueryBundle.from_database(db))
-        stats = await svc.get_daily_stats(query_id, days)
+        stats = cast(list[SearchQueryDailyStat], await svc.get_daily_stats(query_id, days))
         if not stats:
             print("No stats found.")
             return

--- a/src/cli/commands/test.py
+++ b/src/cli/commands/test.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
+from typing import TYPE_CHECKING, cast
 
 import typer
 
@@ -26,6 +27,11 @@ from src.filters.analyzer import ChannelAnalyzer
 from src.models import Message, SearchQuery
 from src.telegram.backends import adapt_transport_session
 from src.telegram.flood_wait import FloodWaitInfo, HandledFloodWaitError, run_with_flood_wait
+
+if TYPE_CHECKING:
+    from src.config import AppConfig
+    from src.search.engine import SearchEngine
+    from src.telegram.client_pool import ClientPool
 
 logger = logging.getLogger(__name__)
 
@@ -148,13 +154,33 @@ class TelegramLiveCheckState:
     results: list[CheckResult]
     copy_db: Database | None = None
     tmp_path: str | None = None
-    config: object | None = None
-    pool: object | None = None
-    engine: object | None = None
+    config: AppConfig | None = None
+    pool: ClientPool | None = None
+    engine: SearchEngine | None = None
 
 
 class TelegramLiveStepSkipError(RuntimeError):
     """Internal control-flow exception used to stop live checks on long flood waits."""
+
+
+def _require_tg_copy_db(state: TelegramLiveCheckState) -> Database:
+    assert state.copy_db is not None, "test: copy_db not initialized"
+    return state.copy_db
+
+
+def _require_tg_config(state: TelegramLiveCheckState) -> AppConfig:
+    assert state.config is not None, "test: config not initialized"
+    return state.config
+
+
+def _require_tg_pool(state: TelegramLiveCheckState) -> ClientPool:
+    assert state.pool is not None, "test: Telegram pool not initialized"
+    return state.pool
+
+
+def _require_tg_engine(state: TelegramLiveCheckState) -> SearchEngine:
+    assert state.engine is not None, "test: search engine not initialized"
+    return state.engine
 
 
 def _print_result(result: CheckResult) -> None:
@@ -222,7 +248,7 @@ def _format_exception(exc: BaseException) -> str:
     return detail or exc.__class__.__name__
 
 
-async def _disable_flood_auto_sleep(pool) -> None:
+async def _disable_flood_auto_sleep(pool: ClientPool) -> None:
     clients = getattr(pool, "clients", None) or {}
     for phone, client in clients.items():
         session = adapt_transport_session(client, disconnect_on_close=False)
@@ -260,7 +286,7 @@ def _is_premium_flood(info: FloodWaitInfo) -> bool:
     }
 
 
-async def _get_live_flood_availability(pool, info: FloodWaitInfo):
+async def _get_live_flood_availability(pool: ClientPool, info: FloodWaitInfo):
     if _is_premium_flood(info):
         availability_getter = getattr(pool, "get_premium_stats_availability", None)
         if callable(availability_getter):
@@ -272,7 +298,7 @@ async def _get_live_flood_availability(pool, info: FloodWaitInfo):
 
 
 async def _decide_live_test_flood_action(
-    pool,
+    pool: ClientPool,
     info: FloodWaitInfo,
 ) -> TelegramLiveFloodDecision:
     availability = await _get_live_flood_availability(pool, info)
@@ -304,7 +330,7 @@ async def _decide_live_test_flood_action(
     )
 
 
-async def _handle_live_flood_wait(pool, check_name: str, info: FloodWaitInfo) -> None:
+async def _handle_live_flood_wait(pool: ClientPool, check_name: str, info: FloodWaitInfo) -> None:
     decision = await _decide_live_test_flood_action(pool, info)
     if decision.action == "rotate":
         logger.info(
@@ -434,7 +460,7 @@ async def _check_photo_tasks(db: Database) -> CheckResult:
 # ---------------------------------------------------------------------------
 
 
-async def _init_db_copy(config_path: str) -> tuple[Database, str, object]:
+async def _init_db_copy(config_path: str) -> tuple[Database, str, AppConfig]:
     """Copy live DB to a temp file, return (copy_db, tmp_path, config)."""
     config, live_db = await runtime.init_db(config_path)
     live_path = live_db._db_path
@@ -495,17 +521,18 @@ async def _run_account_toggle_check(copy_db: Database, results: list[CheckResult
             )
         else:
             acc = accounts[0]
+            account_id = cast(int, acc.id)
             original = acc.is_active
-            await copy_db.set_account_active(acc.id, not original)
+            await copy_db.set_account_active(account_id, not original)
             refreshed = await copy_db.get_accounts()
-            toggled = next(a for a in refreshed if a.id == acc.id)
+            toggled = next(a for a in refreshed if a.id == account_id)
             if toggled.is_active is not (not original):
                 raise RuntimeError("account active state did not change")
             results.append(
                 CheckResult(
                     "account_toggle",
                     Status.PASS,
-                    f"id={acc.id} active: {original} -> {not original}",
+                    f"id={account_id} active: {original} -> {not original}",
                 )
             )
     except Exception as exc:
@@ -518,7 +545,7 @@ async def _run_search_query_add_check(copy_db: Database, results: list[CheckResu
     try:
         sq_repo = copy_db.repos.search_queries
         added_sq_id = await sq_repo.add(
-            SearchQuery(name="__test_cli__", query="__test_cli__"),
+            SearchQuery(name="__test_cli__", query="__test_cli__", interval_minutes=60),
         )
         queries = await sq_repo.get_all()
         found = any(q.id == added_sq_id for q in queries)
@@ -591,17 +618,18 @@ async def _run_channel_toggle_check(copy_db: Database, results: list[CheckResult
             )
         else:
             ch = channels[0]
+            channel_id = cast(int, ch.id)
             original = ch.is_active
-            await copy_db.set_channel_active(ch.id, not original)
+            await copy_db.set_channel_active(channel_id, not original)
             refreshed = await copy_db.get_channels_with_counts()
-            toggled = next(c for c in refreshed if c.id == ch.id)
+            toggled = next(c for c in refreshed if c.id == channel_id)
             if toggled.is_active is not (not original):
                 raise RuntimeError("channel active state did not change")
             results.append(
                 CheckResult(
                     "channel_toggle",
                     Status.PASS,
-                    f"id={ch.id} active: {original} -> {not original}",
+                    f"id={channel_id} active: {original} -> {not original}",
                 )
             )
     except Exception as exc:
@@ -679,7 +707,7 @@ async def _tg_call(
     coro,
     timeout: int = TELEGRAM_TIMEOUT,
     *,
-    pool=None,
+    pool: ClientPool | None = None,
     phone: str | None = None,
     check_name: str | None = None,
 ):
@@ -698,7 +726,7 @@ async def _tg_call(
 
 
 async def _wait_for_available_client_window(
-    pool,
+    pool: ClientPool,
     check_name: str,
     *,
     premium: bool = False,
@@ -751,7 +779,7 @@ def _is_premium_flood_unavailable_error(detail: str | None) -> bool:
 async def _run_operation_with_flood_policy(
     operation_factory,
     *,
-    pool,
+    pool: ClientPool,
     check_name: str,
     timeout: int = TELEGRAM_TIMEOUT,
 ):
@@ -803,7 +831,7 @@ async def _run_search_operation(
         return CheckResult(check_name, Status.PASS, success_detail_factory(result))
 
 
-async def _run_warm_dialog_cache_step(pool) -> CheckResult:
+async def _run_warm_dialog_cache_step(pool: ClientPool) -> CheckResult:
     check_name = "tg_warm_dialog_cache"
     while True:
         client_tuple = await pool.get_available_client()
@@ -853,8 +881,9 @@ async def _abort_tg_live_step(state: TelegramLiveCheckState, name: str, exc: Bas
 
 async def _run_tg_operation_step(state: TelegramLiveCheckState, name, op, on_success) -> bool:
     """Run a flood-policy op; return False only when cleanup already ran."""
+    pool = _require_tg_pool(state)
     try:
-        value = await _run_operation_with_flood_policy(op, pool=state.pool, check_name=name)
+        value = await _run_operation_with_flood_policy(op, pool=pool, check_name=name)
         state.results.append(on_success(value))
         return True
     except TelegramLiveStepSkipError as exc:
@@ -889,17 +918,20 @@ async def _run_tg_db_copy_step(state: TelegramLiveCheckState) -> bool:
 
 async def _run_tg_pool_init_step(state: TelegramLiveCheckState) -> bool:
     try:
+        config = _require_tg_config(state)
+        copy_db = _require_tg_copy_db(state)
         _, state.pool = await _tg_call(
-            runtime.init_pool(state.config, state.copy_db),
+            runtime.init_pool(config, copy_db),
             check_name="tg_pool_init",
         )
-        clients = state.pool.clients if hasattr(state.pool, "clients") else {}
+        pool = _require_tg_pool(state)
+        clients = pool.clients if hasattr(pool, "clients") else {}
         if not clients:
             state.results.append(CheckResult("tg_pool_init", Status.SKIP, "No accounts connected"))
             _skip_remaining_tg_checks(state.results, "pool init skipped", _TG_CHECKS_AFTER_POOL)
             await _cleanup_telegram(state.pool, state.copy_db, state.tmp_path, state.results)
             return False
-        await _disable_flood_auto_sleep(state.pool)
+        await _disable_flood_auto_sleep(pool)
         state.results.append(
             CheckResult("tg_pool_init", Status.PASS, f"{len(clients)} clients connected"),
         )
@@ -917,6 +949,7 @@ async def _run_tg_pool_init_step(state: TelegramLiveCheckState) -> bool:
 
 
 async def _run_tg_resolve_channel_step(state: TelegramLiveCheckState, channels) -> bool:
+    pool = _require_tg_pool(state)
     target_with_username = next((ch for ch in channels if ch.username), None)
     if not target_with_username:
         state.results.append(
@@ -926,8 +959,8 @@ async def _run_tg_resolve_channel_step(state: TelegramLiveCheckState, channels) 
 
     try:
         entity = await _run_operation_with_flood_policy(
-            lambda: state.pool.resolve_channel(target_with_username.username),
-            pool=state.pool,
+            lambda: pool.resolve_channel(target_with_username.username),
+            pool=pool,
             check_name="tg_resolve_channel",
         )
         if entity:
@@ -956,7 +989,8 @@ async def _run_tg_resolve_channel_step(state: TelegramLiveCheckState, channels) 
 
 
 async def _run_tg_warm_dialog_cache_live_step(state: TelegramLiveCheckState) -> bool:
-    warm_result = await _run_warm_dialog_cache_step(state.pool)
+    pool = _require_tg_pool(state)
+    warm_result = await _run_warm_dialog_cache_step(pool)
     state.results.append(warm_result)
     if warm_result.status == Status.SKIP:
         await _cleanup_telegram(state.pool, state.copy_db, state.tmp_path, state.results)
@@ -991,10 +1025,12 @@ async def _run_tg_iter_messages_for_channel(
     ch,
     collector_cls,
 ) -> bool:
+    pool = _require_tg_pool(state)
+    copy_db = _require_tg_copy_db(state)
     while True:
-        client_tuple = await state.pool.get_available_client()
+        client_tuple = await pool.get_available_client()
         if not client_tuple:
-            detail = await _wait_for_available_client_window(state.pool, "tg_iter_messages")
+            detail = await _wait_for_available_client_window(pool, "tg_iter_messages")
             if detail is None:
                 continue
             state.results.append(CheckResult("tg_iter_messages", Status.SKIP, detail))
@@ -1006,14 +1042,14 @@ async def _run_tg_iter_messages_for_channel(
         try:
             entity = await _tg_call(
                 session.resolve_entity(ch.channel_id),
-                pool=state.pool,
+                pool=pool,
                 phone=phone,
                 check_name="tg_iter_messages",
             )
 
             msg_count = await _tg_call(
-                _collect_tg_iter_messages(session, entity, ch, state.copy_db, collector_cls),
-                pool=state.pool,
+                _collect_tg_iter_messages(session, entity, ch, copy_db, collector_cls),
+                pool=pool,
                 phone=phone,
                 check_name="tg_iter_messages",
             )
@@ -1027,7 +1063,7 @@ async def _run_tg_iter_messages_for_channel(
             break
         except HandledFloodWaitError as exc:
             try:
-                await _handle_live_flood_wait(state.pool, "tg_iter_messages", exc.info)
+                await _handle_live_flood_wait(pool, "tg_iter_messages", exc.info)
             except TelegramLiveStepSkipError as stop_exc:
                 state.results.append(CheckResult("tg_iter_messages", Status.SKIP, str(stop_exc)))
                 await _cleanup_telegram(state.pool, state.copy_db, state.tmp_path, state.results)
@@ -1037,7 +1073,7 @@ async def _run_tg_iter_messages_for_channel(
             state.results.append(CheckResult("tg_iter_messages", Status.FAIL, _format_exception(exc)))
             break
         finally:
-            await state.pool.release_client(phone)
+            await pool.release_client(phone)
     return True
 
 
@@ -1059,13 +1095,16 @@ async def _run_tg_channel_stats_step(
     active_channels,
     collector_cls,
 ) -> bool:
+    pool = _require_tg_pool(state)
+    copy_db = _require_tg_copy_db(state)
+    config = _require_tg_config(state)
     if not active_channels:
         state.results.append(
             CheckResult("tg_channel_stats", Status.SKIP, "No active channels"),
         )
         return True
     ch = active_channels[0]
-    collector = collector_cls(state.pool, state.copy_db, state.config.scheduler)
+    collector = collector_cls(pool, copy_db, config.scheduler)
 
     def _stats_result(stats) -> CheckResult:
         if stats:
@@ -1089,12 +1128,14 @@ async def _run_tg_channel_stats_step(
 
 
 async def _run_tg_search_my_chats_step(state: TelegramLiveCheckState) -> bool:
+    engine = _require_tg_engine(state)
+    pool = _require_tg_pool(state)
     return await _run_tg_search_step(
         state,
         "tg_search_my_chats",
         lambda: _run_search_operation(
-            lambda: state.engine.search_my_chats("test", limit=5),
-            pool=state.pool,
+            lambda: engine.search_my_chats("test", limit=5),
+            pool=pool,
             check_name="tg_search_my_chats",
             success_detail_factory=lambda result: f"{result.total} results",
         ),
@@ -1102,6 +1143,8 @@ async def _run_tg_search_my_chats_step(state: TelegramLiveCheckState) -> bool:
 
 
 async def _run_tg_search_in_channel_step(state: TelegramLiveCheckState, channels) -> bool:
+    engine = _require_tg_engine(state)
+    pool = _require_tg_pool(state)
     if not channels:
         state.results.append(
             CheckResult("tg_search_in_channel", Status.SKIP, "No channels"),
@@ -1112,8 +1155,8 @@ async def _run_tg_search_in_channel_step(state: TelegramLiveCheckState, channels
         state,
         "tg_search_in_channel",
         lambda: _run_search_operation(
-            lambda: state.engine.search_in_channel(ch.channel_id, "test", limit=5),
-            pool=state.pool,
+            lambda: engine.search_in_channel(ch.channel_id, "test", limit=5),
+            pool=pool,
             check_name="tg_search_in_channel",
             success_detail_factory=lambda result: f"ch={ch.channel_id}: {result.total} results",
         ),
@@ -1121,12 +1164,14 @@ async def _run_tg_search_in_channel_step(state: TelegramLiveCheckState, channels
 
 
 async def _run_tg_search_premium_step(state: TelegramLiveCheckState) -> bool:
+    engine = _require_tg_engine(state)
+    pool = _require_tg_pool(state)
     return await _run_tg_search_step(
         state,
         "tg_search_premium",
         lambda: _run_search_operation(
-            lambda: state.engine.search_telegram("test", limit=5),
-            pool=state.pool,
+            lambda: engine.search_telegram("test", limit=5),
+            pool=pool,
             check_name="tg_search_premium",
             success_detail_factory=lambda result: f"{result.total} results",
             premium_error_is_skip=True,
@@ -1135,11 +1180,13 @@ async def _run_tg_search_premium_step(state: TelegramLiveCheckState) -> bool:
 
 
 async def _run_tg_search_quota_step(state: TelegramLiveCheckState) -> bool:
+    engine = _require_tg_engine(state)
+    pool = _require_tg_pool(state)
     try:
         while True:
             quota = await _run_operation_with_flood_policy(
-                lambda: state.engine.check_search_quota("test"),
-                pool=state.pool,
+                lambda: engine.check_search_quota("test"),
+                pool=pool,
                 check_name="tg_search_quota",
             )
             if quota is not None:
@@ -1147,15 +1194,15 @@ async def _run_tg_search_quota_step(state: TelegramLiveCheckState) -> bool:
                 state.results.append(CheckResult("tg_search_quota", Status.PASS, detail))
                 break
 
-            detail = await _wait_for_available_client_window(
-                state.pool,
+            window_detail = await _wait_for_available_client_window(
+                pool,
                 "tg_search_quota",
                 premium=True,
                 base_detail="No premium account or quota unavailable",
             )
-            if detail is None:
+            if window_detail is None:
                 continue
-            state.results.append(CheckResult("tg_search_quota", Status.SKIP, detail))
+            state.results.append(CheckResult("tg_search_quota", Status.SKIP, window_detail))
             break
     except TelegramLiveStepSkipError as exc:
         state.results.append(CheckResult("tg_search_quota", Status.SKIP, str(exc)))
@@ -1176,13 +1223,15 @@ async def _run_telegram_live_checks(config_path: str) -> list[CheckResult]:
     if not await _run_tg_pool_init_step(state):
         return state.results
 
-    state.engine = SearchEngine(state.copy_db, state.pool)
+    copy_db = _require_tg_copy_db(state)
+    pool = _require_tg_pool(state)
+    state.engine = SearchEngine(copy_db, pool)
 
     # 3. tg_users_info
     if not await _run_tg_operation_step(
         state,
         "tg_users_info",
-        lambda: state.pool.get_users_info(),
+        lambda: pool.get_users_info(),
         lambda users: CheckResult("tg_users_info", Status.PASS, ", ".join(u.phone for u in users)),
     ):
         return state.results
@@ -1191,15 +1240,13 @@ async def _run_telegram_live_checks(config_path: str) -> list[CheckResult]:
     if not await _run_tg_operation_step(
         state,
         "tg_get_dialogs",
-        lambda: state.pool.get_dialogs(),
+        lambda: pool.get_dialogs(),
         lambda dialogs: CheckResult("tg_get_dialogs", Status.PASS, f"{len(dialogs)} dialogs"),
     ):
         return state.results
 
     # 5. tg_resolve_channel
-    if state.copy_db is None:
-        raise RuntimeError("test: copy_db not initialized before tg_resolve_channel step")
-    channels = await state.copy_db.get_channels(active_only=True)
+    channels = await copy_db.get_channels(active_only=True)
     if not await _run_tg_resolve_channel_step(state, channels):
         return state.results
 

--- a/src/cli/graph_builder.py
+++ b/src/cli/graph_builder.py
@@ -15,7 +15,7 @@ hints, applying auto-wiring rules:
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Callable, cast
 
 from src.cli.node_dsl import NodeSpec, generate_node_id
 from src.models import (
@@ -31,6 +31,7 @@ class GraphBuilderError(ValueError):
 
 
 _AUTO_INSERT_TYPES = {PipelineNodeType.FETCH_MESSAGES}
+_PIPELINE_EDGE_FACTORY = cast(Callable[..., PipelineEdge], PipelineEdge)
 
 
 @dataclass
@@ -208,7 +209,7 @@ class GraphBuilder:
         chain.extend(nid for nid in state.user_node_ids if nid not in chain)
 
         for i in range(len(chain) - 1):
-            state.edges.append(PipelineEdge(from_node=chain[i], to_node=chain[i + 1]))
+            state.edges.append(_PIPELINE_EDGE_FACTORY(from_node=chain[i], to_node=chain[i + 1]))
 
         # -- 7. Explicit edges ---------------------------------------------------
         node_ids = {n.id for n in state.nodes}
@@ -219,7 +220,7 @@ class GraphBuilder:
                     f"Edge references non-existent node: {from_id} -> {to_id}"
                 )
             if (from_id, to_id) not in existing:
-                state.edges.append(PipelineEdge(from_node=from_id, to_node=to_id))
+                state.edges.append(_PIPELINE_EDGE_FACTORY(from_node=from_id, to_node=to_id))
 
     def _apply_overrides_and_validate(self, state: _BuildState) -> None:
         # -- 8. Apply node config overrides --------------------------------------

--- a/src/cli/graph_viz.py
+++ b/src/cli/graph_viz.py
@@ -66,11 +66,11 @@ def render_ascii(graph: PipelineGraph) -> str:
                 # Fan-out
                 prefix = "   "
                 for ci, child_id in enumerate(children):
-                    child = node_by_id.get(child_id)
-                    if child is None:
+                    child_node = node_by_id.get(child_id)
+                    if child_node is None:
                         continue
-                    c_summary = _config_summary(child.config)
-                    label = f"[{child.type.value}] id={child.id}{c_summary}"
+                    c_summary = _config_summary(child_node.config)
+                    label = f"[{child_node.type.value}] id={child_node.id}{c_summary}"
                     if ci == 0:
                         lines.append(f"{prefix}|")
                         lines.append(f"{prefix}+---> {label}")

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import cast
+import importlib
+from typing import Any, cast
 
 import click
 
@@ -25,7 +26,7 @@ from src.cli.typer_app import app
 # ``click`` types if a future Typer drops it, so the import can never crash the
 # CLI.
 try:  # pragma: no cover - exercised indirectly via main() bare-group tests
-    from typer._click import exceptions as _typer_click_exc
+    _typer_click_exc = cast(Any, importlib.import_module("typer._click.exceptions"))
 
     _CLICK_EXCEPTIONS: tuple[type[BaseException], ...] = (
         click.exceptions.ClickException,


### PR DESCRIPTION
Part of #1133.

## What changed
- Cleared the current `src/cli/` mypy surface with type-only narrowing, annotations, and casts.
- Typed the `test` CLI command live-check state around `Database`, `ClientPool`, `SearchEngine`, and `AppConfig` without running live Telegram paths.
- Preserved existing CLI runtime calls where the issue was only mypy visibility, including dynamic registries, Pydantic alias construction, and private Typer click fallback handling.
- Kept the diff confined to `src/cli/`; no `src/agent/` changes.

## Measurements
| Surface | Before | After |
| --- | ---: | ---: |
| `python -m mypy src/` total | 207 | 159 |
| `src/cli/` errors | 48 | 0 |
| `src/cli/commands/test.py` | 18 | 0 |
| `src/cli/commands/pipeline.py` | 10 | 0 |

Full-run error-code deltas: `attr-defined` 59 -> 42, `arg-type` 61 -> 51, `return-value` 18 -> 11, `call-arg` 8 -> 2, `assignment` 21 -> 16, `import-not-found` 1 -> 0, `operator` 3 -> 1. Remaining 159 errors are outside `src/cli/`.

## Validation
- `python -m mypy src/ --show-error-codes` (expected non-zero from remaining non-CLI baseline; `src/cli/` is 0)
- `ruff check src/ tests/`
- `python -c "import src.cli.typer_commands"`
- `pytest tests/ -k "cli or typer" -m "not real_tg_safe and not real_tg_mutation_safe and not real_tg_manual and not real_provider_smoke"` -> 2477 passed, 5 skipped, 7733 deselected
