### PR TITLE
fix(search): AI search calls .invoke on langgraph agent, not missing .run (#1237)

### DIFF
--- a/src/search/ai_search.py
+++ b/src/search/ai_search.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from typing import Any
 
 from src.config import LLMConfig
 from src.database import Database
@@ -22,7 +23,10 @@ class AISearchEngine:
         if isinstance(search, Database):
             search = SearchBundle.from_database(search)
         self._search = search
-        self._agent = None
+        # deepagents.create_deep_agent returns a langgraph CompiledStateGraph;
+        # kept as Any so the runtime hasattr-guard in _run_agent_sync isn't
+        # second-guessed by the static type.
+        self._agent: Any = None
         self._init_error: str | None = None
 
     @property
@@ -82,6 +86,46 @@ class AISearchEngine:
             logger.error("Failed to initialize AI search: %s", e)
             self._init_error = str(e)
 
+    @staticmethod
+    def _extract_result_text(result: object) -> str:
+        """Extract the final assistant text from a deepagents/langgraph result.
+
+        `create_deep_agent` returns a langgraph ``CompiledStateGraph`` whose
+        ``invoke`` yields ``{"messages": [...]}`` — the last message carries the
+        answer as ``content`` (a plain string or a list of content blocks). This
+        mirrors ``DeepagentsBackend._extract_result_text``.
+        """
+        if isinstance(result, dict):
+            messages = result.get("messages") or []
+            if messages:
+                last_message = messages[-1]
+                content = getattr(last_message, "content", None)
+                if content is None and isinstance(last_message, dict):
+                    content = last_message.get("content")
+                if isinstance(content, str):
+                    return content
+                if isinstance(content, list):
+                    return "\n".join(
+                        block.get("text", "") if isinstance(block, dict) else str(block)
+                        for block in content
+                    ).strip()
+            return str(result)
+        return str(result)
+
+    def _run_agent_sync(self, query: str) -> str:
+        """Invoke the agent and normalize its response to text.
+
+        ``create_deep_agent`` returns a langgraph ``CompiledStateGraph`` that
+        exposes ``.invoke`` (not ``.run``); the hasattr-guard keeps the older
+        ``.run`` shape working for backends/fakes that still provide it.
+        """
+        agent = self._agent
+        if hasattr(agent, "run"):
+            result = agent.run(query)
+        else:
+            result = agent.invoke({"messages": [{"role": "user", "content": query}]})
+        return self._extract_result_text(result)
+
     async def search(self, query: str) -> SearchResult:
         """Run AI-powered search."""
         if not self._agent:
@@ -96,8 +140,7 @@ class AISearchEngine:
             )
 
         try:
-            response = await asyncio.to_thread(self._agent.run, query)
-            summary = str(response)
+            summary = await asyncio.to_thread(self._run_agent_sync, query)
 
             # Also get raw messages for display
             page = await self._search.search_messages(SearchParams(query=query, limit=20))

--- a/tests/test_ai_search.py
+++ b/tests/test_ai_search.py
@@ -11,6 +11,31 @@ from src.models import Message
 from src.search.ai_search import AISearchEngine
 
 
+class _FakeAIMessage:
+    """Minimal stand-in for a langchain AIMessage — only ``.content``."""
+
+    def __init__(self, content):
+        self.content = content
+
+
+class _FakeCompiledStateGraph:
+    """Fake with the real ``create_deep_agent`` return signature.
+
+    ``create_deep_agent`` returns a langgraph ``CompiledStateGraph`` that
+    exposes ``.invoke`` and has **no** ``.run`` method. Using this instead of a
+    bare ``MagicMock`` (which auto-creates ``.run``) means the test regresses if
+    anyone reintroduces the ``.run`` call path from #1237.
+    """
+
+    def __init__(self, content):
+        self._content = content
+        self.invoke_calls: list[dict] = []
+
+    def invoke(self, state):
+        self.invoke_calls.append(state)
+        return {"messages": [{"role": "user", "content": "q"}, _FakeAIMessage(self._content)]}
+
+
 @pytest.fixture
 def llm_config():
     return LLMConfig(enabled=True, api_key="test_key", provider="anthropic", model="claude-3")
@@ -79,33 +104,87 @@ async def test_ai_search_initialization_general_error(llm_config, mock_search_bu
 
 @pytest.mark.anyio
 async def test_ai_search_run_success(llm_config, mock_search_bundle, fake_deepagents):
-    mock_agent = MagicMock()
-    mock_agent.run.return_value = "AI Summary Result"
+    # Real CompiledStateGraph shape: only .invoke, returns {"messages": [...]}.
+    # #1237 regressed here because the code called the non-existent .run.
+    agent = _FakeCompiledStateGraph("AI Summary Result")
 
     mock_search_bundle.search_messages.return_value = MessageSearchPage(
         messages=[Message(channel_id=1, message_id=1, text="hello", date=datetime.now(timezone.utc))],
         total=1,
     )
 
-    fake_deepagents.return_value = mock_agent
+    fake_deepagents.return_value = agent
     engine = AISearchEngine(llm_config, mock_search_bundle)
     engine.initialize()
 
     res = await engine.search("hello")
     assert res.ai_summary == "AI Summary Result"
     assert res.total == 1
+    # The query must actually reach the graph via .invoke({"messages": [...]}).
+    assert agent.invoke_calls == [{"messages": [{"role": "user", "content": "hello"}]}]
 
 
 @pytest.mark.anyio
-async def test_ai_search_run_error(llm_config, mock_search_bundle, fake_deepagents):
-    mock_agent = MagicMock()
-    mock_agent.run.side_effect = Exception("AI Fail")
+async def test_ai_search_invoke_not_run_regression(llm_config, mock_search_bundle, fake_deepagents):
+    """Guard against reintroducing the #1237 ``.run`` call.
 
-    fake_deepagents.return_value = mock_agent
+    A langgraph ``CompiledStateGraph`` has no ``.run`` — accessing it raises
+    ``AttributeError``, which ``search`` swallows into a degraded summary. This
+    fake mirrors that: if the code ever calls ``.run`` again, the summary flips
+    back to the "AI search error" fallback and this assertion fails.
+    """
+    agent = _FakeCompiledStateGraph("Structured answer")
+    assert not hasattr(agent, "run")  # sanity: the fake has no .run, like the real graph
+
+    fake_deepagents.return_value = agent
     engine = AISearchEngine(llm_config, mock_search_bundle)
     engine.initialize()
 
     res = await engine.search("hello")
+    assert res.ai_summary == "Structured answer"
+    assert "AI search error" not in res.ai_summary
+
+
+@pytest.mark.anyio
+async def test_ai_search_run_success_list_content(llm_config, mock_search_bundle, fake_deepagents):
+    # Content blocks (Anthropic-style) must be flattened to text.
+    agent = _FakeCompiledStateGraph([{"type": "text", "text": "Block one"}, {"type": "text", "text": "Block two"}])
+
+    fake_deepagents.return_value = agent
+    engine = AISearchEngine(llm_config, mock_search_bundle)
+    engine.initialize()
+
+    res = await engine.search("hello")
+    assert res.ai_summary == "Block one\nBlock two"
+
+
+@pytest.mark.anyio
+async def test_ai_search_legacy_run_agent_still_supported(llm_config, mock_search_bundle, fake_deepagents):
+    # hasattr-guard: backends/fakes that still expose .run keep working.
+    legacy_agent = MagicMock()
+    legacy_agent.run.return_value = "Legacy Result"
+
+    fake_deepagents.return_value = legacy_agent
+    engine = AISearchEngine(llm_config, mock_search_bundle)
+    engine.initialize()
+
+    res = await engine.search("hello")
+    assert res.ai_summary == "Legacy Result"
+    legacy_agent.run.assert_called_once_with("hello")
+    legacy_agent.invoke.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_ai_search_run_error(llm_config, mock_search_bundle, fake_deepagents):
+    agent = MagicMock(spec=["invoke"])
+    agent.invoke.side_effect = Exception("AI Fail")
+
+    fake_deepagents.return_value = agent
+    engine = AISearchEngine(llm_config, mock_search_bundle)
+    engine.initialize()
+
+    res = await engine.search("hello")
+    assert res.ai_summary is not None
     assert "AI search error: AI Fail" in res.ai_summary
 
 


### PR DESCRIPTION
## Проблема (ПРОД-БЛОКЕР)

`AISearchEngine.search` вызывал `self._agent.run(query)`, но `deepagents.create_deep_agent` возвращает langgraph `CompiledStateGraph`, у которого есть только `.invoke`, а `.run` отсутствует. На каждый AI-запрос летел `AttributeError`, который `search()` перехватывал и деградировал в «AI search error … Showing local results» — **AI-поиск падал в 100% вызовов** (находка #2 из код-ревью #1234).

## Решение

По образцу `src/agent/backends/deepagents.py`:
- `_run_agent_sync` с `hasattr`-guard: legacy-путь `.run` сохранён, по умолчанию — `.invoke({"messages": [{"role": "user", "content": query}]})`.
- `_extract_result_text` разбирает ответ `{"messages": [...]}`: берёт последнее сообщение, извлекает `content` (строка или список Anthropic-блоков → плоский текст).
- `self._agent: Any` — рантайм-guard не конфликтует со статическим типом.

## Тесты

- Фейк `_FakeCompiledStateGraph` имеет **реальную сигнатуру** графа: только `.invoke`, без `.run` (в отличие от `MagicMock`, который автосоздаёт `.run` и маскировал бы баг).
- `test_ai_search_invoke_not_run_regression` — явный регресс-гард: если кто-то вернёт `.run`, `AttributeError` вернёт «AI search error», и тест упадёт.
- Покрыты: строковый content, список content-блоков, legacy `.run`, ошибка провайдера.
- **Мутационная верификация:** возврат безусловного `.run` в продкоде роняет 4 теста с точным симптомом `'_FakeCompiledStateGraph' object has no attribute 'run'`.

`ruff check` чист, `pytest tests/test_ai_search.py` — 11 passed, вывод без warnings.

Closes #1237

🤖 Generated with [Claude Code](https://claude.com/claude-code)