### PR TITLE
fix: guard notification regex against ReDoS (#1240)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,11 @@ dependencies = [
     "beautifulsoup4>=4.14.3",
     "orjson>=3.10.0",
     "itsdangerous>=2.2.0",
+    # ReDoS guard for user-supplied notification regexes: the `regex` engine's
+    # `timeout=` aborts catastrophic backtracking inside its C matching loop,
+    # which the stdlib `re` cannot (#1240). Present transitively (dateparser,
+    # tiktoken) but declared here because it is now a direct runtime import.
+    "regex>=2024.11.6",
 ]
 
 [project.optional-dependencies]

--- a/src/services/notification_matcher.py
+++ b/src/services/notification_matcher.py
@@ -5,12 +5,26 @@ import re
 from dataclasses import dataclass, field
 from typing import Protocol
 
+import regex
+
 from src.models import Channel, Message, SearchQuery
 from src.parsers import bare_channel_id
 from src.telegram.notifier import Notifier
 from src.utils.search_query_chat_filter import chat_filter_matches_message
 
 logger = logging.getLogger(__name__)
+
+# User-supplied notification regexes run against third-party channel text (up to
+# ~4096 chars) on the worker's event loop. A pathological pattern like ``(a+)+$``
+# would backtrack exponentially inside a synchronous C call and freeze the loop —
+# heartbeat, collection queue and snapshots all stall, and an asyncio timeout
+# can't help because the loop itself is blocked (#1240). The `regex` engine
+# enforces this wall-clock ceiling *inside* its matching loop, aborting a runaway
+# pattern with a plain ``TimeoutError`` instead. Kept small so a hostile pattern
+# can't stall a whole backlog pass (the 24h backlog is re-presented every pass and
+# dry-run scans the full window), yet comfortably above the worst-case wall time
+# of a legitimate match.
+_REGEX_TIMEOUT_SECONDS = 0.25
 
 
 class NotifiedStore(Protocol):
@@ -28,8 +42,8 @@ def message_matches_query(sq: SearchQuery, msg: Message, channels: list[Channel]
     """True if *msg* matches notification query *sq*.
 
     Shared by the live matcher and the dry-run preview so both use the exact same
-    semantics (regex via re.search, plain via substring) instead of diverging
-    (audit #838/3 keys off this predicate).
+    semantics (regex via a timeout-guarded ``regex.search``, plain via substring)
+    instead of diverging (audit #838/3 keys off this predicate).
     """
     if not msg.text:
         return False
@@ -41,8 +55,19 @@ def message_matches_query(sq: SearchQuery, msg: Message, channels: list[Channel]
         return False
     if sq.is_regex:
         try:
-            return bool(re.search(sq.query, msg.text, re.IGNORECASE))
-        except re.error:
+            return bool(regex.search(sq.query, msg.text, regex.IGNORECASE, timeout=_REGEX_TIMEOUT_SECONDS))
+        except TimeoutError:
+            # Catastrophic backtracking (or just a very heavy pattern) — bail out
+            # without matching so the loop keeps ticking. Logged because a repeated
+            # timeout signals either a malicious pattern or one worth rewriting.
+            logger.warning(
+                "Notification regex timed out after %.3gs (possible ReDoS); query id=%s pattern=%r",
+                _REGEX_TIMEOUT_SECONDS,
+                sq.id,
+                sq.query,
+            )
+            return False
+        except regex.error:
             return False
     if sq.is_fts:
         return _fts_query_matches(sq.query, msg.text)

--- a/tests/test_notification_matcher.py
+++ b/tests/test_notification_matcher.py
@@ -2,15 +2,18 @@
 
 from __future__ import annotations
 
+import time
 from unittest.mock import AsyncMock
 
 import pytest
 
 from src.models import Message, SearchQuery
 from src.services.notification_matcher import (
+    _REGEX_TIMEOUT_SECONDS,
     NotificationMatcher,
     _fts_query_matches,
     _make_message_link,
+    message_matches_query,
 )
 
 
@@ -107,7 +110,7 @@ async def test_match_and_notify_case_insensitive():
 
 @pytest.mark.anyio
 async def test_match_and_notify_regex_query():
-    """Regex query matches via re.search."""
+    """Regex query matches via a timeout-guarded regex.search."""
     notifier = AsyncMock()
     matcher = NotificationMatcher(notifier)
 
@@ -132,6 +135,58 @@ async def test_match_and_notify_regex_error_falls_through():
     result = await matcher.match_and_notify(messages, queries)
 
     assert result == {}  # No match due to regex error
+
+
+# A pattern with nested quantifiers whose backtracking is exponential in the
+# length of a run of 'a' — the textbook ReDoS trigger (#1240).
+_EVIL_REGEX = r"(a+)+$"
+_EVIL_TEXT = "a" * 4096 + "!"
+
+
+def test_message_matches_query_redos_pattern_does_not_hang():
+    """A catastrophic-backtracking regex over a long channel text must bail out
+    fast (via the engine timeout) instead of freezing the event loop.
+
+    Guards the predicate directly — this is the synchronous C call that would
+    block the worker's loop, so we assert on wall-clock time, not on awaits."""
+    sq = make_query(_EVIL_REGEX, is_regex=True)
+    msg = make_message(_EVIL_TEXT)
+
+    start = time.perf_counter()
+    matched = message_matches_query(sq, msg)
+    elapsed = time.perf_counter() - start
+
+    assert matched is False  # timed out -> treated as no match, never raises
+    # The engine timeout checks periodically, so allow generous overshoot over the
+    # configured budget while still proving we don't spin for seconds.
+    assert elapsed < _REGEX_TIMEOUT_SECONDS + 1.0, f"regex ran {elapsed:.2f}s — loop would freeze"
+
+
+@pytest.mark.anyio
+async def test_match_and_notify_redos_pattern_falls_through(caplog):
+    """A ReDoS query fires no notification and logs a timeout warning."""
+    notifier = AsyncMock()
+    matcher = NotificationMatcher(notifier)
+
+    messages = [make_message(_EVIL_TEXT)]
+    queries = [make_query(_EVIL_REGEX, is_regex=True)]
+
+    start = time.perf_counter()
+    with caplog.at_level("WARNING"):
+        result = await matcher.match_and_notify(messages, queries)
+    elapsed = time.perf_counter() - start
+
+    assert result == {}
+    notifier.notify.assert_not_called()
+    assert elapsed < _REGEX_TIMEOUT_SECONDS + 1.0
+    assert any("timed out" in r.message for r in caplog.records)
+
+
+def test_message_matches_query_regex_still_matches_normal_pattern():
+    """The timeout guard must not change semantics for well-behaved patterns."""
+    sq = make_query(r"order #\d+", is_regex=True)
+    assert message_matches_query(sq, make_message("Order #42 shipped")) is True
+    assert message_matches_query(sq, make_message("no order here")) is False
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Closes #1240 — sub-issue of #1234 (code review finding #5). **Prod blocker: ReDoS freezes the worker event loop.**

## Problem
`message_matches_query` runs a user-supplied notification regex via `re.search` over third-party channel text (up to ~4096 chars) directly on the worker's event loop. A pathological pattern such as `(a+)+$` against a long run of `a` backtracks exponentially inside a **synchronous C call** → heartbeat, collection queue and runtime snapshots all freeze. An asyncio timeout can't rescue it because the loop itself is blocked. Amplifiers: the 24h backlog is re-presented to the matcher every pass, and dry-run scans the entire window.

## Fix
Switch the user-regex path from stdlib `re` to the **`regex`** engine's `timeout=` (0.25s). `regex` enforces the wall-clock ceiling *inside* its matching loop and aborts a runaway pattern with a plain `TimeoutError` — the one thing `re` cannot do without a subprocess/thread that a hung C call wouldn't respect anyway.

- On timeout → log a `WARNING` (repeated timeouts flag a malicious or heavy pattern for the operator) and treat as **no match**.
- Invalid patterns → still fall through to no-match (now caught as `regex.error`).
- Well-behaved patterns keep identical matching semantics (`re`-compatible VERSION0 mode).

`to_thread` was considered and rejected: it only stops *awaiting* the hung matcher, leaving the CPU-bound C call spinning a core; `regex.timeout` actually interrupts the backtracking. FTS (`_fts_query_matches`) and the internal `_FTS_TOKEN_RE` keep using `re` — those split on literal `AND`/`OR` boundaries and have no catastrophic-backtracking surface.

## Dependency
`regex>=2024.11.6` promoted to a **direct** dependency in `pyproject.toml`. It was already installed transitively (via `dateparser`, `tiktoken`), but relying on a transitive dep for a direct runtime import is fragile — a future upgrade could drop it. Lightweight, widely-used, pure C extension.

## Tests
- `test_message_matches_query_redos_pattern_does_not_hang` — evil `(a+)+$` over 4096 chars returns `False` in well under a second (asserts wall-clock, since this is the sync call that would freeze the loop). **Mutation-verified**: the old `re.search` does not finish in 8s in an isolated process.
- `test_match_and_notify_redos_pattern_falls_through` — end-to-end: no notification fires, timeout warning is logged, completes fast.
- `test_message_matches_query_regex_still_matches_normal_pattern` — the guard doesn't change semantics for legitimate patterns.

`ruff check`, `lint-imports`, and 160 tests across the notification/collector/search-query/regression suites pass clean (warnings-as-errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
