### PR TITLE
Part of #1133: clear agent mypy errors

### DIFF
--- a/src/agent/backends/_stream.py
+++ b/src/agent/backends/_stream.py
@@ -95,7 +95,7 @@ async def _dispatch_rate_limit_event(
         "Rate limit event (thread %d): status=%s, resets_at=%s, utilization=%s",
         thread_id, rl_status, resets, utilization,
     )
-    rl_parts = [rl_status]
+    rl_parts: list[str] = [rl_status]
     if utilization is not None:
         rl_parts.append(f"{utilization:.0%}")
     rl_summary = ", ".join(rl_parts)

--- a/src/agent/backends/claude_sdk.py
+++ b/src/agent/backends/claude_sdk.py
@@ -6,6 +6,7 @@ import os
 import shutil
 import time
 from contextlib import suppress
+from typing import Any, Protocol, cast
 
 from claude_agent_sdk import (
     ClaudeAgentOptions,
@@ -35,6 +36,14 @@ from src.database import Database
 from src.utils.json import safe_json_dumps
 
 logger = logging.getLogger(__name__)
+
+
+class _ClosableAsyncIterator(Protocol):
+    def __aiter__(self) -> "_ClosableAsyncIterator": ...
+
+    async def __anext__(self) -> object: ...
+
+    async def aclose(self) -> None: ...
 
 
 class ClaudeSdkBackend:
@@ -123,8 +132,8 @@ class ClaudeSdkBackend:
         if "[api:request]" in _lower:
             api_request_count[0] += 1
             api_request_ts[0] = time.monotonic()
-            label = f"Жду ответ Claude API #{api_request_count[0]}: «{prompt_short}»"
-            payload = safe_json_dumps({"type": "status", "text": label}, ensure_ascii=False)
+            request_label = f"Жду ответ Claude API #{api_request_count[0]}: «{prompt_short}»"
+            payload = safe_json_dumps({"type": "status", "text": request_label}, ensure_ascii=False)
             try:
                 queue.put_nowait(f"data: {payload}\n\n")
             except Exception:
@@ -203,7 +212,7 @@ class ClaudeSdkBackend:
 
         return ClaudeAgentOptions(
             system_prompt=system_prompt,
-            mcp_servers={"telegram_db": self._server},
+            mcp_servers={"telegram_db": cast(Any, self._server)},
             tools=enabled_builtins or None,
             allowed_tools=allowed,
             cli_path=cli_path or None,
@@ -402,7 +411,10 @@ class ClaudeSdkBackend:
             first_event_logged = False
             _api_request_count[0] = 0
             try:
-                aiter = query(prompt=_as_prompt_stream(prompt), options=options).__aiter__()
+                aiter = cast(
+                    _ClosableAsyncIterator,
+                    query(prompt=_as_prompt_stream(prompt), options=options).__aiter__(),
+                )
                 try:
                   while True:
                     if not first_event_logged:

--- a/src/agent/backends/deepagents.py
+++ b/src/agent/backends/deepagents.py
@@ -4,9 +4,9 @@ import asyncio
 import logging
 import os
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Coroutine
 from datetime import UTC, datetime
-from typing import TypeVar
+from typing import Any, TypeVar, cast
 
 from src.agent.backends._stream import _embed_history_in_prompt, _ToolTracker
 from src.agent.prompt_template import DEFAULT_AGENT_PROMPT_TEMPLATE
@@ -236,7 +236,7 @@ class DeepagentsBackend:
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError:
-            return asyncio.run(operation())
+            return asyncio.run(cast(Coroutine[Any, Any, _ToolResult], operation()))
         raise RuntimeError(
             f"Deepagents tool '{tool_name}' cannot run inside an active event loop: {loop}"
         )
@@ -295,7 +295,7 @@ class DeepagentsBackend:
         gate_active: bool = False,
         record_last_used: bool = True,
         system_prompt: str = DEFAULT_AGENT_PROMPT_TEMPLATE,
-    ):
+    ) -> Any:
         configured_model_name = cfg.selected_model.strip()
         if not configured_model_name:
             raise RuntimeError("Deepagents provider model is not configured.")
@@ -328,7 +328,7 @@ class DeepagentsBackend:
                     resolved_model_name,
                 )
                 from src.agent.react_agent import OllamaReActAgent
-                agent = OllamaReActAgent(
+                agent: Any = OllamaReActAgent(
                     base_url=str(extra.get("base_url", "http://localhost:11434")),
                     model=resolved_model_name,
                     tools=tools or self._default_tools(
@@ -353,10 +353,11 @@ class DeepagentsBackend:
         try:
             from langchain.chat_models import init_chat_model
 
+            model_kwargs = cast(dict[str, Any], extra)
             model = init_chat_model(
                 model=resolved_model_name,
                 model_provider=model_provider,
-                **extra,
+                **model_kwargs,
             )
         except ImportError as exc:
             package = (
@@ -422,7 +423,7 @@ class DeepagentsBackend:
         # environment. Treat legacy fallback as available when validation passes (e.g.,
         # anthopic fallback requires explicit fallback API key).
         if all(self._is_legacy_candidate(cfg) for cfg in candidates):
-            errors: list[str] = []
+            legacy_errors: list[str] = []
             for cfg in candidates:
                 validation_error = (
                     self._legacy_validation_error(cfg)
@@ -430,7 +431,7 @@ class DeepagentsBackend:
                     else self._validation_error(cfg)
                 )
                 if validation_error:
-                    errors.append(f"{cfg.provider}: {validation_error}")
+                    legacy_errors.append(f"{cfg.provider}: {validation_error}")
                     continue
                 self._preflight_available = True
                 self._init_error = None
@@ -445,15 +446,15 @@ class DeepagentsBackend:
                 return
             self._preflight_available = False
             self._init_error = (
-                "; ".join(errors) if errors else "Deepagents providers are not configured."
+                "; ".join(legacy_errors) if legacy_errors else "Deepagents providers are not configured."
             )
             raise RuntimeError(self._init_error)
 
-        errors: list[str] = []
+        candidate_errors: list[str] = []
         for cfg in candidates:
             validation_error = self._validation_error(cfg)
             if validation_error:
-                errors.append(f"{cfg.provider}: {validation_error}")
+                candidate_errors.append(f"{cfg.provider}: {validation_error}")
                 continue
             try:
                 self._build_agent(cfg)
@@ -466,11 +467,11 @@ class DeepagentsBackend:
                 )
                 return
             except Exception as exc:
-                errors.append(format_provider_error(cfg.provider, exc))
+                candidate_errors.append(format_provider_error(cfg.provider, exc))
                 logger.warning("Deepagents provider preflight failed (%s): %s", cfg.provider, exc)
         self._preflight_available = False
         self._init_error = (
-            "; ".join(errors) if errors else "Deepagents providers are not configured."
+            "; ".join(candidate_errors) if candidate_errors else "Deepagents providers are not configured."
         )
         raise RuntimeError(self._init_error)
 

--- a/src/agent/manager.py
+++ b/src/agent/manager.py
@@ -55,6 +55,7 @@ from src.services.agent_provider_service import ProviderModelCompatibilityRecord
 logger = logging.getLogger(__name__)
 
 _HISTORY_BUDGET = 100_000 * 4  # ~100K tokens in chars
+AgentBackend = ClaudeSdkBackend | DeepagentsBackend | CodexSdkBackend | AdkSdkBackend
 
 __all__ = [
     "AgentManager",
@@ -398,6 +399,7 @@ class AgentManager:
         if status.error and (backend_name is None or status.using_override):
             yield _sse({"error": f"Ошибка агента: {status.error}"})
             return
+        backend: AgentBackend
         if backend_name == "claude":
             backend = self._claude_backend
         elif backend_name == "deepagents":
@@ -445,7 +447,7 @@ class AgentManager:
             )
 
         async def _run_backend(
-            selected_backend: ClaudeSdkBackend | DeepagentsBackend | CodexSdkBackend | AdkSdkBackend,
+            selected_backend: AgentBackend,
             failure_prefix: Callable[[str], str],
         ) -> None:
             # Set ContextVar here so token is created and reset in the same task context.

--- a/src/agent/permission_gate.py
+++ b/src/agent/permission_gate.py
@@ -26,6 +26,10 @@ import threading
 import uuid
 from contextvars import ContextVar
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.agent.tools.permissions import ToolAccessState
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +68,7 @@ class AgentRequestContext:
     thread_id: int
     queue: asyncio.Queue              # SSE queue for this request
     db_permissions: dict[str, bool] | None = None  # legacy boolean view
-    tool_access_policy: dict[str, object] | None = None
+    tool_access_policy: dict[str, ToolAccessState] | None = None
     permission_gate: PermissionGate | None = None
     permission_timeout: int | None = None  # legacy config field; prompts no longer time out
     cancel_event: threading.Event | None = None

--- a/src/agent/runtime_context.py
+++ b/src/agent/runtime_context.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import asyncio
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Coroutine
 from concurrent.futures import CancelledError as FutureCancelledError
 from concurrent.futures import TimeoutError as FutureTimeoutError
 from dataclasses import dataclass
 from types import MappingProxyType
-from typing import Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast
 
 _T = TypeVar("_T")
 RuntimeKind = Literal["live", "snapshot", "none"]
@@ -19,6 +19,10 @@ DEFAULT_SYNC_TIMEOUT_SEC = 120.0
 # provider_adapters.py) so the adapter times out first with its specific
 # message and subprocess kill — the generic bridge deadline is only a backstop.
 DEFAULT_TOOL_SYNC_TIMEOUT_SEC = MappingProxyType({"generate_image": 240.0})
+
+if TYPE_CHECKING:
+    from src.database import Database
+    from src.telegram.client_pool import ClientPool
 
 
 class AgentToolRuntimeError(RuntimeError):
@@ -42,9 +46,9 @@ def detect_runtime_kind(client_pool: object | None) -> RuntimeKind:
 class AgentRuntimeContext:
     """Runtime dependencies shared by async and thread-based agent tools."""
 
-    db: object
+    db: Database
     config: object | None = None
-    client_pool: object | None = None
+    client_pool: ClientPool | None = None
     scheduler_manager: object | None = None
     runtime_kind: RuntimeKind = "none"
     owner_loop: asyncio.AbstractEventLoop | None = None
@@ -59,9 +63,9 @@ class AgentRuntimeContext:
     def build(
         cls,
         *,
-        db: object,
+        db: Database,
         config: object | None = None,
-        client_pool: object | None = None,
+        client_pool: ClientPool | None = None,
         scheduler_manager: object | None = None,
         runtime_kind: RuntimeKind | None = None,
         owner_loop: asyncio.AbstractEventLoop | None = None,
@@ -111,7 +115,10 @@ class AgentRuntimeContext:
                     f"Agent tool '{tool_name}' cannot synchronously block the live Telegram owner event loop.",
                     retryable=True,
                 )
-            future = asyncio.run_coroutine_threadsafe(operation(), self.owner_loop)
+            future = asyncio.run_coroutine_threadsafe(
+                cast(Coroutine[Any, Any, _T], operation()),
+                self.owner_loop,
+            )
             cancel_event = None
             permission_wait_tracker = None
             try:
@@ -183,7 +190,7 @@ class AgentRuntimeContext:
                         ) from exc
 
         if current_loop is None:
-            return asyncio.run(operation())
+            return asyncio.run(cast(Coroutine[Any, Any, _T], operation()))
 
         raise AgentToolRuntimeError(
             f"Agent tool '{tool_name}' cannot run inside an active event loop without a sync bridge.",

--- a/src/agent/tools/_formatters.py
+++ b/src/agent/tools/_formatters.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
+from typing import Any, cast
 from unittest.mock import Mock
 
 
@@ -126,7 +127,7 @@ def format_notification_status(bot: object | None, target_status: object | None 
 
 
 def format_filter_report(report: object) -> str:
-    results = list(_value(report, "results", []) or [])
+    results = list(cast(Iterable[object], _value(report, "results", []) or []))
     if not results:
         return "Нет каналов для анализа фильтров. 0 каналов проверено, 0 рекомендовано к фильтрации."
 
@@ -137,7 +138,7 @@ def format_filter_report(report: object) -> str:
     ]
     for result in flagged:
         flags_value = _value(result, "flags", []) or []
-        flags = ", ".join(str(flag) for flag in flags_value) if flags_value else "—"
+        flags = ", ".join(str(flag) for flag in cast(Iterable[object], flags_value)) if flags_value else "—"
         title = _value(result, "title") or "Без названия"
         lines.append(f"- {title} (id={_value(result, 'channel_id', '?')}): {flags}")
     return "\n".join(lines)
@@ -148,7 +149,7 @@ def format_channel_stats(stats: Mapping[int, object], channels: Iterable[object]
         return "Статистика каналов пока не собрана."
 
     channels_by_id = {
-        int(channel_id): channel
+        int(cast(Any, channel_id)): channel
         for channel in channels or []
         if (channel_id := _value(channel, "channel_id")) is not None
     }

--- a/src/agent/tools/_registry.py
+++ b/src/agent/tools/_registry.py
@@ -8,7 +8,7 @@ import re as _re
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from inspect import isawaitable
-from typing import Any
+from typing import TYPE_CHECKING, Any, TypeAlias, cast
 
 from src.agent.runtime_context import AgentRuntimeContext
 from src.telegram.flood_wait import (
@@ -19,6 +19,13 @@ from src.telegram.flood_wait import (
 )
 from src.utils.datetime import try_parse_utc_datetime
 from src.utils.introspection import explicit_pool_method
+
+if TYPE_CHECKING:
+    from src.database import Database
+    from src.models import Account, AccountSummary
+    from src.telegram.client_pool import ClientPool
+
+    AccountLike: TypeAlias = Account | AccountSummary
 
 logger = logging.getLogger(__name__)
 
@@ -39,9 +46,9 @@ class ToolInputError(ValueError):
 class AgentToolContext:
     """Shared dependencies and guards for agent tool handlers."""
 
-    db: object
+    db: Database
     config: object | None = None
-    client_pool: object | None = None
+    client_pool: ClientPool | None = None
     scheduler_manager: object | None = None
     embedding_service: object | None = None
     runtime_context: AgentRuntimeContext | None = None
@@ -50,9 +57,9 @@ class AgentToolContext:
     def build(
         cls,
         *,
-        db: object,
+        db: Database,
         config: object | None = None,
-        client_pool: object | None = None,
+        client_pool: ClientPool | None = None,
         scheduler_manager: object | None = None,
         embedding_service: object | None = None,
         runtime_context: AgentRuntimeContext | None = None,
@@ -85,12 +92,17 @@ class AgentToolContext:
         return await require_phone_permission(self.db, phone, tool_name)
 
     async def resolve_live_read_phone(self, raw_phone: object, *, tool_name: str) -> tuple[str, dict | None]:
-        return await resolve_live_read_phone(self.db, self.client_pool, raw_phone, tool_name=tool_name)
+        return await resolve_live_read_phone(
+            self.db,
+            cast("ClientPool", self.client_pool),
+            raw_phone,
+            tool_name=tool_name,
+        )
 
     def channel_service(self):
         from src.services.channel_service import ChannelService
 
-        return ChannelService(self.db, self.client_pool, None)
+        return ChannelService(self.db, cast("ClientPool", self.client_pool), None)
 
     def pipeline_service(self):
         from src.services.pipeline_service import PipelineService
@@ -101,8 +113,8 @@ class AgentToolContext:
 def get_tool_context(
     kwargs: dict,
     *,
-    db: object,
-    client_pool: object | None = None,
+    db: Database,
+    client_pool: ClientPool | None = None,
     embedding_service: object | None = None,
 ) -> AgentToolContext:
     """Return the shared tool context passed by the registry, or build one for direct tests."""
@@ -323,7 +335,7 @@ def _pool_reports_connections(client_pool: object | None) -> bool:
         return False
 
 
-async def _get_accounts(db: object, *, active_only: bool = False) -> list[object]:
+async def _get_accounts(db: Database, *, active_only: bool = False) -> list[AccountLike]:
     for getter_name in ("get_account_summaries", "get_accounts"):
         getter = getattr(db, getter_name, None)
         if not callable(getter):
@@ -335,11 +347,11 @@ async def _get_accounts(db: object, *, active_only: bool = False) -> list[object
         if isawaitable(result):
             result = await result
         if isinstance(result, (list, tuple)):
-            return list(result)
+            return cast("list[AccountLike]", list(result))
     return []
 
 
-async def _clear_account_flood(db: object, phone: str) -> None:
+async def _clear_account_flood(db: Database, phone: str) -> None:
     updater = getattr(db, "update_account_flood", None)
     if not callable(updater):
         return
@@ -352,11 +364,11 @@ async def _clear_account_flood(db: object, phone: str) -> None:
 
 
 async def get_accounts_with_flood_cleanup(
-    db: object,
+    db: Database,
     *,
     active_only: bool = False,
     now: datetime | None = None,
-) -> list[object]:
+) -> list[AccountLike]:
     """Load accounts and clear stale flood_wait_until values before callers inspect them."""
     now = now or datetime.now(timezone.utc)
     accounts = await _get_accounts(db, active_only=active_only)
@@ -404,7 +416,7 @@ def require_live_runtime(
 
 
 def available_live_read_phones(
-    accounts: list[object],
+    accounts: list[AccountLike],
     connected_phones: set[str],
     *,
     trust_empty_connected: bool = True,
@@ -431,8 +443,8 @@ def available_live_read_phones(
 
 
 async def resolve_live_read_phone(
-    db: object,
-    client_pool: object,
+    db: Database,
+    client_pool: ClientPool,
     raw_phone: object,
     *,
     tool_name: str,
@@ -608,7 +620,7 @@ def require_pool(client_pool: object | None, action: str = "Эта операц�
     )
 
 
-async def resolve_phone(db: object, raw_phone: object) -> tuple[str, dict | None]:
+async def resolve_phone(db: Database, raw_phone: object) -> tuple[str, dict | None]:
     """Normalize phone, default to primary account if empty.
 
     Returns ``(phone, None)`` on success or ``("", error_response)`` on failure.
@@ -637,7 +649,7 @@ async def resolve_phone(db: object, raw_phone: object) -> tuple[str, dict | None
     return primary.phone, None
 
 
-async def require_phone_permission(db: object, phone: str, tool_name: str) -> dict | None:
+async def require_phone_permission(db: Database, phone: str, tool_name: str) -> dict | None:
     """Return helpful response with allowed phones if not permitted, else None.
 
     If db has no phone permissions configured, returns None (all phones allowed).
@@ -743,7 +755,7 @@ class ResolvedEntityLease:
 
 
 async def _released_resolve_entity_result(
-    client_pool: object,
+    client_pool: ClientPool,
     release_phones: list[str],
     error: dict,
 ) -> ResolvedEntityLease:
@@ -762,8 +774,8 @@ def should_try_dialog_title_lookup(identifier: object) -> bool:
 
 
 async def load_dialogs_for_title_lookup(
-    db: object,
-    client_pool: object,
+    db: Database,
+    client_pool: ClientPool,
     phone: str,
     *,
     refresh: bool = False,
@@ -789,8 +801,8 @@ async def load_dialogs_for_title_lookup(
 
 
 async def find_dialogs_by_exact_title(
-    db: object,
-    client_pool: object,
+    db: Database,
+    client_pool: ClientPool,
     phone: str,
     title: object,
     *,
@@ -832,7 +844,7 @@ def format_dialog_title_candidates(title: object, matches: list[dict]) -> dict:
 
 
 async def resolve_entity(
-    client_pool: object,
+    client_pool: ClientPool,
     phone: str,
     chat_id: str,
     *,

--- a/src/agent/tools/accounts.py
+++ b/src/agent/tools/accounts.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated, cast
 
 from claude_agent_sdk import tool
 from mcp.types import ToolAnnotations
@@ -24,11 +24,14 @@ from src.agent.tools._registry import (
     require_confirmation,
 )
 from src.database.repositories.accounts import AccountSessionDecryptError
-from src.models import Account
+from src.models import Account, AccountSummary
 from src.services.account_availability import compute_account_availability
 from src.services.notification_target_service import NotificationTargetService
 from src.services.runtime_diagnostics import evaluate_worker_heartbeat
 from src.telegram.auth import validate_session_string
+
+if TYPE_CHECKING:
+    from src.telegram.client_pool import ClientPool
 
 logger = logging.getLogger(__name__)
 
@@ -84,7 +87,7 @@ def _remaining_seconds(account: object) -> int | None:
     return max(1, int((flood_until - datetime.now(timezone.utc)).total_seconds()))
 
 
-def _diagnostic_lines(accounts: list[object], client_pool: object | None) -> list[str]:
+def _diagnostic_lines(accounts: list[Account | AccountSummary], client_pool: object | None) -> list[str]:
     active_accounts = [a for a in accounts if getattr(a, "is_active", False)]
     active_phones = [str(getattr(a, "phone", "")) for a in active_accounts if getattr(a, "phone", "")]
     connected = connected_phones_from_pool(client_pool)
@@ -124,8 +127,9 @@ async def get_live_account_info_text(runtime: AgentRuntimeContext, phone: object
             details.append(f"Runtime connected phones snapshot: {_format_phones(connected)}.")
         return "\n".join(details)
 
+    client_pool = cast("ClientPool", runtime.client_pool)
     try:
-        users = await runtime.client_pool.get_users_info(include_avatar=False)
+        users = await client_pool.get_users_info(include_avatar=False)
     except Exception:
         users = []
     if phone_filter:

--- a/src/agent/tools/messaging_chat_state.py
+++ b/src/agent/tools/messaging_chat_state.py
@@ -207,7 +207,7 @@ def register_chat_state_read_tools(db: Any, ctx: Any, client_pool: Any) -> list[
         "To save messages to DB for search, use add_channel + collect_channel instead.",
         READ_MESSAGES_SCHEMA,
     )
-    async def read_messages(args):
+    async def read_messages(args: dict[str, Any]) -> dict[str, Any]:
         live_gate = ctx.require_live_runtime("Чтение сообщений", tool_name="read_messages")
         if live_gate:
             return live_gate

--- a/src/agent/tools/messaging_write.py
+++ b/src/agent/tools/messaging_write.py
@@ -322,7 +322,7 @@ def register_message_write_tools(ctx: Any, client_pool: Any) -> list[Any]:
         "Ask user for confirmation first.",
         SEND_REACTIONS_SCHEMA,
     )
-    async def send_reactions(args):
+    async def send_reactions(args: dict[str, Any]) -> dict[str, Any]:
         pool_gate = ctx.require_pool("Реакции на сообщения")
         if pool_gate:
             return pool_gate

--- a/src/agent/tools/permissions.py
+++ b/src/agent/tools/permissions.py
@@ -16,8 +16,9 @@ import json
 import logging
 import time
 from collections import OrderedDict
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from types import MappingProxyType
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 from src.agent.tools._categories import (
     TOOL_MODULE_ORDER,
@@ -26,6 +27,12 @@ from src.agent.tools._categories import (
     ToolMeta,
 )
 from src.agent.tools._registry import _get_accounts
+
+if TYPE_CHECKING:
+    from src.database import Database
+    from src.models import Account, AccountSummary
+
+    AccountLike: TypeAlias = Account | AccountSummary
 
 __all__ = [  # noqa: F822 — TOOL_CATEGORIES & co. are served by module __getattr__
     "TOOL_CATEGORIES",
@@ -120,7 +127,7 @@ def _phone_binded_tools() -> frozenset[str]:
     return _build_metadata()[2]
 
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> Any:
     # PEP 562: keep the historical module attributes working for all existing
     # importers while building them lazily (tool modules pull the agent SDK —
     # CLI paths that import permissions for constants must not pay for that
@@ -171,7 +178,7 @@ def _default_permissions(*, for_missing_in_saved: bool = False) -> dict[str, boo
     return {name: True for name in _tool_categories()}
 
 
-def _is_per_phone_format(saved: dict) -> bool:
+def _is_per_phone_format(saved: dict[str, object]) -> bool:
     """Detect whether saved dict is per-phone (values are dicts) or flat (values are bools)."""
     if not saved:
         return False
@@ -179,7 +186,7 @@ def _is_per_phone_format(saved: dict) -> bool:
     return isinstance(first_value, dict)
 
 
-async def _load_raw_permissions(db) -> dict:
+async def _load_raw_permissions(db: Database) -> dict[str, Any]:
     """Load raw JSON from DB setting."""
     raw = await db.get_setting(TOOL_PERMISSIONS_SETTING)
     if not raw:
@@ -191,7 +198,7 @@ async def _load_raw_permissions(db) -> dict:
         return {}
 
 
-async def _load_raw_permissions_strict(db) -> tuple[dict, bool]:
+async def _load_raw_permissions_strict(db: Database) -> tuple[dict[str, Any], bool]:
     """Load raw permissions and preserve corruption as a fail-closed signal."""
     raw = await db.get_setting(TOOL_PERMISSIONS_SETTING)
     if not raw:
@@ -223,7 +230,7 @@ def _merge_access_states(states: list[ToolAccessState]) -> ToolAccessState:
     return ToolAccessState.DENIED
 
 
-async def load_tool_access_policy(db, *, use_cache: bool = False) -> dict[str, ToolAccessState]:
+async def load_tool_access_policy(db: Database, *, use_cache: bool = False) -> dict[str, ToolAccessState]:
     """Return aggregate tool access states for model visibility decisions.
 
     ``ALLOWED`` means at least one configured scope explicitly allows the tool.
@@ -265,7 +272,7 @@ async def load_tool_access_policy(db, *, use_cache: bool = False) -> dict[str, T
     return result
 
 
-async def get_tool_access_state(db, tool_name: str, *, phone: str = "") -> ToolAccessState:
+async def get_tool_access_state(db: Database, tool_name: str, *, phone: str = "") -> ToolAccessState:
     """Return access state for one tool, optionally scoped to a phone."""
     if tool_name not in _tool_categories():
         return ToolAccessState.DENIED
@@ -289,7 +296,7 @@ async def get_tool_access_state(db, tool_name: str, *, phone: str = "") -> ToolA
     return _state_from_saved_value(phone_perms.get(tool_name))
 
 
-async def get_explicit_allowed_phones(db, tool_name: str) -> list[str]:
+async def get_explicit_allowed_phones(db: Database, tool_name: str) -> list[str]:
     """Return phones with an explicit True grant for the tool."""
     try:
         saved, malformed = await _load_raw_permissions_strict(db)
@@ -305,7 +312,7 @@ async def get_explicit_allowed_phones(db, tool_name: str) -> list[str]:
     )
 
 
-async def load_tool_permissions(db, phone: str | None = None) -> dict[str, bool]:
+async def load_tool_permissions(db: Database, phone: str | None = None) -> dict[str, bool]:
     """Load per-tool permissions from DB for a specific phone.
 
     If *phone* is ``None``, loads permissions for the primary account.
@@ -367,7 +374,10 @@ async def load_tool_permissions(db, phone: str | None = None) -> dict[str, bool]
     return result
 
 
-async def load_tool_permissions_all_phones(db, accounts) -> dict[str, dict[str, bool]]:
+async def load_tool_permissions_all_phones(
+    db: Database,
+    accounts: Iterable[AccountLike],
+) -> dict[str, dict[str, bool]]:
     """Load permissions for every account phone.  Returns ``{phone: {tool: bool}}``."""
     defaults = _default_permissions()
     missing_defaults = _default_permissions(for_missing_in_saved=True)
@@ -398,7 +408,7 @@ async def load_tool_permissions_all_phones(db, accounts) -> dict[str, dict[str, 
     return result
 
 
-async def save_tool_permissions(db, permissions: dict[str, bool], phone: str | None = None) -> None:
+async def save_tool_permissions(db: Database, permissions: dict[str, bool], phone: str | None = None) -> None:
     """Persist per-tool permissions as JSON.
 
     If *phone* is given, saves under the per-phone key without touching other phones.
@@ -432,7 +442,7 @@ async def save_tool_permissions(db, permissions: dict[str, bool], phone: str | N
     await db.set_setting(TOOL_PERMISSIONS_SETTING, json.dumps(saved, ensure_ascii=False))
 
 
-async def load_tool_permissions_union(db, *, use_cache: bool = False) -> dict[str, bool]:
+async def load_tool_permissions_union(db: Database, *, use_cache: bool = False) -> dict[str, bool]:
     """Compatibility boolean view: True only for explicitly allowed tools.
 
     New code should use ``load_tool_access_policy`` plus ``visible_tools_for_llm``

--- a/src/agent/tools/search.py
+++ b/src/agent/tools/search.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, Any
 
 from claude_agent_sdk import tool
 from mcp.types import ToolAnnotations
@@ -33,9 +33,9 @@ TOOL_GROUPS: list[tuple[str, dict[str, ToolMeta]]] = [
     }),
 ]
 
-def register(db, client_pool, embedding_service, **kwargs):
+def register(db: Any, client_pool: Any, embedding_service: Any, **kwargs: Any) -> list[Any]:
     """Register search-related agent tools."""
-    tools = []
+    tools: list[Any] = []
 
     def _render_search_result(
         *,
@@ -167,16 +167,16 @@ def register(db, client_pool, embedding_service, **kwargs):
     # Lazy SearchEngine — created once on first Telegram/hybrid search
     # ------------------------------------------------------------------
 
-    _engine_cache: list = []
+    _engine_cache: list[Any] = []
 
-    def _get_engine():
+    def _get_engine() -> Any:
         if not _engine_cache:
             from src.search.engine import SearchEngine
 
             _engine_cache.append(SearchEngine(db, pool=client_pool, config=kwargs.get("config")))
         return _engine_cache[0]
 
-    def _render_search_response(result) -> str:
+    def _render_search_response(result: Any) -> str:
         """Render SearchResult into text, handling .error field."""
         if result.error:
             return f"Ошибка: {result.error}"

--- a/src/agent/tools/telegram_queue.py
+++ b/src/agent/tools/telegram_queue.py
@@ -146,7 +146,7 @@ def register_queue_status_tools(db: Any, ctx: Any) -> list[Any]:
         "recent tasks, delay reasons, and failures. Read-only.",
         GET_TELEGRAM_QUEUE_STATUS_SCHEMA,
     )
-    async def get_telegram_queue_status(args):
+    async def get_telegram_queue_status(args: dict[str, Any]) -> dict[str, Any]:
         try:
             command_type = arg_str(args, "command_type")
             phone = normalize_phone(arg_str(args, "phone"))


### PR DESCRIPTION
Part of #1133

## Summary
- Typed the agent tool context/runtime dependencies as concrete `Database`, `ClientPool`, and account model shapes instead of broad `object`.
- Cleared agent-local mypy issues in tool registry/helpers, permissions, backend stream handling, deepagents/Claude SDK typing, and nested tool handler annotations.
- Kept the diff restricted to `src/agent/`; no `src/cli/` changes.

## Mypy measurements
| Surface | origin/main | This PR | Delta |
| --- | ---: | ---: | ---: |
| `python -m mypy src/` total error lines | 207 | 173 | -34 |
| `src/agent/` error lines | 34 | 0 | -34 |
| `src/agent/` `annotation-unchecked` notes | 6 | 0 | -6 |
| New non-agent error lines | 0 | 0 | 0 |

Agent baseline categories removed: `attr-defined` 15, `arg-type` 7, `assignment` 4, `no-redef` 3, `call-overload` 3, `dict-item` 1, `var-annotated` 1.

## Validation
- `python -m mypy src/`
- `ruff check src/`
- `python -c "import src.agent.manager; import src.agent.tools._registry"`
- `pytest tests/ -k "agent or tool"` -> 2713 passed, 8 skipped, 7494 deselected
- `git diff --check`