### PR TITLE
chore(web): clear mypy errors (Part of #1133)

### DIFF
--- a/src/web/agent/handlers.py
+++ b/src/web/agent/handlers.py
@@ -6,7 +6,7 @@ import asyncio
 import json
 import logging
 import sqlite3
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from fastapi import HTTPException, Request
 
@@ -261,7 +261,7 @@ async def inject_context(request: Request, thread_id: int) -> AgentJson:
         topic_id=topic_id,
     )
     ch = await db.get_channel_by_channel_id(channel_id)
-    title = ch.title if ch else str(channel_id)
+    title = cast(str, ch.title) if ch else str(channel_id)
 
     topics = await db.get_forum_topics(channel_id)
     topics_map = {t["id"]: t["title"] for t in topics}

--- a/src/web/bootstrap.py
+++ b/src/web/bootstrap.py
@@ -43,7 +43,7 @@ from src.telegram.client_pool import ClientPool
 from src.telegram.collector import Collector
 from src.telegram.notifier import Notifier
 from src.utils.asyncio import make_log_task_exception_callback
-from src.web.container import AppContainer
+from src.web.container import AppContainer, WebClientPool, WebCollector, WebScheduler
 from src.web.log_handler import LogBuffer
 from src.web.paths import TEMPLATES_DIR
 from src.web.runtime_shims import SnapshotClientPool, SnapshotCollector, SnapshotSchedulerManager
@@ -72,7 +72,8 @@ def _connected_pool_count(pool: object) -> int:
 
 
 async def _retry_telegram_pool_until_connected(container: AppContainer) -> None:
-    while _connected_pool_count(container.pool) == 0 and getattr(
+    pool = cast(ClientPool, container.pool)
+    while _connected_pool_count(pool) == 0 and getattr(
         container, "shutting_down", False
     ) is not True:
         try:
@@ -84,11 +85,11 @@ async def _retry_telegram_pool_until_connected(container: AppContainer) -> None:
             raise
         if (
             getattr(container, "shutting_down", False) is True
-            or _connected_pool_count(container.pool) > 0
+            or _connected_pool_count(pool) > 0
         ):
             return
         try:
-            await asyncio.wait_for(container.pool.initialize(), timeout=_POOL_INIT_TIMEOUT)
+            await asyncio.wait_for(pool.initialize(), timeout=_POOL_INIT_TIMEOUT)
         except asyncio.TimeoutError:
             logger.warning(
                 "startup: telegram pool retry timed out after %ds; connected_count=0",
@@ -106,7 +107,7 @@ async def _retry_telegram_pool_until_connected(container: AppContainer) -> None:
         except Exception:
             logger.exception("startup: telegram pool retry failed")
         else:
-            connected_count = _connected_pool_count(container.pool)
+            connected_count = _connected_pool_count(pool)
             if connected_count > 0:
                 logger.info(
                     "startup: telegram pool recovered after retry; connected_count=%d",
@@ -231,6 +232,8 @@ async def build_container_with_templates(
 
     api_id, api_hash = await load_telegram_credentials(db, config)
     auth = TelegramAuth(api_id, api_hash)
+    pool: WebClientPool
+    search_pool: ClientPool | None
     if runtime_mode == "worker":
         pool = ClientPool(
             auth,
@@ -241,8 +244,9 @@ async def build_container_with_templates(
     else:
         pool = SnapshotClientPool(db)
         await pool.refresh()
-    notification_target_service = NotificationTargetService(notification_bundle, pool)
-    photo_publish_service = PhotoPublishService(pool)
+    pool_for_live_typed_services = cast(ClientPool, pool)
+    notification_target_service = NotificationTargetService(notification_bundle, pool_for_live_typed_services)
+    photo_publish_service = PhotoPublishService(pool_for_live_typed_services)
     photo_task_service = PhotoTaskService(photo_loader_bundle, photo_publish_service)
     photo_auto_upload_service = PhotoAutoUploadService(photo_loader_bundle, photo_publish_service)
     notifier = None
@@ -251,27 +255,30 @@ async def build_container_with_templates(
     telegram_command_dispatcher = None
     agent_manager = None
     live_runtime_pause_gate = LiveRuntimePauseGate() if runtime_mode == "worker" else None
+    collector: WebCollector
     if runtime_mode == "worker":
+        live_pool = cast(ClientPool, pool)
         notifier = Notifier(
             notification_target_service, config.notifications.admin_chat_id, notification_bundle
         )
         collector = Collector(
-            pool,
+            live_pool,
             db,
             config.scheduler,
             notifier,
             live_runtime_pause_gate=live_runtime_pause_gate,
         )
+        live_collector = cast(Collector, collector)
         collection_queue = CollectionQueue(
-            collector,
+            live_collector,
             channel_bundle,
             live_runtime_pause_gate=live_runtime_pause_gate,
         )
-        search_pool = pool
+        search_pool = live_pool
     else:
         snapshot_collector = SnapshotCollector(db)
         await snapshot_collector.refresh()
-        collector = cast(Collector, snapshot_collector)
+        collector = snapshot_collector
         search_pool = None
     search_engine = SearchEngine(search_bundle, search_pool, config=config)
     ai_search = AISearchEngine(config.llm, search_bundle)
@@ -279,7 +286,7 @@ async def build_container_with_templates(
 
     from src.services.collection_service import CollectionService
 
-    collection_service = CollectionService(channel_bundle, collector, collection_queue)
+    collection_service = CollectionService(channel_bundle, cast(Collector, collector), collection_queue)
     task_enqueuer = TaskEnqueuer(db, collection_service)
 
     from src.services.provider_service import RuntimeProviderRegistry
@@ -289,9 +296,12 @@ async def build_container_with_templates(
     llm_provider_service = RuntimeProviderRegistry(db, config, env=dict(os.environ))
     await llm_provider_service.load_db_providers()
 
+    scheduler: WebScheduler
     if runtime_mode == "worker":
+        live_pool = cast(ClientPool, pool)
+        live_collector = cast(Collector, collector)
         unified_dispatcher = UnifiedDispatcher(
-            collector,
+            live_collector,
             channel_bundle,
             repos.tasks,
             sq_bundle=search_query_bundle,
@@ -300,7 +310,7 @@ async def build_container_with_templates(
             search_engine=search_engine,
             pipeline_bundle=pipeline_bundle,
             db=db,
-            client_pool=pool,
+            client_pool=live_pool,
             notifier=notifier,
             config=config,
             llm_provider_service=llm_provider_service,
@@ -312,15 +322,15 @@ async def build_container_with_templates(
             search_query_bundle=search_query_bundle,
             task_enqueuer=task_enqueuer,
             pipeline_bundle=pipeline_bundle,
-            warm_dialogs_callback=pool.warm_all_dialogs,
+            warm_dialogs_callback=live_pool.warm_all_dialogs,
             live_runtime_pause_gate=live_runtime_pause_gate,
-            resolve_backoff_callback=pool.get_resolve_username_backoff_remaining_sec,
+            resolve_backoff_callback=live_pool.get_resolve_username_backoff_remaining_sec,
         )
         telegram_command_dispatcher = TelegramCommandDispatcher(
             db,
-            pool,
+            live_pool,
             config,
-            collector,
+            live_collector,
             scheduler=scheduler,
             auth=auth,
             search_engine=search_engine,
@@ -331,7 +341,7 @@ async def build_container_with_templates(
         agent_manager = AgentManager(
             db,
             config,
-            client_pool=pool,
+            client_pool=live_pool,
             scheduler_manager=scheduler,
             live_runtime_pause_gate=live_runtime_pause_gate,
         )
@@ -430,9 +440,10 @@ async def _initialize_startup_telegram_pool(
         t1 = time.monotonic()
 
     if runtime_mode == "worker" and container.auth.is_configured:
+        pool = cast(ClientPool, container.pool)
         telegram_pool_degraded = False
         try:
-            await asyncio.wait_for(container.pool.initialize(), timeout=_POOL_INIT_TIMEOUT)
+            await asyncio.wait_for(pool.initialize(), timeout=_POOL_INIT_TIMEOUT)
         except asyncio.TimeoutError:
             logger.warning(
                 "startup: telegram pool timed out after %ds — continuing without full init",
@@ -448,7 +459,7 @@ async def _initialize_startup_telegram_pool(
                 exc.status,
                 exc.action,
             )
-        connected_count = _connected_pool_count(container.pool)
+        connected_count = _connected_pool_count(pool)
         if connected_count == 0:
             telegram_pool_degraded = True
             logger.warning(
@@ -459,12 +470,12 @@ async def _initialize_startup_telegram_pool(
                 _schedule_telegram_pool_retry(container)
         # Warm entity cache + preferred_phone map for all accounts in background.
         # Store the task so the collector can wait on it during a race condition.
-        if not telegram_pool_degraded and hasattr(container.pool, "warm_all_dialogs"):
+        if not telegram_pool_degraded and hasattr(pool, "warm_all_dialogs"):
             _warm_task = asyncio.create_task(
-                container.pool.warm_all_dialogs(), name="warm_all_dialogs_startup"
+                pool.warm_all_dialogs(), name="warm_all_dialogs_startup"
             )
             _warm_task.add_done_callback(_log_task_exception)
-            container.pool._warming_task = _warm_task
+            pool._warming_task = _warm_task
     logger.info("startup: telegram pool done (%.1fs)", time.monotonic() - t_start)
     if _is_dev:
         logger.info("startup/start: telegram_pool %.2fs", time.monotonic() - t1)
@@ -535,11 +546,12 @@ async def _start_scheduler(
     t_start: float,
 ) -> None:
     if runtime_mode == "worker":
-        await container.scheduler.load_settings()
+        scheduler = cast(SchedulerManager, container.scheduler)
+        await scheduler.load_settings()
         autostart = await container.db.get_setting("scheduler_autostart")
         if autostart == "1":
             logger.info("Auto-starting scheduler (scheduler_autostart=1)")
-            await container.scheduler.start()
+            await scheduler.start()
     logger.info("startup: scheduler done (%.1fs)", time.monotonic() - t_start)
 
 

--- a/src/web/channels/forms.py
+++ b/src/web/channels/forms.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+from typing import cast
+
 from starlette.datastructures import FormData
 
 
 def parse_channel_ids(form: FormData) -> list[str]:
     """Extract the multi-value ``channel_ids`` field from a bulk-add form."""
-    return form.getlist("channel_ids")
+    return cast(list[str], form.getlist("channel_ids"))
 
 
 def parse_tags(raw: object) -> list[str]:

--- a/src/web/container.py
+++ b/src/web/container.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
+from typing import TypeAlias
 
 from fastapi.templating import Jinja2Templates
 
@@ -39,7 +40,12 @@ from src.telegram.client_pool import ClientPool
 from src.telegram.collector import Collector
 from src.telegram.notifier import Notifier
 from src.web.log_handler import LogBuffer
+from src.web.runtime_shims import SnapshotClientPool, SnapshotCollector, SnapshotSchedulerManager
 from src.web.timing import TimingBuffer
+
+WebClientPool: TypeAlias = ClientPool | SnapshotClientPool
+WebCollector: TypeAlias = Collector | SnapshotCollector
+WebScheduler: TypeAlias = SchedulerManager | SnapshotSchedulerManager
 
 
 @dataclass(slots=True)
@@ -58,20 +64,20 @@ class AppContainer:
     scheduler_bundle: SchedulerBundle
     search_query_bundle: SearchQueryBundle
     auth: TelegramAuth
-    pool: ClientPool | object
+    pool: WebClientPool
     notification_target_service: NotificationTargetService
     notifier: Notifier | None
     photo_publish_service: PhotoPublishService
     photo_task_service: PhotoTaskService
     photo_auto_upload_service: PhotoAutoUploadService
-    collector: Collector | object
+    collector: WebCollector
     collection_queue: CollectionQueue | None
     task_enqueuer: TaskEnqueuer | None
     unified_dispatcher: UnifiedDispatcher | None
     telegram_command_dispatcher: TelegramCommandDispatcher | None
     search_engine: SearchEngine
     ai_search: AISearchEngine
-    scheduler: SchedulerManager | object
+    scheduler: WebScheduler
     templates: Jinja2Templates
     log_buffer: LogBuffer | None
     timing_buffer: TimingBuffer | None

--- a/src/web/deps.py
+++ b/src/web/deps.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TypeVar
+from typing import TypeVar, cast
 
 from fastapi import Request
 from fastapi.templating import Jinja2Templates
@@ -22,7 +22,6 @@ from src.database.bundles import (
     SearchBundle,
     SearchQueryBundle,
 )
-from src.scheduler.service import SchedulerManager
 from src.search.ai_search import AISearchEngine
 from src.search.engine import SearchEngine
 from src.services.channel_service import ChannelService
@@ -44,7 +43,7 @@ from src.telegram.auth import TelegramAuth
 from src.telegram.client_pool import ClientPool
 from src.telegram.collector import Collector
 from src.telegram.notifier import Notifier
-from src.web.container import AppContainer
+from src.web.container import AppContainer, WebClientPool, WebCollector, WebScheduler
 from src.web.log_handler import LogBuffer
 from src.web.paths import TEMPLATES_DIR
 from src.web.timing import TimingBuffer
@@ -69,7 +68,7 @@ def _request_cached(request: Request, key: str, factory: Callable[[], T]) -> T:
     if value is _MISSING:
         value = factory()
         setattr(request.state, key, value)
-    return value
+    return cast(T, value)
 
 
 def _require_app_state_attr(request: Request, name: str):
@@ -197,11 +196,11 @@ def get_search_query_bundle(request: Request) -> SearchQueryBundle:
     return get_container(request).search_query_bundle
 
 
-def get_pool(request: Request) -> ClientPool:
+def get_pool(request: Request) -> WebClientPool:
     return get_container(request).pool
 
 
-def get_collector(request: Request) -> Collector:
+def get_collector(request: Request) -> WebCollector:
     return get_container(request).collector
 
 
@@ -222,7 +221,7 @@ def get_task_enqueuer(request: Request) -> TaskEnqueuer | None:
     return get_container(request).task_enqueuer
 
 
-def get_scheduler(request: Request) -> SchedulerManager:
+def get_scheduler(request: Request) -> WebScheduler:
     return get_container(request).scheduler
 
 
@@ -320,7 +319,7 @@ def channel_service(request: Request) -> ChannelService:
     return _request_cached(
         request,
         "_channel_service",
-        lambda: ChannelService(get_db(request), get_pool(request), get_queue(request)),
+        lambda: ChannelService(get_db(request), cast(ClientPool, get_pool(request)), get_queue(request)),
     )
 
 
@@ -330,7 +329,7 @@ def collection_service(request: Request) -> CollectionService:
         "_collection_service",
         lambda: CollectionService(
             get_channel_bundle(request),
-            get_collector(request),
+            cast(Collector, get_collector(request)),
             get_queue(request),
         ),
     )
@@ -389,5 +388,5 @@ def filter_deletion_service(request: Request) -> FilterDeletionService:
     )
 
 
-def scheduler_service(request: Request) -> SchedulerManager:
+def scheduler_service(request: Request) -> WebScheduler:
     return get_scheduler(request)

--- a/src/web/dialogs/handlers.py
+++ b/src/web/dialogs/handlers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import time
+from typing import cast
 
 from fastapi import Request
 
@@ -302,7 +303,7 @@ async def react_message(request: Request) -> CommandRedirect | DialogRedirect:
 async def cancel_queue_command(request: Request, command_id: int) -> DialogRedirect:
     """Cancel a pending Telegram command living in `telegram_commands` (issue #621)."""
     form = await request.form()
-    phone = (form.get("phone") or "") if hasattr(form, "get") else ""
+    phone = cast(str, form.get("phone") or "") if hasattr(form, "get") else ""
     ok = await deps.telegram_command_service(request).cancel(command_id)
     error = None if ok else "command_not_cancellable"
     msg = "command_cancelled" if ok else None
@@ -397,7 +398,7 @@ async def edit_permissions(request: Request) -> CommandRedirect | DialogRedirect
         return DialogRedirect(form.phone, error="no_permission_flags")
     if not form.phone or not form.chat_id or not form.user_id:
         return DialogRedirect(form.phone, error="missing_fields")
-    payload = {"phone": form.phone, "chat_id": form.chat_id, "user_id": form.user_id}
+    payload: dict[str, object] = {"phone": form.phone, "chat_id": form.chat_id, "user_id": form.user_id}
     if form.until_date:
         payload["until_date"] = form.until_date
     if form.send_messages is not None:

--- a/src/web/dialogs/responses.py
+++ b/src/web/dialogs/responses.py
@@ -59,7 +59,7 @@ def dialog_response(request: Request, result: DialogResult):
     if isinstance(result, DialogRedirect):
         return dialogs_redirect(result.phone, msg=result.msg, error=result.error)
     if isinstance(result, CommandRedirect):
-        params = {"command_id": result.command_id}
+        params: dict[str, object | None] = {"command_id": result.command_id}
         if result.phone and "phone=" not in result.target_path:
             params["phone"] = result.phone
         return redirect_see_other(result.target_path, params)

--- a/src/web/embedded_worker.py
+++ b/src/web/embedded_worker.py
@@ -199,7 +199,9 @@ class EmbeddedWorker:
         finally:
             logger.info("[embedded-worker] stopping")
             try:
-                await stop_container(self._container)
+                container = self._container
+                assert container is not None, "Embedded worker container is required during shutdown"
+                await stop_container(container)
             except Exception:
                 logger.exception("[embedded-worker] stop_container raised")
             self._container = None

--- a/src/web/filter/forms.py
+++ b/src/web/filter/forms.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import cast
+
 from starlette.datastructures import FormData
 
 from src.filters.criteria import VALID_FLAGS
@@ -37,7 +39,7 @@ def parse_pks(form: FormData, field: str = "pks") -> list[int]:
     pks: list[int] = []
     for v in form.getlist(field):
         try:
-            pks.append(int(v))
+            pks.append(int(cast(str, v)))
         except (ValueError, TypeError):
             continue
     return pks

--- a/src/web/filter/handlers.py
+++ b/src/web/filter/handlers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from typing import cast
 
 from fastapi import Request
 
@@ -121,7 +122,7 @@ async def hard_delete_all(request: Request) -> FilterRedirect:
     #      comparison rejects. Duplicates are rejected at parse time.
     #      Delete then runs on the unique PK list extracted from the
     #      validated snapshot.
-    confirm = (form.get("confirm") or "").strip()
+    confirm = cast(str, form.get("confirm") or "").strip()
     if confirm != HARD_DELETE_ALL_CONFIRM_PHRASE:
         return manage_redirect(error="hard_delete_confirm_required")
     confirm_pks_raw = form.get("confirm_pks")
@@ -200,7 +201,7 @@ async def apply_filters(request: Request) -> FilterRedirect:
     form = await request.form()
     if form.get("snapshot") != "1":
         return channels_redirect(error="filter_snapshot_required")
-    snapshot_results = parse_snapshot(form.getlist("selected"))
+    snapshot_results = parse_snapshot(cast(list[str], form.getlist("selected")))
     report = FilterReport(
         results=snapshot_results,
         total_channels=len(snapshot_results),

--- a/src/web/photo_loader/forms.py
+++ b/src/web/photo_loader/forms.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from fastapi import UploadFile
 from pydantic import BaseModel, ConfigDict
+from typing_extensions import TypedDict
 
 from src.models import PhotoSendMode
 from src.services.photo_task_service import PhotoTarget
@@ -16,6 +17,14 @@ from src.utils.datetime import parse_required_schedule_datetime
 
 UPLOAD_ROOT = Path("data/photo_uploads")
 FormMapping = Mapping[str, Any]
+
+
+class PhotoAutoUpdateValues(TypedDict, total=False):
+    folder_path: str
+    send_mode: PhotoSendMode
+    caption: str
+    interval_minutes: int
+    is_active: bool
 
 
 class _FrozenForm(BaseModel):
@@ -74,7 +83,7 @@ class PhotoPhoneForm(_FrozenForm):
 
 class PhotoAutoUpdateForm(_FrozenForm):
     phone: str
-    values: dict[str, object]
+    values: PhotoAutoUpdateValues
 
 
 async def persist_uploads(files: list[UploadFile], folder_name: str) -> list[str]:
@@ -112,7 +121,7 @@ def parse_schedule_at(value: str) -> datetime:
 
 
 def parse_auto_update_form(form: FormMapping) -> PhotoAutoUpdateForm:
-    values: dict[str, object] = {}
+    values: PhotoAutoUpdateValues = {}
     if form.get("folder"):
         values["folder_path"] = form["folder"]
     if form.get("mode"):

--- a/src/web/pipelines/handlers.py
+++ b/src/web/pipelines/handlers.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime
+from typing import cast
 
 from fastapi import Request
 
@@ -157,7 +159,7 @@ async def _page_context(request: Request) -> dict:
             logger.warning("pipeline_needs_llm failed for pipeline_id=%s", pipeline.id, exc_info=True)
             needs_llm_map[pipeline.id] = True
     # gather next_run times for pipelines (batch query)
-    next_runs = {}
+    next_runs: dict[int, str | None] = {}
     try:
         scheduler = deps.get_scheduler(request)
         all_jobs = scheduler.get_all_jobs_next_run()
@@ -166,7 +168,7 @@ async def _page_context(request: Request) -> dict:
             if pipeline is None or pipeline.id is None:
                 continue
             job_id = f"pipeline_run_{pipeline.id}"
-            nr = all_jobs.get(job_id)
+            nr = cast(datetime | None, all_jobs.get(job_id))
             next_runs[pipeline.id] = nr.isoformat() if nr else None
     except Exception:
         next_runs = {}
@@ -258,6 +260,7 @@ async def create_wizard_submit(
     if form.run_after:
         _since = _to_since_hours(form.since_value, form.since_unit)
         enqueuer = deps.get_task_enqueuer(request)
+        assert enqueuer is not None, "Task enqueuer is required to enqueue pipeline runs"
         await enqueuer.enqueue_pipeline_run(pipeline_id, since_hours=_since)
         return _pipeline_redirect("pipeline_run_with_since")
     return _pipeline_redirect("pipeline_added")
@@ -399,6 +402,7 @@ async def run_pipeline(request: Request, pipeline_id: int, form: PipelineRunForm
     try:
         since_hours = _to_since_hours(form.since_value, form.since_unit)
         enqueuer = deps.get_task_enqueuer(request)
+        assert enqueuer is not None, "Task enqueuer is required to enqueue pipeline runs"
         await enqueuer.enqueue_pipeline_run(pipeline_id, since_hours=since_hours)
     except Exception:
         logger.warning("Failed to enqueue pipeline run for pipeline_id=%d", pipeline_id, exc_info=True)
@@ -415,6 +419,7 @@ async def dry_run_pipeline(request: Request, pipeline_id: int):
         return _pipeline_redirect("llm_not_configured", error=True)
     try:
         enqueuer = deps.get_task_enqueuer(request)
+        assert enqueuer is not None, "Task enqueuer is required to enqueue pipeline runs"
         await enqueuer.enqueue_pipeline_run(pipeline_id, dry_run=True)
     except Exception:
         logger.warning("Failed to enqueue dry-run for pipeline_id=%d", pipeline_id, exc_info=True)

--- a/src/web/routes/accounts.py
+++ b/src/web/routes/accounts.py
@@ -2,6 +2,7 @@
 
 import logging
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING, cast
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse, RedirectResponse
@@ -12,6 +13,9 @@ from src.database.repositories.accounts import AccountSessionDecryptError
 from src.web import deps
 from src.web.schemas.accounts import AccountInfoResponse, FloodStatusItem
 from src.web.schemas.common import ErrorResponse
+
+if TYPE_CHECKING:
+    from src.telegram.client_pool import ClientPool
 
 logger = logging.getLogger(__name__)
 
@@ -148,7 +152,7 @@ async def account_info(request: Request, account_id: int):
     runtime = AgentRuntimeContext.build(
         db=db,
         config=getattr(request.app.state, "config", None),
-        client_pool=client_pool,
+        client_pool=cast("ClientPool | None", client_pool),
     )
     try:
         live_info = await get_live_account_info_text(runtime, acc.phone)

--- a/src/web/routes/auth.py
+++ b/src/web/routes/auth.py
@@ -52,7 +52,7 @@ async def login_page(request: Request):
     api_configured = _is_api_configured(request)
     step = "phone" if api_configured else "credentials"
     command = await _auth_command(request)
-    context = {"step": step, "error": None, "phone": "", "api_configured": api_configured}
+    context: dict[str, object] = {"step": step, "error": None, "phone": "", "api_configured": api_configured}
     if command is not None and command.command_type.startswith("auth."):
         payload = command.payload or {}
         result = command.result_payload or {}

--- a/src/web/routes/dashboard.py
+++ b/src/web/routes/dashboard.py
@@ -68,13 +68,13 @@ async def fragment_overview(request: Request):
             and a.session_status == AccountSessionStatus.OK
             and a.phone in deps.get_pool(request).clients
         ):
-            until = a.flood_wait_until
-            if until is None:
+            flood_until = a.flood_wait_until
+            if flood_until is None:
                 all_connected_flooded = False
             else:
-                if until.tzinfo is None:
-                    until = until.replace(tzinfo=timezone.utc)
-                if not is_blocking_flood_wait_until(until, now=now):
+                if flood_until.tzinfo is None:
+                    flood_until = flood_until.replace(tzinfo=timezone.utc)
+                if not is_blocking_flood_wait_until(flood_until, now=now):
                     all_connected_flooded = False
     if connected_count == 0:
         all_connected_flooded = False

--- a/src/web/routes/export.py
+++ b/src/web/routes/export.py
@@ -9,6 +9,7 @@ EXPORT task (the worker owns the live Telegram clients needed to fetch media).
 from __future__ import annotations
 
 import logging
+from typing import Literal, cast
 
 from fastapi import APIRouter, Form, Request
 from fastapi.responses import JSONResponse
@@ -32,7 +33,9 @@ async def export_channel(
     date_to: str | None = Form(None),
     limit: int = Form(5000),
 ) -> JSONResponse:
-    fmt = format if format in ("json", "html", "both") else "json"
+    fmt: Literal["json", "html", "both"] = (
+        cast(Literal["json", "html", "both"], format) if format in ("json", "html", "both") else "json"
+    )
     # Cap the inline export so a single web request can't pull a 100k-message
     # channel into the event loop (Claude review on #937).
     limit = max(1, min(limit, 10_000))

--- a/src/web/routes/search_queries.py
+++ b/src/web/routes/search_queries.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 
@@ -48,7 +50,7 @@ async def get_search_query_stats(request: Request, sq_id: int, days: int = 30):
     svc = deps.search_query_service(request)
     if await svc.get(sq_id) is None:
         return JSONResponse({"error": "search_query_not_found"}, status_code=404)
-    stats = await svc.get_daily_stats(sq_id, days=days)
+    stats = cast(list[SearchQueryDailyStat], await svc.get_daily_stats(sq_id, days=days))
     return JSONResponse([s.model_dump(mode="json") for s in stats])
 
 

--- a/src/web/scheduler/context.py
+++ b/src/web/scheduler/context.py
@@ -15,8 +15,9 @@ from datetime import datetime, timezone
 from typing import NamedTuple
 
 from fastapi import Request
+from typing_extensions import TypedDict
 
-from src.models import AccountSessionStatus
+from src.models import AccountSessionStatus, CollectionTask
 from src.services.pipeline_result import result_kind_label
 from src.services.runtime_diagnostics import (
     WORKER_HEARTBEAT_STALE_AFTER_SEC as WORKER_HEARTBEAT_STALE_AFTER_SEC_SVC,
@@ -49,7 +50,7 @@ WORKER_HEARTBEAT_STALE_AFTER_SEC = WORKER_HEARTBEAT_STALE_AFTER_SEC_SVC
 
 
 def _is_running_task_stale(
-    running_task,
+    running_task: CollectionTask | None,
     *,
     idle_timeout_sec: float | None = None,
     now: datetime | None = None,
@@ -213,8 +214,14 @@ def _collector_health_recommendations(
     return recommendations
 
 
-def _dedupe_recent_unavailability_events(recent_tasks) -> list[dict[str, object]]:
-    events: dict[str, dict[str, object]] = {}
+class _RecentUnavailabilityEvent(TypedDict):
+    message: str
+    count: int
+    latest_at: datetime | None
+
+
+def _dedupe_recent_unavailability_events(recent_tasks: list[CollectionTask]) -> list[_RecentUnavailabilityEvent]:
+    events: dict[str, _RecentUnavailabilityEvent] = {}
     for task in recent_tasks:
         message = ""
         if task.note and "Flood Wait" in task.note:
@@ -226,7 +233,7 @@ def _dedupe_recent_unavailability_events(recent_tasks) -> list[dict[str, object]
         if not message:
             continue
         item = events.setdefault(message, {"message": message, "count": 0, "latest_at": None})
-        item["count"] = int(item["count"]) + 1
+        item["count"] = item["count"] + 1
         occurred_at = _as_utc_datetime(task.completed_at or task.started_at or task.created_at)
         if occurred_at is not None:
             latest_at = item["latest_at"]
@@ -291,7 +298,7 @@ class _RecentTasksSummary(NamedTuple):
     """Running/zero-collect figures derived from recent collection-task rows.
     Split out of ``_build_collector_health_context`` (#922)."""
 
-    running_task: object | None
+    running_task: CollectionTask | None
     running_count: int
     recent_zero_collect_count: int
     running_task_stale: bool
@@ -339,7 +346,7 @@ async def _probe_collector_availability(collector) -> _CollectorAvailability:
     return _CollectorAvailability(state, retry_after, next_at, all_flooded_blocking)
 
 
-def _summarize_recent_tasks(recent_tasks: list, idle_timeout_sec) -> _RecentTasksSummary:
+def _summarize_recent_tasks(recent_tasks: list[CollectionTask], idle_timeout_sec: float | None) -> _RecentTasksSummary:
     """Reduce recent collection-task rows to the running/zero-collect figures the
     scheduler page needs. Pure logic split out of
     ``_build_collector_health_context`` (#922)."""

--- a/src/web/scheduler/handlers.py
+++ b/src/web/scheduler/handlers.py
@@ -349,16 +349,18 @@ async def dry_run_notifications(request: Request) -> SchedulerTemplate:
         preview_messages = []
     channels = await db.get_channels() if preview_messages else []
 
-    results = []
+    results: list[dict[str, object]] = []
+    total_matches = 0
     for sq in queries:
         matched, _ = dry_run_matches(preview_messages, sq, channels)
+        count = counts.get(sq.id, 0)
+        total_matches += count
         results.append({
             "query": sq.name or sq.query,
-            "count": counts.get(sq.id, 0),
+            "count": count,
             "previews": [(m.text or "")[:150] for m in matched[:2]],
         })
 
-    total_matches = sum(r["count"] for r in results)
     logger.info("Dry-run notifications: %d queries, %d matches, since=%s", len(queries), total_matches, since)
 
     return SchedulerTemplate(

--- a/src/web/search/handlers.py
+++ b/src/web/search/handlers.py
@@ -11,7 +11,9 @@ from dataclasses import dataclass, field
 from fastapi import Request
 from pydantic import ValidationError
 
-from src.models import SearchResult, TelegramCommandStatus
+from src.database import Database
+from src.models import Channel, SearchResult, TelegramCommandStatus
+from src.services.search_service import SearchService
 from src.utils.safe_logging import elapsed_ms, query_log_fields
 from src.web import deps
 from src.web.search.forms import extract_length, parse_channel_id
@@ -200,16 +202,16 @@ class _SearchContext:
     skeleton (#946 lazyload) and the results fragment."""
 
     redirect: SearchRedirect | None = None
-    db: object = None
-    service: object = None
-    channels: list = field(default_factory=list)
+    db: Database | None = None
+    service: SearchService | None = None
+    channels: list[Channel] = field(default_factory=list)
     channel_id_int: int | None = None
     channel_id_error: str | None = None
     mode: str = "local"
     fts_query: str = ""
     min_length: int | None = None
     max_length: int | None = None
-    available_modes: set = field(default_factory=set)
+    available_modes: set[str] = field(default_factory=set)
     runtime_mode: str = "web"
     limit: int = 50
     offset: int = 0
@@ -299,6 +301,7 @@ async def render_search_page(
     ctx = await _build_search_context(request, q=q, channel_id=channel_id, mode=mode, page=page)
     if ctx.redirect is not None:
         return ctx.redirect
+    assert ctx.service is not None, "Search service is required after search context setup"
 
     try:
         search_quota = await ctx.service.check_quota()
@@ -346,6 +349,7 @@ async def render_search_results(
         return SearchTemplate("search_results.html", {"result": None})
 
     service = ctx.service
+    assert service is not None, "Search service is required after search context setup"
     channel_id_int = ctx.channel_id_int
     mode = ctx.mode
     limit, offset = ctx.limit, ctx.offset

--- a/src/web/settings/forms.py
+++ b/src/web/settings/forms.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeAlias, TypeVar
 
 from fastapi import Request
 from pydantic import BaseModel, ConfigDict, ValidationError
@@ -24,7 +24,7 @@ class SettingsFormError(ValueError):
 
 FormMapping = Mapping[str, Any]
 TForm = TypeVar("TForm", bound=BaseModel)
-SettingsFormResult = TForm | SettingsFormError
+SettingsFormResult: TypeAlias = TForm | SettingsFormError
 
 
 class _FrozenForm(BaseModel):


### PR DESCRIPTION
Part of #1133

## Summary
- Type the web runtime container as explicit live/snapshot unions for `pool`, `collector`, and `scheduler` instead of `object`.
- Narrow the remaining `object` sources in web contexts and handlers with concrete local types, TypedDicts, Literals, and assert-based Optional narrowing.
- Keep web-mode snapshot shims intact; casts are limited to existing service boundaries whose annotations are narrower than the runtime web wiring.

## Validation
- `python -m mypy src/` -> `125` total baseline to `76` remaining non-web errors; `src/web/` `49 -> 0`.
- `ruff check src/ tests/` -> pass.
- `python -c "import src.web.bootstrap"` -> pass.
- `git diff --check` -> pass.
- `pytest tests/ -k "web or route or handler or bootstrap"` -> `2104 passed, 8111 deselected`.
- `pytest tests/ -k web` -> `602 passed, 9613 deselected`.

## Notes
- Scope is only `src/web/`; `src/services/` is untouched.
- The web container still uses `SnapshotClientPool`, `SnapshotCollector`, and `SnapshotSchedulerManager` in web mode.