### PR TITLE
chore(ruff): enable DTZ datetime guard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,7 +150,7 @@ line-length = 120
 include = ["*.py"]
 
 [tool.ruff.lint]
-select = ["B023", "E", "F", "I", "N", "W"]
+select = ["B023", "DTZ", "E", "F", "I", "N", "W"]
 
 [tool.mypy]
 

--- a/src/agent/prompt_template.py
+++ b/src/agent/prompt_template.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 from datetime import date as date_cls
+from datetime import datetime, timezone
 from string import Formatter
 
 AGENT_PROMPT_TEMPLATE_SETTING = "agent_prompt_template"
@@ -111,7 +112,7 @@ def build_prompt_template_context(
         else:
             source_messages = context_message
 
-    resolved_today = today or date_cls.today()
+    resolved_today = today or datetime.now(timezone.utc).date()
     return {
         "source_messages": source_messages,
         "channel_title": channel_title,

--- a/src/search/local_search.py
+++ b/src/search/local_search.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from src.database.bundles import SearchBundle
 from src.models import SearchParams, SearchResult
@@ -101,7 +101,7 @@ class LocalSearch:
                 # Normalize date-only strings to be inclusive (match SQL path behavior)
                 effective_to = date_to
                 if len(date_to) == 10:  # "YYYY-MM-DD" without time
-                    next_day = datetime.strptime(date_to, "%Y-%m-%d") + timedelta(days=1)
+                    next_day = datetime.strptime(date_to, "%Y-%m-%d").replace(tzinfo=timezone.utc) + timedelta(days=1)
                     effective_to = next_day.strftime("%Y-%m-%d")
                 if str(msg.date) >= effective_to:
                     continue

--- a/src/services/search_query_service.py
+++ b/src/services/search_query_service.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import date as date_cls
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 
 from src.database import Database
 from src.database.bundles import SearchQueryBundle
@@ -102,7 +101,7 @@ class SearchQueryService:
             logger.info("Search query '%s' (id=%d): regex not counted via FTS", sq.query, sq_id)
             return 0
         daily = await self._bundle.get_fts_daily_stats_for_query(sq, days=1)
-        today = date_cls.today().isoformat()
+        today = datetime.now(timezone.utc).date().isoformat()
         count = next((stat.count for stat in daily if stat.day == today), 0)
         if sq.track_stats:
             await self._bundle.record_stat(sq_id, count)
@@ -150,7 +149,7 @@ class SearchQueryService:
     ) -> list[SearchQueryDailyStat]:
         if stats is None:
             return []
-        today = date_cls.today()
+        today = datetime.now(timezone.utc).date()
         if not stats:
             return [
                 SearchQueryDailyStat(day=(today - timedelta(days=i)).isoformat(), count=0)

--- a/src/services/task_handlers/stats.py
+++ b/src/services/task_handlers/stats.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections import deque
-from datetime import date, datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone
 
 from src.database import DatabaseBusyError
 from src.models import (
@@ -297,7 +297,7 @@ class StatsTaskHandler:
         if callable(setter):
             setter(running)
         elif hasattr(self._context.collector, "_stats_all_running"):
-            setattr(self._context.collector, "_stats_all_running", running)
+            self._context.collector._stats_all_running = running
 
     def _stats_batch_limit(self) -> int:
         config = self._context.config
@@ -367,7 +367,7 @@ class StatsTaskHandler:
             return
 
         try:
-            today = date.today().isoformat()
+            today = datetime.now(timezone.utc).date().isoformat()
             daily = await ctx.sq_bundle.get_fts_daily_stats_for_query(sq, days=1)
             today_count = 0
             for d in daily:

--- a/tests/repositories/test_messages_repository.py
+++ b/tests/repositories/test_messages_repository.py
@@ -69,7 +69,7 @@ async def test_insert_message_with_all_fields(messages_repo):
         text="Full message",
         media_type="photo",
         topic_id=5,
-        date=datetime(2026, 3, 16, 12, 0, 0),
+        date=datetime(2026, 3, 16, 12, 0, 0, tzinfo=timezone.utc),
     )
     result = await messages_repo.insert_message(msg)
     assert result is True
@@ -91,7 +91,7 @@ async def test_insert_message_sender_identity_round_trips(messages_repo):
         sender_last_name="Doe",
         sender_username="@jdoe",
         text="Identity message",
-        date=datetime(2026, 3, 16, 12, 0, 0),
+        date=datetime(2026, 3, 16, 12, 0, 0, tzinfo=timezone.utc),
     )
     assert await messages_repo.insert_message(msg) is True
 
@@ -116,7 +116,7 @@ async def test_insert_message_with_structured_facets(messages_repo):
         service_action_semantic="join",
         service_action_payload_json='{"inviter_id": 42}',
         sender_kind="user",
-        date=datetime(2026, 3, 16, 12, 5, 0),
+        date=datetime(2026, 3, 16, 12, 5, 0, tzinfo=timezone.utc),
     )
     result = await messages_repo.insert_message(msg)
     assert result is True
@@ -370,8 +370,8 @@ async def test_search_messages_by_date_from(messages_repo):
     """Test filtering by date_from."""
     await messages_repo.insert_messages_batch(
         [
-            make_message(1, 100, "Old", date=datetime(2026, 3, 10)),
-            make_message(1, 101, "New", date=datetime(2026, 3, 16)),
+            make_message(1, 100, "Old", date=datetime(2026, 3, 10, tzinfo=timezone.utc)),
+            make_message(1, 101, "New", date=datetime(2026, 3, 16, tzinfo=timezone.utc)),
         ]
     )
 
@@ -384,8 +384,8 @@ async def test_search_messages_by_date_to(messages_repo):
     """Test filtering by date_to (inclusive)."""
     await messages_repo.insert_messages_batch(
         [
-            make_message(1, 100, "Old", date=datetime(2026, 3, 10)),
-            make_message(1, 101, "New", date=datetime(2026, 3, 16)),
+            make_message(1, 100, "Old", date=datetime(2026, 3, 10, tzinfo=timezone.utc)),
+            make_message(1, 101, "New", date=datetime(2026, 3, 16, tzinfo=timezone.utc)),
         ]
     )
 
@@ -399,9 +399,9 @@ async def test_search_messages_by_date_range(messages_repo):
     """Test filtering by date range."""
     await messages_repo.insert_messages_batch(
         [
-            make_message(1, 100, "Before", date=datetime(2026, 3, 5)),
-            make_message(1, 101, "In range", date=datetime(2026, 3, 10)),
-            make_message(1, 102, "After", date=datetime(2026, 3, 20)),
+            make_message(1, 100, "Before", date=datetime(2026, 3, 5, tzinfo=timezone.utc)),
+            make_message(1, 101, "In range", date=datetime(2026, 3, 10, tzinfo=timezone.utc)),
+            make_message(1, 102, "After", date=datetime(2026, 3, 20, tzinfo=timezone.utc)),
         ]
     )
 

--- a/tests/routes/test_dashboard_routes.py
+++ b/tests/routes/test_dashboard_routes.py
@@ -229,7 +229,7 @@ async def test_dashboard_flood_wait_naive_datetime(route_client, base_app):
     """Dashboard handles flood_wait_until with naive datetime (no tzinfo)."""
     app, db, pool = base_app
     # Naive future datetime
-    future_time = datetime.now() + timedelta(hours=1)
+    future_time = (datetime.now(timezone.utc) + timedelta(hours=1)).replace(tzinfo=None)
     accounts = await db.get_accounts(active_only=False)
     for acc in accounts:
         await db.update_account_flood(acc.phone, future_time)

--- a/tests/routes/test_rss_routes.py
+++ b/tests/routes/test_rss_routes.py
@@ -27,7 +27,7 @@ async def test_rfc822_none():
 async def test_rfc822_naive_datetime():
     from src.web.routes.rss import _rfc822
 
-    naive = datetime(2025, 6, 15, 10, 30, 0)
+    naive = datetime(2025, 6, 15, 10, 30, 0, tzinfo=timezone.utc).replace(tzinfo=None)
     result = _rfc822(naive)
     assert "+0000" in result or "GMT" in result or "UTC" in result
 

--- a/tests/routes/test_scheduler_routes.py
+++ b/tests/routes/test_scheduler_routes.py
@@ -397,9 +397,7 @@ async def test_scheduler_has_active_tasks_flag(client):
 async def test_scheduler_last_run_display(client):
     """Test scheduler displays last run time."""
     # Set last_run on scheduler
-    from datetime import datetime
-
-    client._transport.app.state.scheduler._last_run = datetime.now()
+    client._transport.app.state.scheduler._last_run = datetime.now(timezone.utc)
 
     resp = await client.get("/scheduler/")
     assert resp.status_code == 200
@@ -417,9 +415,7 @@ async def test_scheduler_last_stats_display(client):
 @pytest.mark.anyio
 async def test_scheduler_last_search_run_display(client):
     """Test scheduler displays last search run time."""
-    from datetime import datetime
-
-    client._transport.app.state.scheduler._last_search_run = datetime.now()
+    client._transport.app.state.scheduler._last_search_run = datetime.now(timezone.utc)
 
     resp = await client.get("/scheduler/")
     assert resp.status_code == 200

--- a/tests/routes/test_scheduler_routes_edge_cases.py
+++ b/tests/routes/test_scheduler_routes_edge_cases.py
@@ -448,7 +448,7 @@ async def test_scheduler_health_with_naive_flood_wait(client, base_app):
     app, db, _ = base_app
     accounts = await db.get_accounts(active_only=False)
     # Set flood with naive datetime (no timezone)
-    naive_future = datetime.now() + timedelta(hours=1)
+    naive_future = (datetime.now(timezone.utc) + timedelta(hours=1)).replace(tzinfo=None)
     for acc in accounts:
         await db.update_account_flood(acc.phone, naive_future)
 

--- a/tests/routes/test_settings_routes_provider_notifications.py
+++ b/tests/routes/test_settings_routes_provider_notifications.py
@@ -24,7 +24,7 @@ async def db(base_app):
 async def test_settings_page_flood_wait_naive_tz(route_client, db):
     """Test settings page when flood_wait_until has no tzinfo (line 424)."""
     accounts = await db.get_accounts(active_only=False)
-    future_naive = datetime.now() + timedelta(hours=1)  # no tzinfo
+    future_naive = (datetime.now(timezone.utc) + timedelta(hours=1)).replace(tzinfo=None)
     for acc in accounts:
         await db.update_account_flood(acc.phone, future_naive)
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from datetime import date, datetime
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -875,7 +875,7 @@ async def test_chat_stream_renders_saved_prompt_template_variables(db):
     assistant_msg.content = [TextBlock(text="hello")]
     result_msg = MagicMock(spec=ResultMessage)
     expected_system_prompt = (
-        f"Дата: {date.today().isoformat()}\n"
+        f"Дата: {datetime.now(timezone.utc).date().isoformat()}\n"
         "Канал: ForumChan\n"
         "Тема: Вопросы\n"
         'Сообщения:\n{"id": 1, "date": "2024-01-15", "author": "sender name=User", '
@@ -1322,7 +1322,7 @@ async def test_chat_stream_edge_history_mix(db):
 
 # ── format_context tests ─────────────────────────────────────────────────────
 
-_NOW = datetime(2024, 1, 15, 12, 0, 0)
+_NOW = datetime(2024, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
 
 
 def _msg(message_id: int, text: str, topic_id: int | None = None, sender: str = "User") -> Message:

--- a/tests/test_agent_tool_smoke_contract.py
+++ b/tests/test_agent_tool_smoke_contract.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -69,7 +69,7 @@ def _minimal_deepagents_kwargs(tool_name: str) -> dict[str, object]:
 
 
 async def _seed_read_only_contract_data(db) -> None:
-    now = datetime.now()
+    now = datetime.now(timezone.utc)
     await db.add_channel(Channel(channel_id=1001, title="Named Contract", username="named_contract"))
     await db.add_channel(Channel(channel_id=1002, title=None, username=None))
     await db.save_channel_stats(ChannelStats(channel_id=1001, subscriber_count=101, avg_views=12.5))

--- a/tests/test_agent_tools_messaging_errors.py
+++ b/tests/test_agent_tools_messaging_errors.py
@@ -1118,7 +1118,7 @@ class TestReadMessagesTool:
 
     @pytest.mark.anyio
     async def test_with_date_and_sender(self, mock_db, mock_pool):
-        from datetime import datetime
+        from datetime import datetime, timezone
 
         client = _make_client()
         _setup_resolve_entity(mock_pool, client)
@@ -1126,7 +1126,7 @@ class TestReadMessagesTool:
         msg = SimpleNamespace(
             id=5,
             sender_id=42,
-            date=datetime(2025, 6, 15, 12, 30),
+            date=datetime(2025, 6, 15, 12, 30, tzinfo=timezone.utc),
             text="Dated message",
         )
 

--- a/tests/test_ai_search.py
+++ b/tests/test_ai_search.py
@@ -1,6 +1,6 @@
 import sys
 import types
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -83,7 +83,7 @@ async def test_ai_search_run_success(llm_config, mock_search_bundle, fake_deepag
     mock_agent.run.return_value = "AI Summary Result"
 
     mock_search_bundle.search_messages.return_value = MessageSearchPage(
-        messages=[Message(channel_id=1, message_id=1, text="hello", date=datetime.now())],
+        messages=[Message(channel_id=1, message_id=1, text="hello", date=datetime.now(timezone.utc))],
         total=1,
     )
 
@@ -113,7 +113,7 @@ async def test_ai_search_run_error(llm_config, mock_search_bundle, fake_deepagen
 async def test_search_posts_tool_logic(llm_config, mock_search_bundle, fake_deepagents):
     # This tests the tool function defined inside initialize
     mock_search_bundle.search_messages.return_value = MessageSearchPage(
-        messages=[Message(channel_id=1, message_id=1, text="content", date=datetime.now())],
+        messages=[Message(channel_id=1, message_id=1, text="content", date=datetime.now(timezone.utc))],
         total=1,
     )
 

--- a/tests/test_channel_analytics_service.py
+++ b/tests/test_channel_analytics_service.py
@@ -275,7 +275,7 @@ async def test_get_citation_stats(db):
             text=f"msg {i}",
             views=100,
             forwards=i * 10,
-            date=datetime(2025, 1, 15, 12, 0, 0),
+            date=datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc),
         ))
     await _seed_messages_batch(db, 100123, messages)
 
@@ -300,7 +300,7 @@ async def test_get_err(db):
             views=100,
             forwards=5,
             reply_count=2,
-            date=datetime(2025, 1, 15, 12, 0, 0),
+            date=datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc),
         ))
     await _seed_messages_batch(db, 100123, messages)
 
@@ -402,7 +402,7 @@ async def test_get_ranked_channels_by_err(db):
             views=50,
             forwards=1,
             reply_count=0,
-            date=datetime(2025, 1, 15, 12, 0, 0),
+            date=datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc),
         )
         await db.insert_message(msg)
 
@@ -414,7 +414,7 @@ async def test_get_ranked_channels_by_err(db):
             views=500,
             forwards=20,
             reply_count=10,
-            date=datetime(2025, 1, 15, 12, 0, 0),
+            date=datetime(2025, 1, 15, 12, 0, 0, tzinfo=timezone.utc),
         )
         await db.insert_message(msg)
 

--- a/tests/test_cli_export_commands.py
+++ b/tests/test_cli_export_commands.py
@@ -47,7 +47,7 @@ def test_rfc822_with_datetime():
 
 
 def test_rfc822_naive_datetime():
-    dt = datetime(2024, 6, 1, 0, 0, 0)
+    dt = datetime(2024, 6, 1, 0, 0, 0, tzinfo=timezone.utc).replace(tzinfo=None)
     result = _rfc822(dt)
     assert "2024" in result
 

--- a/tests/test_cli_extended.py
+++ b/tests/test_cli_extended.py
@@ -687,9 +687,9 @@ class TestCLITestExtended:
             m.id = 100
             m.text = "test msg"
             m.sender_id = 123
-            from datetime import datetime
+            from datetime import datetime, timezone
 
-            m.date = datetime.now()
+            m.date = datetime.now(timezone.utc)
             m.media = None
             sender_patch = patch(
                 "src.telegram.collector.Collector._get_sender_name",
@@ -799,9 +799,9 @@ class TestCLITestExtended:
             m.id = 100
             m.text = "test msg"
             m.sender_id = 123
-            from datetime import datetime
+            from datetime import datetime, timezone
 
-            m.date = datetime.now()
+            m.date = datetime.now(timezone.utc)
             m.media = None
             sender_patch = patch(
                 "src.telegram.collector.Collector._get_sender_name",
@@ -936,9 +936,9 @@ class TestCLITestExtended:
             m.id = 100
             m.text = "test msg"
             m.sender_id = 123
-            from datetime import datetime
+            from datetime import datetime, timezone
 
-            m.date = datetime.now()
+            m.date = datetime.now(timezone.utc)
             m.media = None
             sender_patch = patch(
                 "src.telegram.collector.Collector._get_sender_name",
@@ -1041,9 +1041,9 @@ class TestCLITestExtended:
             m.id = 100
             m.text = "test msg"
             m.sender_id = 123
-            from datetime import datetime
+            from datetime import datetime, timezone
 
-            m.date = datetime.now()
+            m.date = datetime.now(timezone.utc)
             m.media = None
             sender_patch = patch(
                 "src.telegram.collector.Collector._get_sender_name",
@@ -1162,9 +1162,9 @@ class TestCLITestExtended:
             m.id = 100
             m.text = "test msg"
             m.sender_id = 123
-            from datetime import datetime
+            from datetime import datetime, timezone
 
-            m.date = datetime.now()
+            m.date = datetime.now(timezone.utc)
             m.media = None
             sender_patch = patch(
                 "src.telegram.collector.Collector._get_sender_name",
@@ -1285,9 +1285,9 @@ class TestCLITestExtended:
             m.id = 100
             m.text = "test msg"
             m.sender_id = 123
-            from datetime import datetime
+            from datetime import datetime, timezone
 
-            m.date = datetime.now()
+            m.date = datetime.now(timezone.utc)
             m.media = None
             sender_patch = patch(
                 "src.telegram.collector.Collector._get_sender_name",

--- a/tests/test_collector_extended.py
+++ b/tests/test_collector_extended.py
@@ -152,7 +152,7 @@ async def test_notification_queries_logic(collector, mock_db):
     msgs = [
         Message(
             channel_id=1, message_id=42, text="This is a test message",
-            date=datetime.now(), channel_username="mychan",
+            date=datetime.now(timezone.utc), channel_username="mychan",
         )
     ]
     await collector._check_notification_queries(msgs)
@@ -171,7 +171,7 @@ async def test_notification_queries_private_channel_link(collector, mock_db):
     mock_db.get_notification_queries.return_value = [sq]
 
     msgs = [
-        Message(channel_id=-1001234567890, message_id=99, text="hello world", date=datetime.now())
+        Message(channel_id=-1001234567890, message_id=99, text="hello world", date=datetime.now(timezone.utc))
     ]
     await collector._check_notification_queries(msgs)
     notifier.notify.assert_called_once()
@@ -212,11 +212,19 @@ async def test_empty_ledger_does_not_replay_backlog(collector, mock_db):
     store = _LedgerStore()  # empty ledger -> has_any() is False
     mock_db.repos.notified_messages = store
     # A backlog message that would match if replayed — must NOT be fetched/sent.
-    backlog_msg = Message(channel_id=1, message_id=1, text="old hit", date=datetime.now())
+    backlog_msg = Message(channel_id=1, message_id=1, text="old hit", date=datetime.now(timezone.utc))
     get_recent = AsyncMock(return_value=[backlog_msg])
     mock_db.repos.messages.get_recent_for_channels = get_recent
 
-    fresh = [Message(channel_id=1, message_id=50, text="fresh hit", date=datetime.now(), channel_username="c")]
+    fresh = [
+        Message(
+            channel_id=1,
+            message_id=50,
+            text="fresh hit",
+            date=datetime.now(timezone.utc),
+            channel_username="c",
+        )
+    ]
     await collector._check_notification_queries(fresh)
 
     # Backlog rescan skipped on empty ledger, so get_recent_for_channels was never called...
@@ -236,11 +244,25 @@ async def test_seeded_ledger_replays_backlog_for_retry(collector, mock_db):
 
     store = _LedgerStore(seeded_channels={1})  # ledger already has rows for channel 1
     mock_db.repos.notified_messages = store
-    backlog_msg = Message(channel_id=1, message_id=7, text="retry hit", date=datetime.now(), channel_username="c")
+    backlog_msg = Message(
+        channel_id=1,
+        message_id=7,
+        text="retry hit",
+        date=datetime.now(timezone.utc),
+        channel_username="c",
+    )
     get_recent = AsyncMock(return_value=[backlog_msg])
     mock_db.repos.messages.get_recent_for_channels = get_recent
 
-    fresh = [Message(channel_id=1, message_id=50, text="fresh hit", date=datetime.now(), channel_username="c")]
+    fresh = [
+        Message(
+            channel_id=1,
+            message_id=50,
+            text="fresh hit",
+            date=datetime.now(timezone.utc),
+            channel_username="c",
+        )
+    ]
     await collector._check_notification_queries(fresh)
 
     get_recent.assert_awaited_once()
@@ -269,7 +291,7 @@ async def test_collect_channel_stats_flooded_error(collector, mock_pool):
 
     mock_pool.get_stats_availability = AsyncMock(
         return_value=StatsClientAvailability(
-            state="all_flooded", retry_after_sec=10, next_available_at_utc=datetime.now()
+            state="all_flooded", retry_after_sec=10, next_available_at_utc=datetime.now(timezone.utc)
         )
     )
 

--- a/tests/test_collector_message_parse.py
+++ b/tests/test_collector_message_parse.py
@@ -152,7 +152,7 @@ def test_build_message_maps_core_fields():
 
 
 def test_build_message_naive_date_coerced_to_utc():
-    naive = datetime(2025, 6, 1, 10, 0, 0)
+    naive = datetime(2025, 6, 1, 10, 0, 0, tzinfo=timezone.utc).replace(tzinfo=None)
     message = build_message_from_telethon(_msg(date=naive), channel_id=-100123)
     assert message.date is not None
     assert message.date.tzinfo == timezone.utc

--- a/tests/test_messaging_deepagents_provider_paths.py
+++ b/tests/test_messaging_deepagents_provider_paths.py
@@ -1085,7 +1085,7 @@ class TestProviderConfigService:
         from src.services.agent_provider_service import ProviderModelCompatibilityRecord
 
         svc, _ = self._make_service()
-        naive_dt = datetime.now().isoformat()  # naive, no tz
+        naive_dt = datetime.now(UTC).replace(tzinfo=None).isoformat()
         record = ProviderModelCompatibilityRecord(model="m", status="s", tested_at=naive_dt)
         # Should handle naive datetime without crashing
         result = svc.is_compatibility_record_fresh(record)

--- a/tests/test_regression_infra_coverage.py
+++ b/tests/test_regression_infra_coverage.py
@@ -550,7 +550,7 @@ class TestTelegramUtilsCoverage:
         """Line 11: naive datetime converted to UTC."""
         from src.telegram.utils import normalize_utc
 
-        naive = datetime(2026, 1, 1, 12, 0, 0)
+        naive = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc).replace(tzinfo=None)
         result = normalize_utc(naive)
         assert result.tzinfo == timezone.utc
 

--- a/tests/test_scheduler_ui.py
+++ b/tests/test_scheduler_ui.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -27,7 +27,7 @@ async def test_get_job_next_run_returns_none_when_no_scheduler():
 
 @pytest.mark.anyio
 async def test_get_job_next_run_returns_time_when_job_exists():
-    dt = datetime(2026, 3, 17, 12, 0)
+    dt = datetime(2026, 3, 17, 12, 0, tzinfo=timezone.utc)
     job = FakeJob("pipeline_run_1", next_run_time=dt)
     mgr = SchedulerManager()
     mgr._scheduler = FakeScheduler(job)

--- a/tests/test_search_queries.py
+++ b/tests/test_search_queries.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -22,7 +22,7 @@ def svc(bundle):
 async def _insert_messages(db, texts, channel_id=100, base_date=None, username=None):
     """Helper: add a channel and insert messages with given texts."""
     if base_date is None:
-        base_date = datetime.now()
+        base_date = datetime.now(timezone.utc)
     ch = Channel(channel_id=channel_id, title="test", username=username)
     await db.repos.channels.add_channel(ch)
     for i, text in enumerate(texts):
@@ -118,7 +118,7 @@ async def test_get_last_recorded_at_all(bundle):
 
 @pytest.mark.anyio
 async def test_fts_daily_stats_groups_by_day(bundle, db):
-    now = datetime.now()
+    now = datetime.now(timezone.utc)
     yesterday = now - timedelta(days=1)
     ch = Channel(channel_id=200, title="ch")
     await db.repos.channels.add_channel(ch)
@@ -144,7 +144,7 @@ async def test_fts_daily_stats_groups_by_day(bundle, db):
 
 @pytest.mark.anyio
 async def test_run_once_counts_today_only(svc, db):
-    now = datetime.now()
+    now = datetime.now(timezone.utc)
     old = now - timedelta(days=5)
     await _insert_messages(db, ["target msg"], channel_id=300, base_date=now)
     ch2 = Channel(channel_id=301, title="ch2")

--- a/tests/test_search_query_service.py
+++ b/tests/test_search_query_service.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import date as date_cls
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -238,7 +237,7 @@ async def test_run_once_regex_query_returns_zero(service, bundle):
 async def test_run_once_fts_query_with_stats(service, bundle):
     """FTS query records stats when track_stats=True."""
     sq_id = await service.add("test", is_fts=True, track_stats=True)
-    today = date_cls.today().isoformat()
+    today = datetime.now(timezone.utc).date().isoformat()
     bundle.set_stats(sq_id, [SearchQueryDailyStat(day=today, count=5)])
 
     result = await service.run_once(sq_id)
@@ -261,7 +260,7 @@ def test_fill_missing_days_empty_stats():
 
 def test_fill_missing_days_fills_gaps():
     """Existing days preserved, missing days filled with 0."""
-    today = date_cls.today()
+    today = datetime.now(timezone.utc).date()
     day3 = (today - timedelta(days=3)).isoformat()
     day1 = (today - timedelta(days=1)).isoformat()
 

--- a/tests/test_telegram_command_dispatcher.py
+++ b/tests/test_telegram_command_dispatcher.py
@@ -2119,7 +2119,7 @@ async def test_dialogs_broadcast_stats_str_value():
 
 
 async def test_dialogs_broadcast_stats_with_period():
-    from datetime import datetime
+    from datetime import datetime, timezone
 
     db = _mock_db()
     pool = _mock_pool()
@@ -2131,8 +2131,8 @@ async def test_dialogs_broadcast_stats_with_period():
     stats.reactions_per_post = None
     stats.forwards_per_post = None
     period = MagicMock()
-    period.min_date = datetime(2026, 1, 1)
-    period.max_date = datetime(2026, 12, 31)
+    period.min_date = datetime(2026, 1, 1, tzinfo=timezone.utc).replace(tzinfo=None)
+    period.max_date = datetime(2026, 12, 31, tzinfo=timezone.utc).replace(tzinfo=None)
     stats.period = period
     stats.enabled_notifications = None
     c.get_broadcast_stats = AsyncMock(return_value=stats)

--- a/tests/test_telegram_utils.py
+++ b/tests/test_telegram_utils.py
@@ -18,7 +18,7 @@ async def test_normalize_utc_none_returns_none():
 @pytest.mark.anyio
 async def test_normalize_utc_naive_treated_as_utc():
     """Naive datetime gets UTC tzinfo."""
-    naive = datetime(2024, 3, 15, 10, 30, 45)
+    naive = datetime(2024, 3, 15, 10, 30, 45, tzinfo=timezone.utc).replace(tzinfo=None)
     result = normalize_utc(naive)
 
     assert result is not None
@@ -58,7 +58,7 @@ async def test_normalize_utc_already_utc():
 @pytest.mark.anyio
 async def test_normalize_utc_preserves_values():
     """Time components unchanged after conversion from naive."""
-    naive = datetime(2024, 12, 31, 23, 59, 59, 999999)
+    naive = datetime(2024, 12, 31, 23, 59, 59, 999999, tzinfo=timezone.utc).replace(tzinfo=None)
     result = normalize_utc(naive)
 
     assert result is not None

--- a/tests/test_template_globals.py
+++ b/tests/test_template_globals.py
@@ -23,7 +23,7 @@ def test_whitespace_string_returns_dash():
 
 
 def test_naive_datetime_gets_utc_suffix():
-    dt = datetime(2024, 3, 15, 10, 30, 0)
+    dt = datetime(2024, 3, 15, 10, 30, 0, tzinfo=timezone.utc).replace(tzinfo=None)
     result = str(local_dt_filter(dt))
     assert "data-utc=" in result
     # naive datetime should have +00:00 appended (via replace(tzinfo=utc))

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -97,7 +97,7 @@ def test_convert_telethon_message_basic():
     msg.sender.first_name = "John"
     msg.sender.last_name = "Doe"
     msg.sender.username = "jdoe"
-    msg.date = datetime(2025, 1, 1)
+    msg.date = datetime(2025, 1, 1, tzinfo=timezone.utc).replace(tzinfo=None)
     msg.message = "hello"
     msg.media = None
 

--- a/tests/test_unified_dispatcher.py
+++ b/tests/test_unified_dispatcher.py
@@ -66,9 +66,7 @@ def mock_tasks_repo():
 @pytest.fixture
 def mock_sq_bundle():
     """Mock SearchQueryBundle."""
-    from datetime import date
-
-    today = date.today().isoformat()
+    today = datetime.now(timezone.utc).date().isoformat()
     bundle = MagicMock()
     bundle.get_by_id = AsyncMock(return_value=MagicMock(query="test query"))
     bundle.get_fts_daily_stats_for_query = AsyncMock(

--- a/tests/test_utils_datetime.py
+++ b/tests/test_utils_datetime.py
@@ -32,7 +32,7 @@ def test_parse_required_schedule_datetime_returns_utc():
 
 
 def test_parse_required_schedule_datetime_treats_naive_as_utc():
-    source = datetime(2026, 5, 5, 12, 0)
+    source = datetime(2026, 5, 5, 12, 0, tzinfo=timezone.utc).replace(tzinfo=None)
     assert parse_required_schedule_datetime(source) == source.replace(tzinfo=timezone.utc)
 
 
@@ -48,4 +48,6 @@ def test_normalize_utc_converts_aware_datetime():
 
 def test_utc_isoformat_returns_none_or_utc_string():
     assert utc_isoformat(None) is None
-    assert utc_isoformat(datetime(2026, 5, 5, 12, 0)) == "2026-05-05T12:00:00+00:00"
+    assert utc_isoformat(
+        datetime(2026, 5, 5, 12, 0, tzinfo=timezone.utc).replace(tzinfo=None)
+    ) == "2026-05-05T12:00:00+00:00"

--- a/tests/test_utils_json.py
+++ b/tests/test_utils_json.py
@@ -1,5 +1,5 @@
 """Tests for src/utils/json.py — safe_json_dumps."""
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 
 import pytest
 from pydantic import BaseModel
@@ -18,7 +18,7 @@ def test_plain_types():
 
 
 def test_datetime_serialization():
-    dt = datetime(2026, 4, 19, 12, 30, 45)
+    dt = datetime(2026, 4, 19, 12, 30, 45, tzinfo=timezone.utc).replace(tzinfo=None)
     result = safe_json_dumps({"ts": dt})
     assert '"2026-04-19T12:30:45"' in result
 
@@ -52,7 +52,7 @@ def test_unknown_type_raises_type_error():
 
 def test_mixed_types():
     payload = {
-        "dt": datetime(2026, 1, 1),
+        "dt": datetime(2026, 1, 1, tzinfo=timezone.utc).replace(tzinfo=None),
         "data": b"\xff",
         "model": _SampleModel(name="x", value=1),
         "plain": "text",
@@ -77,7 +77,10 @@ def test_custom_default_does_not_receive_datetime():
             return o.hex()
         raise TypeError("custom default should not be called for datetime")
 
-    out = safe_json_dumps({"ts": datetime(2026, 1, 1)}, default=only_bytes)
+    out = safe_json_dumps(
+        {"ts": datetime(2026, 1, 1, tzinfo=timezone.utc).replace(tzinfo=None)},
+        default=only_bytes,
+    )
     assert "2026-01-01" in out
 
 
@@ -87,7 +90,10 @@ def test_indent_pretty_prints():
 
 
 def test_list_of_datetime():
-    items = [datetime(2026, 1, 1), datetime(2026, 6, 15)]
+    items = [
+        datetime(2026, 1, 1, tzinfo=timezone.utc).replace(tzinfo=None),
+        datetime(2026, 6, 15, tzinfo=timezone.utc).replace(tzinfo=None),
+    ]
     result = safe_json_dumps(items)
     assert "2026-01-01" in result
     assert "2026-06-15" in result

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3626,7 +3626,7 @@ class TestWebAgent:
         thread_id = await db.create_agent_thread("Context")
         await db.add_channel(Channel(channel_id=1, title="Context Channel"))
         await db.insert_message(
-            Message(channel_id=1, message_id=1, text="ctx", date=datetime.now())
+            Message(channel_id=1, message_id=1, text="ctx", date=datetime.now(timezone.utc))
         )
 
         resp = await client.post(f"/agent/threads/{thread_id}/context", json={"channel_id": "1"})

--- a/tests/test_web_scheduler_helpers.py
+++ b/tests/test_web_scheduler_helpers.py
@@ -62,14 +62,14 @@ def test_dedupe_recent_unavailability_events_handles_mixed_timezone_datetimes():
                 error=None,
                 completed_at=None,
                 started_at=None,
-                created_at=datetime(2026, 5, 2, 17, 10, 24),
+                created_at=datetime(2026, 5, 2, 17, 10, 24, tzinfo=timezone.utc).replace(tzinfo=None),
             ),
             SimpleNamespace(
                 note="Отложено: все аккаунты во Flood Wait до 2026-05-02T17:12:00+00:00",
                 error=None,
                 completed_at=datetime(2026, 5, 2, 17, 10, 25, tzinfo=timezone.utc),
                 started_at=None,
-                created_at=datetime(2026, 5, 2, 17, 10, 24),
+                created_at=datetime(2026, 5, 2, 17, 10, 24, tzinfo=timezone.utc).replace(tzinfo=None),
             ),
         ]
     )


### PR DESCRIPTION
Part of #1227

## Summary
- Enable the Ruff `DTZ` rule family so naive datetime usage is guarded in CI.
- Convert the scoped `src` DTZ findings to UTC-aware date/datetime handling.
- Update DTZ-covered tests to use UTC-aware fixtures, while preserving intentional naive-input coverage via explicit `.replace(tzinfo=None)` construction.
- Fix the scoped `B010` in `src/services/task_handlers/stats.py` with direct attribute assignment.

## DTZ011 Decision
- Fixed `DTZ011` in `src` with `datetime.now(timezone.utc).date()` because these values are UTC date labels/stats keys.
- Fixed test `DTZ011` cases the same way where they compare to current-day stats.
- No `per-file-ignores` were added. Tests that intentionally exercise naive datetime behavior now create naive values explicitly from UTC-aware values.

## Validation
- `ruff check src/ tests/ conftest.py --select DTZ` -> 71 -> 0, clean.
- `ruff check src/ tests/ conftest.py` -> clean.
- `python -c "import src.services.search_query_service; import src.search.local_search; import src.agent.prompt_template; import src.services.task_handlers.stats"` -> clean.
- `pytest tests/ -k "search_quer or local_search or prompt or stats or datetime or dispatcher" -q` -> `1028 passed, 9 skipped, 9178 deselected` with no warnings reported.
