### PR TITLE
Part of #1133

### DIFF
--- a/src/agent/tools/search_queries.py
+++ b/src/agent/tools/search_queries.py
@@ -46,7 +46,7 @@ def register(db, client_pool, embedding_service, **kwargs):
 
             svc = SearchQueryService(db)
             active_only = arg_bool(args, "active_only", False)
-            queries = await svc.list(active_only=active_only)
+            queries = await svc.list_queries(active_only=active_only)
             if not queries:
                 return _text_response("Поисковые запросы не найдены.")
             lines = [f"Поисковые запросы ({len(queries)}):"]

--- a/src/services/content_calendar_service.py
+++ b/src/services/content_calendar_service.py
@@ -75,6 +75,7 @@ class ContentCalendarService:
             for run in runs:
                 if run.pipeline_id is None:
                     continue
+                assert run.id is not None
 
                 pipeline = pipelines_by_id.get(run.pipeline_id)
                 if pipeline is None:
@@ -119,6 +120,7 @@ class ContentCalendarService:
         for run in runs:
             if run.pipeline_id is None:
                 continue
+            assert run.id is not None
 
             pipeline = pipelines_by_id.get(run.pipeline_id)
             if pipeline is None:

--- a/src/services/content_generation_service.py
+++ b/src/services/content_generation_service.py
@@ -511,7 +511,9 @@ class ContentGenerationService:
             logger.debug("agent_tools unavailable for pipeline execution", exc_info=True)
 
         executor = PipelineExecutor()
-        result = await executor.execute(pipeline, pipeline.pipeline_json, services)
+        graph = pipeline.pipeline_json
+        assert graph is not None
+        result = await executor.execute(pipeline, graph, services)
 
         return {
             "generated_text": result.get("generated_text", ""),

--- a/src/services/dispatcher/accounts_mixin.py
+++ b/src/services/dispatcher/accounts_mixin.py
@@ -10,7 +10,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from src.database.live_accounts import load_live_usable_accounts
-from src.models import Account
+from src.models import Account, AccountSummary
 
 if TYPE_CHECKING:
     from src.services.dispatcher._base import _DispatcherProtocol
@@ -52,7 +52,7 @@ class AccountsCommandsMixin(_Base):
     async def _handle_accounts_toggle(self, payload: dict[str, Any]) -> dict[str, Any]:
         account_id = int(payload["account_id"])
         summaries = await self._db.get_account_summaries(active_only=False)
-        account_summary = next((a for a in summaries if a.id == account_id), None)
+        account_summary: AccountSummary | Account | None = next((a for a in summaries if a.id == account_id), None)
         live_account: Account | None = None
         if account_summary is None:
             accounts = await load_live_usable_accounts(self._db, active_only=False)

--- a/src/services/dispatcher/channels_mixin.py
+++ b/src/services/dispatcher/channels_mixin.py
@@ -71,6 +71,8 @@ class ChannelsCommandsMixin(_Base):
         deactivated = 0
         quarantined = 0
         for ch in channels:
+            channel_pk = ch.id
+            assert channel_pk is not None
             identifier = ch.username or str(ch.channel_id)
             try:
                 # numeric_fallback so a stale @username doesn't deactivate a live
@@ -84,13 +86,13 @@ class ChannelsCommandsMixin(_Base):
             # for human review. This runs in the background worker with no interactive
             # user, so flagging for review is the only safe move (#875 redesign).
             if info and info.get("review"):
-                await self._db.repos.channels.set_channel_review(ch.id, info.get("reason", "uncertain"))
+                await self._db.repos.channels.set_channel_review(channel_pk, info.get("reason", "uncertain"))
                 quarantined += 1
                 continue
             # Definitive not-found → deactivate; transient None → skip and leave
             # active (audit #835/8; old `if info is False` was unreachable).
             if info and info.get("gone"):
-                await self._db.set_channel_active(ch.id, False)
+                await self._db.set_channel_active(channel_pk, False)
                 await self._db.set_channel_type(ch.channel_id, "unavailable")
                 deactivated += 1
                 continue
@@ -99,7 +101,7 @@ class ChannelsCommandsMixin(_Base):
                 continue
             # Resolved live: clear any stale quarantine flag (channel recovered).
             if getattr(ch, "needs_review", False):
-                await self._db.repos.channels.clear_channel_review(ch.id)
+                await self._db.repos.channels.clear_channel_review(channel_pk)
             await self._db.set_channel_type(ch.channel_id, info["channel_type"])
             updated += 1
         return {

--- a/src/services/error_recovery_service.py
+++ b/src/services/error_recovery_service.py
@@ -8,7 +8,7 @@ import weakref
 from collections import Counter
 from dataclasses import dataclass
 from enum import Enum
-from typing import Awaitable, Callable, TypeVar
+from typing import Awaitable, Callable, TypeVar, cast
 
 from tenacity import AsyncRetrying, RetryCallState, retry_if_exception, stop_after_attempt
 from tenacity.wait import wait_exponential, wait_exponential_jitter
@@ -242,7 +242,7 @@ class ErrorRecoveryService:
         error = retry_state.outcome.exception()
         if error is None:
             return
-        category = ErrorClassifier.classify(error)
+        category = ErrorClassifier.classify(cast(Exception, error))
         delay = retry_state.next_action.sleep if retry_state.next_action else 0.0
         logger.warning(
             "Attempt %d/%d failed (%s): %s. Retrying in %.1fs",

--- a/src/services/image_generation_service.py
+++ b/src/services/image_generation_service.py
@@ -194,9 +194,11 @@ class ImageGenerationService:
 
         for name in IMAGE_PROVIDER_ORDER:
             spec = IMAGE_PROVIDER_SPECS[name]
-            if spec.keyless:
-                if spec.detect() and spec.keyless_factory is not None:
-                    self._adapters[name] = spec.keyless_factory()
+            detect = spec.detect
+            keyless_factory = spec.keyless_factory
+            if detect is not None:
+                if detect() and keyless_factory is not None:
+                    self._adapters[name] = keyless_factory()
             else:
                 key = _env_key(spec.env_vars)
                 if key and spec.keyed_factory is not None:

--- a/src/services/image_provider_service.py
+++ b/src/services/image_provider_service.py
@@ -345,9 +345,11 @@ class ImageProviderService:
             cfg = cfg_by_provider.get(name)
             if cfg is not None and not cfg.enabled:
                 continue
-            if spec.keyless:
-                if spec.detect() and spec.keyless_factory is not None:
-                    adapters[name] = spec.keyless_factory()
+            detect = spec.detect
+            keyless_factory = spec.keyless_factory
+            if detect is not None:
+                if detect() and keyless_factory is not None:
+                    adapters[name] = keyless_factory()
                 elif cfg is not None and cfg.enabled:
                     # Enabled in the UI but detection failed (SDK missing or not
                     # authenticated). detect() results are cached for the process

--- a/src/services/provider_service.py
+++ b/src/services/provider_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Awaitable, Callable, Dict, Mapping, Optional
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, Mapping, Optional, cast
 
 from src.agent.provider_registry import (
     ProviderRuntimeConfig,
@@ -15,9 +15,14 @@ from src.agent.provider_registry import (
 
 logger = logging.getLogger(__name__)
 
+if TYPE_CHECKING:
+    from src.config import AppConfig
+    from src.database import Database
+
+
 async def build_provider_service(
-    db: object | None = None,
-    config: object | None = None,
+    db: Database | None = None,
+    config: AppConfig | None = None,
     env: Mapping[str, str] | None = None,
 ) -> "RuntimeProviderRegistry":
     """Create RuntimeProviderRegistry and eagerly load DB-backed providers when possible.
@@ -60,13 +65,13 @@ class RuntimeProviderRegistry:
 
     def __init__(
         self,
-        db: Optional[object] = None,
-        config: Optional[object] = None,
+        db: Optional[Database] = None,
+        config: Optional[AppConfig] = None,
         *,
         env: Mapping[str, str] | None = None,
     ) -> None:
-        self.db = db
-        self._config = config
+        self.db: Database | None = db
+        self._config: AppConfig | None = config
         # Env is injected explicitly. The registry NEVER reads the process
         # environment: doing so coupled provider registration to shared process
         # state, which under ``pytest -n auto`` let a neighbouring xdist worker's
@@ -384,10 +389,11 @@ class RuntimeProviderRegistry:
                 extra["max_tokens"] = int(max_tokens)
             if temperature is not None:
                 extra["temperature"] = float(temperature)
+            chat_kwargs = cast(dict[str, Any], extra)
             chat_model = init_chat_model(
                 model=resolved_model,
                 model_provider=model_provider,
-                **extra,
+                **chat_kwargs,
             )
             response = await chat_model.ainvoke(prompt)
             return self._response_text(response)

--- a/src/services/publish_service.py
+++ b/src/services/publish_service.py
@@ -3,12 +3,32 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass
+from typing import Any, Protocol
 
 from src.database import Database
 from src.models import ContentPipeline, GenerationRun, PipelinePublishMode, PipelineTarget
 from src.telegram.backends import adapt_transport_session
 
 logger = logging.getLogger(__name__)
+
+
+class _PublishClientPool(Protocol):
+    async def get_client_by_phone(
+        self,
+        phone: str,
+        *,
+        wait_for_flood: bool = False,
+    ) -> tuple[Any, str] | None: ...
+
+    async def release_client(self, phone: str) -> None: ...
+
+    async def resolve_dialog_entity(
+        self,
+        session: Any,
+        phone: str,
+        dialog_id: int,
+        target_type: str | None = None,
+    ) -> Any: ...
 
 
 @dataclass
@@ -34,7 +54,7 @@ class PublishService:
     - Updating generation_runs.published_at on success
     """
 
-    def __init__(self, db: Database, client_pool: object) -> None:
+    def __init__(self, db: Database, client_pool: _PublishClientPool | None) -> None:
         self._db = db
         self._client_pool = client_pool
 

--- a/src/services/search_query_service.py
+++ b/src/services/search_query_service.py
@@ -48,7 +48,7 @@ class SearchQueryService:
         )
         return await self._bundle.add(sq)
 
-    async def list(self, active_only: bool = False) -> list[SearchQuery]:
+    async def list_queries(self, active_only: bool = False) -> list[SearchQuery]:
         return await self._bundle.get_all(active_only)
 
     async def get(self, sq_id: int) -> SearchQuery | None:
@@ -122,12 +122,13 @@ class SearchQueryService:
         channels = await self._get_channels()
         # Regex queries can't be counted via FTS5; exclude them from FTS stats batch
         tracked = [sq for sq in queries if sq.track_stats and not sq.is_regex]
-        tracked_ids = {sq.id for sq in tracked}
+        tracked_ids = {sq.id for sq in tracked if sq.id is not None}
         # Only tracked non-regex queries have stats; others get empty daily_stats/total_30d=0
         stats_map = await self._bundle.get_fts_daily_stats_batch(tracked, days)
         result = []
         for sq in queries:
-            raw = stats_map.get(sq.id, []) if sq.id in tracked_ids else None
+            sq_id = sq.id
+            raw = stats_map.get(sq_id, []) if sq_id is not None and sq_id in tracked_ids else None
             daily = self._fill_missing_days(raw, days)
             total = sum(s.count for s in daily)
             chat_validation = validate_chat_filter(sq.chat_filter, channels)
@@ -135,7 +136,7 @@ class SearchQueryService:
                 {
                     "query": sq,
                     "total_30d": total,
-                    "last_run": last_runs.get(sq.id),
+                    "last_run": last_runs.get(sq_id) if sq_id is not None else None,
                     "daily_stats": daily,
                     "chat_filter_warnings": chat_validation.warning_text(),
                     "chat_filter_channel_id": single_resolved_channel_id(sq.chat_filter, channels),

--- a/src/services/task_handlers/base.py
+++ b/src/services/task_handlers/base.py
@@ -11,12 +11,14 @@ from src.models import CollectionTask, CollectionTaskType
 from src.telegram.collector import Collector
 
 if TYPE_CHECKING:
+    from src.config import AppConfig
     from src.database import Database
     from src.search.engine import SearchEngine
     from src.services.content_generation_service import ContentGenerationService
     from src.services.image_generation_service import ImageGenerationService
     from src.services.photo_auto_upload_service import PhotoAutoUploadService
     from src.services.photo_task_service import PhotoTaskService
+    from src.telegram.client_pool import ClientPool
     from src.telegram.notifier import Notifier
 
 logger = logging.getLogger(__name__)
@@ -42,9 +44,9 @@ class TaskHandlerContext:
     search_engine: "SearchEngine | None" = None
     pipeline_bundle: PipelineBundle | None = None
     db: "Database | None" = None
-    client_pool: object | None = None
+    client_pool: "ClientPool | None" = None
     notifier: "Notifier | None" = None
-    config: object | None = None
+    config: "AppConfig | None" = None
     llm_provider_service: object | None = None
 
 
@@ -52,11 +54,13 @@ async def build_image_service(context: TaskHandlerContext) -> "ImageGenerationSe
     from src.services.image_generation_service import ImageGenerationService
 
     adapters = None
-    if context.db and context.config:
+    db = context.db
+    config = context.config
+    if db is not None and config is not None:
         try:
             from src.services.image_provider_service import ImageProviderService
 
-            svc = ImageProviderService(context.db, context.config)
+            svc = ImageProviderService(db, config)
             configs = await svc.load_provider_configs()
             built = svc.build_adapters(configs)
             if configs:
@@ -69,10 +73,10 @@ async def build_image_service(context: TaskHandlerContext) -> "ImageGenerationSe
     # Opt-in production rate-limit / daily cost cap (#814); None unless the
     # operator enabled production_limits, so default behavior is unchanged.
     limits = None
-    if context.db and context.config:
+    if db is not None and config is not None:
         from src.services.production_limits_service import ProductionLimitsService
 
-        limits = ProductionLimitsService.from_config(context.db, context.config)
+        limits = ProductionLimitsService.from_config(db, config)
     return ImageGenerationService(adapters=adapters, limits=limits)
 
 
@@ -96,13 +100,16 @@ async def build_content_generation_service(context: TaskHandlerContext) -> "Cont
     from src.services.quality_scoring_service import QualityScoringService
 
     db = context.db
+    search_engine = context.search_engine
+    assert db is not None
+    assert search_engine is not None
     notification_service = DraftNotificationService(db, context.notifier)
     image_service = await build_image_service(context)
     provider_service = await resolve_llm_provider_service(context)
     quality_service = QualityScoringService(db, provider_service=provider_service)
     return ContentGenerationService(
         db,
-        context.search_engine,
+        search_engine,
         config=context.config,
         image_service=image_service,
         notification_service=notification_service,

--- a/src/services/task_handlers/filter_analyze.py
+++ b/src/services/task_handlers/filter_analyze.py
@@ -43,18 +43,19 @@ class FilterAnalyzeTaskHandler:
 
     async def handle(self, task: CollectionTask) -> None:
         ctx = self._context
-        if task.id is None:
+        task_id = task.id
+        if task_id is None:
             return
 
         if not isinstance(task.payload, FilterAnalyzeTaskPayload):
             await ctx.tasks.update_collection_task(
-                task.id, CollectionTaskStatus.FAILED, error="Unsupported filter-analyze payload"
+                task_id, CollectionTaskStatus.FAILED, error="Unsupported filter-analyze payload"
             )
             return
 
         if ctx.db is None:
             await ctx.tasks.update_collection_task(
-                task.id, CollectionTaskStatus.FAILED, error="Database is not available"
+                task_id, CollectionTaskStatus.FAILED, error="Database is not available"
             )
             return
 
@@ -65,7 +66,7 @@ class FilterAnalyzeTaskHandler:
             # apply_filters writes under the same DB contention that can stall
             # analyze_all, so the timeout must cover both (review on #823).
             report = await analyzer.analyze_all()
-            if await self._is_cancelled(task.id):
+            if await self._is_cancelled(task_id):
                 return report
             await analyzer.apply_filters(report)
             return report
@@ -77,22 +78,22 @@ class FilterAnalyzeTaskHandler:
                 report = await _analyze()
         except asyncio.TimeoutError:
             await ctx.tasks.update_collection_task(
-                task.id,
+                task_id,
                 CollectionTaskStatus.FAILED,
                 error=f"Analysis timed out after {timeout:.0f}s",
             )
             return
         except Exception as exc:
-            logger.exception("filter/analyze task %s failed", task.id)
+            logger.exception("filter/analyze task %s failed", task_id)
             await ctx.tasks.update_collection_task(
-                task.id, CollectionTaskStatus.FAILED, error=str(exc)[:500]
+                task_id, CollectionTaskStatus.FAILED, error=str(exc)[:500]
             )
             return
 
         # An admin can cancel the task from the scheduler page mid-analysis;
         # honour that before any side effects (Codex review on #823).
-        if await self._is_cancelled(task.id):
-            logger.info("filter/analyze task %s cancelled, skipping apply/purge", task.id)
+        if await self._is_cancelled(task_id):
+            logger.info("filter/analyze task %s cancelled, skipping apply/purge", task_id)
             return
 
         purge_note = ""
@@ -104,11 +105,11 @@ class FilterAnalyzeTaskHandler:
             # completes; the purge failure stays visible in the note and the
             # log instead of raising a false "analysis failed" alarm (#676,
             # review on #823).
-            logger.exception("filter/analyze task %s: auto-purge failed", task.id)
+            logger.exception("filter/analyze task %s: auto-purge failed", task_id)
             purge_note = f" auto_purge_failed={str(exc)[:200]}"
 
         await ctx.tasks.update_collection_task(
-            task.id,
+            task_id,
             CollectionTaskStatus.COMPLETED,
             messages_collected=report.filtered_count,
             note=(

--- a/src/services/task_handlers/photo.py
+++ b/src/services/task_handlers/photo.py
@@ -59,6 +59,7 @@ class PhotoTaskHandler:
             return
         try:
             jobs = await ctx.photo_auto_upload_service.run_due()
+            assert isinstance(jobs, int)
             await ctx.tasks.update_collection_task(
                 task.id,
                 CollectionTaskStatus.COMPLETED,

--- a/src/services/task_handlers/stats.py
+++ b/src/services/task_handlers/stats.py
@@ -36,13 +36,14 @@ class StatsTaskHandler:
 
     async def handle_stats_all(self, task: CollectionTask) -> None:
         ctx = self._context
-        if task.id is None:
+        task_id = task.id
+        if task_id is None:
             return
 
         payload = task.payload
         if not isinstance(payload, StatsAllTaskPayload):
             await ctx.tasks.update_collection_task(
-                task.id, CollectionTaskStatus.FAILED, error="Unsupported stats task payload"
+                task_id, CollectionTaskStatus.FAILED, error="Unsupported stats task payload"
             )
             return
 
@@ -65,7 +66,7 @@ class StatsTaskHandler:
 
         if not remaining_ids:
             await ctx.tasks.update_collection_task(
-                task.id,
+                task_id,
                 CollectionTaskStatus.COMPLETED,
                 messages_collected=len(channel_ids),
             )
@@ -78,7 +79,7 @@ class StatsTaskHandler:
                 collector_wait_sec += ctx.poll_interval_sec
                 if collector_wait_sec >= ctx.channel_timeout_sec:
                     await ctx.tasks.update_collection_task(
-                        task.id,
+                        task_id,
                         CollectionTaskStatus.FAILED,
                         messages_collected=channels_ok + channels_err,
                         error="Timed out waiting for collector to finish",
@@ -96,7 +97,7 @@ class StatsTaskHandler:
                 remaining_channel_ids=list(remaining_ids),
             )
             await ctx.tasks.reschedule_stats_task(
-                task.id,
+                task_id,
                 payload=reschedule_payload,
                 run_after=datetime.now(timezone.utc),
                 messages_collected=channels_ok + channels_err,
@@ -140,7 +141,7 @@ class StatsTaskHandler:
         async def _persist_progress() -> None:
             progress_payload = await _snapshot_payload()
             await ctx.tasks.persist_stats_progress(
-                task.id,
+                task_id,
                 payload=progress_payload,
                 messages_collected=progress_payload.channels_ok + progress_payload.channels_err,
             )
@@ -171,7 +172,7 @@ class StatsTaskHandler:
         async def _worker() -> None:
             nonlocal cancelled, stop_workers
             while not ctx.stop_event.is_set():
-                fresh = await ctx.tasks.get_collection_task(task.id)
+                fresh = await ctx.tasks.get_collection_task(task_id)
                 if fresh and fresh.status == CollectionTaskStatus.CANCELLED:
                     async with state_lock:
                         cancelled = True
@@ -210,7 +211,7 @@ class StatsTaskHandler:
                     logger.error("Stats error for channel %s: %s", channel.channel_id, exc)
                     await _record_processed(channel_id, ok=False)
                 else:
-                    fresh = await ctx.tasks.get_collection_task(task.id)
+                    fresh = await ctx.tasks.get_collection_task(task_id)
                     if fresh and fresh.status == CollectionTaskStatus.CANCELLED:
                         async with state_lock:
                             cancelled = True
@@ -267,7 +268,7 @@ class StatsTaskHandler:
         if fail_error is not None:
             progress_payload = await _snapshot_payload()
             await ctx.tasks.update_collection_task(
-                task.id,
+                task_id,
                 CollectionTaskStatus.FAILED,
                 messages_collected=progress_payload.channels_ok + progress_payload.channels_err,
                 error=fail_error,
@@ -278,7 +279,7 @@ class StatsTaskHandler:
         if reschedule_at is not None or progress_payload.remaining_channel_ids:
             cooldown_at = datetime.now(timezone.utc) + timedelta(seconds=self._stats_cooldown_sec())
             await ctx.tasks.reschedule_stats_task(
-                task.id,
+                task_id,
                 payload=progress_payload,
                 run_after=reschedule_at or cooldown_at,
                 messages_collected=progress_payload.channels_ok + progress_payload.channels_err,
@@ -286,7 +287,7 @@ class StatsTaskHandler:
             return
 
         await ctx.tasks.update_collection_task(
-            task.id,
+            task_id,
             CollectionTaskStatus.COMPLETED,
             messages_collected=channels_ok + channels_err,
         )
@@ -335,12 +336,13 @@ class StatsTaskHandler:
 
     async def handle_sq_stats(self, task: CollectionTask) -> None:
         ctx = self._context
-        if task.id is None:
+        task_id = task.id
+        if task_id is None:
             return
 
         if not ctx.sq_bundle:
             await ctx.tasks.update_collection_task(
-                task.id,
+                task_id,
                 CollectionTaskStatus.COMPLETED,
                 note="No search query bundle configured",
             )
@@ -349,7 +351,7 @@ class StatsTaskHandler:
         payload = task.payload
         if not isinstance(payload, SqStatsTaskPayload):
             await ctx.tasks.update_collection_task(
-                task.id,
+                task_id,
                 CollectionTaskStatus.FAILED,
                 error="Invalid SQ_STATS payload",
             )
@@ -358,7 +360,7 @@ class StatsTaskHandler:
         sq = await ctx.sq_bundle.get_by_id(payload.sq_id)
         if not sq:
             await ctx.tasks.update_collection_task(
-                task.id,
+                task_id,
                 CollectionTaskStatus.COMPLETED,
                 note=f"Search query id={payload.sq_id} not found",
             )
@@ -374,14 +376,14 @@ class StatsTaskHandler:
                     break
             await ctx.sq_bundle.record_stat(payload.sq_id, today_count)
             await ctx.tasks.update_collection_task(
-                task.id,
+                task_id,
                 CollectionTaskStatus.COMPLETED,
                 messages_collected=today_count,
                 note=f"sq={sq.query}",
             )
         except Exception as exc:
             await ctx.tasks.update_collection_task(
-                task.id,
+                task_id,
                 CollectionTaskStatus.FAILED,
                 error=str(exc)[:500],
             )

--- a/src/services/telegram_command_dispatcher.py
+++ b/src/services/telegram_command_dispatcher.py
@@ -339,6 +339,7 @@ class TelegramCommandDispatcher(
         retry_busy: bool = True,
         **kwargs: Any,
     ) -> None:
+        assert command_id is not None
         delay = COMMAND_STATUS_UPDATE_BUSY_RETRY_INITIAL_SEC
         while True:
             try:

--- a/src/services/telegram_export_builder.py
+++ b/src/services/telegram_export_builder.py
@@ -290,7 +290,7 @@ class TelegramExportBuilder:
             rows.append(media_html)
         reactions = parse_reactions_json(message.reactions_json)
         if reactions:
-            rendered = "  ".join(f'{html.escape(r["emoji"])} {r["count"]}' for r in reactions)
+            rendered = "  ".join(f'{html.escape(str(r["emoji"]))} {r["count"]}' for r in reactions)
             rows.append(f'<div class="reactions">{rendered}</div>')
         return f'<div class="message" id="message{message.message_id}">' + "".join(rows) + "</div>"
 

--- a/src/services/unified_dispatcher.py
+++ b/src/services/unified_dispatcher.py
@@ -24,11 +24,13 @@ from src.services.task_handlers.base import build_image_service
 from src.telegram.collector import Collector
 
 if TYPE_CHECKING:
+    from src.config import AppConfig
     from src.database import Database
     from src.search.engine import SearchEngine
     from src.services.image_generation_service import ImageGenerationService
     from src.services.photo_auto_upload_service import PhotoAutoUploadService
     from src.services.photo_task_service import PhotoTaskService
+    from src.telegram.client_pool import ClientPool
     from src.telegram.notifier import Notifier
 
 logger = logging.getLogger(__name__)
@@ -88,9 +90,9 @@ class UnifiedDispatcher:
         search_engine: "SearchEngine" | None = None,
         pipeline_bundle: PipelineBundle | None = None,
         db: "Database" | None = None,
-        client_pool: object | None = None,
+        client_pool: "ClientPool | None" = None,
         notifier: "Notifier | None" = None,
-        config: object | None = None,
+        config: "AppConfig | None" = None,
         llm_provider_service: object | None = None,
         live_runtime_pause_gate: LiveRuntimePauseGate | None = None,
     ):

--- a/tests/test_agent_tools_deepagents_sync.py
+++ b/tests/test_agent_tools_deepagents_sync.py
@@ -700,7 +700,7 @@ class TestDeepagentsSyncListSearchQueries:
         from src.agent.tools.deepagents_sync import build_deepagents_tools
 
         svc_mock = MagicMock()
-        svc_mock.list = AsyncMock(return_value=[])
+        svc_mock.list_queries = AsyncMock(return_value=[])
         with patch("src.services.search_query_service.SearchQueryService", return_value=svc_mock):
             tools = build_deepagents_tools(mock_db)
             tool_map = {t.__name__: t for t in tools}
@@ -712,7 +712,7 @@ class TestDeepagentsSyncListSearchQueries:
 
         q = SimpleNamespace(id=3, query="crypto", is_active=True, interval_minutes=60)
         svc_mock = MagicMock()
-        svc_mock.list = AsyncMock(return_value=[q])
+        svc_mock.list_queries = AsyncMock(return_value=[q])
         with patch("src.services.search_query_service.SearchQueryService", return_value=svc_mock):
             tools = build_deepagents_tools(mock_db)
             tool_map = {t.__name__: t for t in tools}

--- a/tests/test_regression_agent_tools_misc.py
+++ b/tests/test_regression_agent_tools_misc.py
@@ -418,7 +418,7 @@ class TestSearchQueryToolErrors:
         handlers, _ = sq_setup
         sq = SimpleNamespace(id=1, query="test", interval_minutes=60, is_active=True,
                              is_regex=True, is_fts=True, notify_on_collect=True)
-        with patch("src.services.search_query_service.SearchQueryService.list",
+        with patch("src.services.search_query_service.SearchQueryService.list_queries",
                     new_callable=AsyncMock, return_value=[sq]):
             result = await handlers["list_search_queries"]({})
             text = _text(result)
@@ -426,7 +426,7 @@ class TestSearchQueryToolErrors:
 
     async def test_list_search_queries_exception(self, sq_setup):
         handlers, _ = sq_setup
-        with patch("src.services.search_query_service.SearchQueryService.list",
+        with patch("src.services.search_query_service.SearchQueryService.list_queries",
                     new_callable=AsyncMock, side_effect=RuntimeError("fail")):
             result = await handlers["list_search_queries"]({})
             assert "ошибка" in _text(result).lower()
@@ -800,7 +800,7 @@ class TestDeepagentsSyncExceptions:
         tools, _ = sync_tools
         assert "list_search_queries" in tools
         with patch(
-            "src.services.search_query_service.SearchQueryService.list",
+            "src.services.search_query_service.SearchQueryService.list_queries",
             side_effect=RuntimeError("fail"),
         ):
             result = tools["list_search_queries"]()
@@ -1011,4 +1011,3 @@ class TestAgentManagerEdge:
 # ===========================================================================
 # 24. cli/commands/test.py — _run_write_checks (via real in-memory DB)
 # ===========================================================================
-

--- a/tests/test_regression_bool_args_1115.py
+++ b/tests/test_regression_bool_args_1115.py
@@ -291,7 +291,7 @@ async def test_add_search_query_string_false_flags_disabled(db):
 
     from src.services.search_query_service import SearchQueryService
 
-    queries = await SearchQueryService(db).list()
+    queries = await SearchQueryService(db).list_queries()
     assert len(queries) == 1
     sq = queries[0]
     assert sq.is_regex is False

--- a/tests/test_search_queries.py
+++ b/tests/test_search_queries.py
@@ -40,7 +40,7 @@ async def test_add_and_list(svc):
     sq_id = await svc.add("аренда квартир", 30)
     assert sq_id > 0
 
-    items = await svc.list()
+    items = await svc.list_queries()
     assert len(items) == 1
     assert items[0].query == "аренда квартир"
     assert items[0].interval_minutes == 30
@@ -49,11 +49,11 @@ async def test_add_and_list(svc):
 @pytest.mark.anyio
 async def test_toggle(svc):
     sq_id = await svc.add("query", 60)
-    items = await svc.list()
+    items = await svc.list_queries()
     assert items[0].is_active is True
 
     await svc.toggle(sq_id)
-    items = await svc.list()
+    items = await svc.list_queries()
     assert items[0].is_active is False
 
 
@@ -61,7 +61,7 @@ async def test_toggle(svc):
 async def test_delete(svc):
     sq_id = await svc.add("query", 60)
     await svc.delete(sq_id)
-    items = await svc.list()
+    items = await svc.list_queries()
     assert len(items) == 0
 
 

--- a/tests/test_search_query_service.py
+++ b/tests/test_search_query_service.py
@@ -119,7 +119,7 @@ async def test_list_returns_all_queries(service, bundle):
     await service.add("query1")
     await service.add("query2")
 
-    result = await service.list()
+    result = await service.list_queries()
 
     assert len(result) == 2
 
@@ -131,7 +131,7 @@ async def test_list_active_only(service, bundle):
     id2 = await service.add("inactive query")
     await bundle.set_active(id2, False)
 
-    result = await service.list(active_only=True)
+    result = await service.list_queries(active_only=True)
 
     assert len(result) == 1
     assert result[0].id == id1


### PR DESCRIPTION
## Summary

Part of #1133.

- Renamed `SearchQueryService.list()` to `list_queries()` to avoid shadowing the builtin `list` inside service annotations.
- Updated all confirmed `SearchQueryService` callsites, including agent-tool and test callers.
- Cleared the remaining `src/services/` mypy errors with type-only narrowing: local non-None aliases/asserts for nullable ids, concrete `Database`/`AppConfig` provider registry sources, optional callable narrowing for image providers, and narrow protocol/context annotations.

## Mypy proof

- Before: `python -m mypy src/` -> `Found 125 errors in 60 files`
- After: `python -m mypy src/` -> `Found 87 errors in 42 files`
- After services errors: `0` lines matching `^src/services/.* error:`
- Remaining `src/services/` line is only the existing `embedding_service.py` informational `annotation-unchecked` note.

## Validation

- `ruff check src/ tests/` -> passed
- `python -c "import src.services.search_query_service; import src.services.provider_service"` -> passed
- `pytest tests/test_search_query_service.py tests/test_search_queries.py tests/test_regression_bool_args_1115.py::test_add_search_query_string_false_flags_disabled tests/test_provider_service.py tests/test_provider_service_db_load.py tests/test_provider_service_registration.py tests/test_provider_service_env_injection.py` -> `116 passed`
- Hermetic `pytest tests/ -k "search_query or provider"` with provider env vars cleared -> `876 passed, 24 skipped, 9315 deselected`
- `git diff --check` -> passed
- `src/web/` diff guard -> no files
- old `SearchQueryService` `.list(` grep across `src`/`tests` files containing `SearchQueryService` -> no matches

Note: in my local shell, running the broad provider filter without clearing live provider env vars routes the quality-scoring default-provider tests through configured live providers. The hermetic run above clears those provider env vars and is the stable validation surface for this type-only PR.