### PR TITLE
chore(ruff): bind B023 closure captures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,7 +150,7 @@ line-length = 120
 include = ["*.py"]
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "N", "W"]
+select = ["B023", "E", "F", "I", "N", "W"]
 
 [tool.mypy]
 

--- a/src/services/ab_testing_service.py
+++ b/src/services/ab_testing_service.py
@@ -87,7 +87,7 @@ class ABTestingService:
 
                 # Bind the loop-local prompt into the recovered call. A def (not a
                 # lambda with a default arg) keeps mypy's lambda inference happy.
-                async def _call(prompt: str = prompt) -> str:
+                async def _call(prompt: str = prompt, provider_callable=provider_callable) -> str:
                     return await provider_callable(
                         prompt=prompt,
                         max_tokens=1000,

--- a/src/telegram/collector_mixins/collection.py
+++ b/src/telegram/collector_mixins/collection.py
@@ -717,14 +717,18 @@ class CollectionMixin:
             is_first_run = channel.last_collected_id == 0
             should_notify = self._notifier is not None and not is_first_run
 
-            async def _check_collected_notification_queries() -> None:
+            async def _check_collected_notification_queries(
+                channel_username: str | None,
+                *,
+                should_notify: bool = should_notify,
+            ) -> None:
                 nonlocal all_messages
                 # Auto-translate runs regardless of notifications (audit #836/6).
                 await self._maybe_enqueue_auto_translate()
                 if not should_notify or not all_messages:
                     return
                 for message in all_messages:
-                    message.channel_username = channel.username
+                    message.channel_username = channel_username
                 await self._check_notification_queries(all_messages)
                 all_messages = []
 
@@ -740,7 +744,16 @@ class CollectionMixin:
                 mask_phone(phone),
             )
 
-            async def _flush_batch(batch: list[Message]) -> bool:
+            async def _flush_batch(
+                batch: list[Message],
+                *,
+                channel_id: int = channel_id,
+                channel_log_name: str = channel_log_name,
+                should_notify: bool = should_notify,
+                all_messages: list[Message] = all_messages,
+                phone: str = phone,
+                total_collected: int = total_collected,
+            ) -> bool:
                 nonlocal persisted_max_msg_id, collected_count, saw_topic_message
                 if not batch:
                     return True
@@ -874,7 +887,7 @@ class CollectionMixin:
                     channel_id=channel_id,
                     messages_batch=messages_batch,
                     flush_batch=_flush_batch,
-                    get_persisted_max_msg_id=lambda: persisted_max_msg_id,
+                    get_persisted_max_msg_id=lambda: persisted_max_msg_id,  # noqa: B023 - must read post-flush value.
                     min_id=min_id,
                     phone=phone,
                     session=session,
@@ -889,7 +902,7 @@ class CollectionMixin:
             # The closure drains its buffer on success, so this is idempotent
             # and exactly-once across every exit path below: stop/idle return
             # (#1127/#1168), FloodWait rotation/return (#1169), normal completion.
-            await _check_collected_notification_queries()
+            await _check_collected_notification_queries(channel.username)
 
             if stop_due_to_persistence_error or stream_idle_timeout:
                 # Idle timeout and persistence errors both stop this pass;

--- a/src/telegram/collector_mixins/stats.py
+++ b/src/telegram/collector_mixins/stats.py
@@ -238,7 +238,7 @@ class StatsMixin:
                 if channel.username:
                     try:
                         entity = await self._pool.run_live_username_resolve(
-                            lambda: session.resolve_entity(channel.username),
+                            lambda session=session, username=channel.username: session.resolve_entity(username),
                             operation="collect_channel_stats_resolve_username",
                             phone=phone,
                             username=str(channel.username),

--- a/tests/test_database_write_lock.py
+++ b/tests/test_database_write_lock.py
@@ -181,7 +181,7 @@ async def test_delete_channel_serialized_with_pipeline_add(db: Database):
             generation_backend=PipelineGenerationBackend.CHAIN,
         )
 
-        async def do_add():
+        async def do_add(pipeline: ContentPipeline = pipeline, ch_id: int = ch_id):
             try:
                 await db.repos.content_pipelines.add(
                     pipeline,


### PR DESCRIPTION
## Summary
- enable Ruff B023 in the default lint select
- bind the 18 B023 closure captures with default parameters
- keep the mutated persisted_max_msg_id getter dynamic with a targeted noqa

Refs #1227.

## Validation
- ruff check src/ tests/ conftest.py
- ruff check --select B023 src/ tests/ conftest.py
- pytest tests/test_database_write_lock.py -v -n 0
- pytest tests/ -v -m aiosqlite_serial (`943 passed, 9272 deselected`)

## Notes
- Full parallel lane `pytest tests/ -v -m "not aiosqlite_serial" -n auto` was stopped after unrelated default-provider failures in `tests/test_quality_scoring_service.py` (`3 failed, 9115 passed, 143 skipped`).
- Isolated `pytest tests/test_quality_scoring_service.py -v -n 0` reproduced the provider/network-dependent failure outside this diff.