### PR TITLE
fix(web): route scheduler mutations through reconcile command (#1236, #1247)

### DIFF
--- a/src/web/pipelines/handlers.py
+++ b/src/web/pipelines/handlers.py
@@ -49,6 +49,7 @@ from src.web.pipelines.responses import (
     PipelineTemplate,
     PipelineUrlRedirect,
 )
+from src.web.scheduler.commands import enqueue_scheduler_reconcile
 
 logger = logging.getLogger("src.web.routes.pipelines")
 
@@ -253,8 +254,9 @@ async def create_wizard_submit(
     if form.is_active:
         await svc.toggle(pipeline_id)
     try:
-        scheduler = deps.get_scheduler(request)
-        await scheduler.sync_pipeline_jobs()
+        # Web-mode scheduler is a read-only snapshot shim; enqueue a reconcile so the
+        # live worker scheduler re-registers content_generate_<id> jobs (#1236).
+        await enqueue_scheduler_reconcile(request, requested_by="web:pipeline.sync")
     except Exception:
         logger.warning("Scheduler sync failed", exc_info=True)
     if form.run_after:
@@ -290,10 +292,10 @@ async def add_pipeline(
         )
     except PipelineValidationError:
         return _pipeline_redirect("pipeline_invalid", error=True)
-    # sync scheduler jobs
     try:
-        scheduler = deps.get_scheduler(request)
-        await scheduler.sync_pipeline_jobs()
+        # Web-mode scheduler is a read-only snapshot shim; enqueue a reconcile so the
+        # live worker scheduler re-registers content_generate_<id> jobs (#1236).
+        await enqueue_scheduler_reconcile(request, requested_by="web:pipeline.sync")
     except Exception:
         logger.warning("Scheduler sync failed", exc_info=True)
     # Warn if pipeline needs LLM but no provider is configured — still create it.
@@ -360,10 +362,10 @@ async def edit_pipeline(
         return _pipeline_redirect(str(exc), error=True, phone=phone)
     if not ok:
         return _pipeline_redirect("pipeline_invalid", error=True)
-    # sync scheduler jobs
     try:
-        scheduler = deps.get_scheduler(request)
-        await scheduler.sync_pipeline_jobs()
+        # Web-mode scheduler is a read-only snapshot shim; enqueue a reconcile so the
+        # live worker scheduler re-registers content_generate_<id> jobs (#1236).
+        await enqueue_scheduler_reconcile(request, requested_by="web:pipeline.sync")
     except Exception:
         logger.warning("Scheduler sync failed", exc_info=True)
     return _pipeline_redirect("pipeline_edited")
@@ -374,8 +376,9 @@ async def toggle_pipeline(request: Request, pipeline_id: int):
     if not ok:
         return _pipeline_redirect("pipeline_invalid", error=True)
     try:
-        scheduler = deps.get_scheduler(request)
-        await scheduler.sync_pipeline_jobs()
+        # Web-mode scheduler is a read-only snapshot shim; enqueue a reconcile so the
+        # live worker scheduler re-registers content_generate_<id> jobs (#1236).
+        await enqueue_scheduler_reconcile(request, requested_by="web:pipeline.sync")
     except Exception:
         logger.warning("Scheduler sync failed", exc_info=True)
     return _pipeline_redirect("pipeline_toggled")
@@ -384,8 +387,9 @@ async def toggle_pipeline(request: Request, pipeline_id: int):
 async def delete_pipeline(request: Request, pipeline_id: int):
     await deps.pipeline_service(request).delete(pipeline_id)
     try:
-        scheduler = deps.get_scheduler(request)
-        await scheduler.sync_pipeline_jobs()
+        # Web-mode scheduler is a read-only snapshot shim; enqueue a reconcile so the
+        # live worker scheduler re-registers content_generate_<id> jobs (#1236).
+        await enqueue_scheduler_reconcile(request, requested_by="web:pipeline.sync")
     except Exception:
         logger.warning("Scheduler sync failed", exc_info=True)
     return _pipeline_redirect("pipeline_deleted")
@@ -863,8 +867,9 @@ async def create_from_template(
     except PipelineValidationError as exc:
         return _pipeline_redirect(str(exc), error=True)
     try:
-        scheduler = deps.get_scheduler(request)
-        await scheduler.sync_pipeline_jobs()
+        # Web-mode scheduler is a read-only snapshot shim; enqueue a reconcile so the
+        # live worker scheduler re-registers content_generate_<id> jobs (#1236).
+        await enqueue_scheduler_reconcile(request, requested_by="web:pipeline.sync")
     except Exception:
         logger.warning("Scheduler sync failed", exc_info=True)
     return PipelineUrlRedirect(f"/pipelines/{pipeline_id}/edit")
@@ -909,8 +914,9 @@ async def import_pipeline(
         return _pipeline_redirect(f"Ошибка импорта: {exc}", error=True)
 
     try:
-        scheduler = deps.get_scheduler(request)
-        await scheduler.sync_pipeline_jobs()
+        # Web-mode scheduler is a read-only snapshot shim; enqueue a reconcile so the
+        # live worker scheduler re-registers content_generate_<id> jobs (#1236).
+        await enqueue_scheduler_reconcile(request, requested_by="web:pipeline.sync")
     except Exception:
         logger.warning("Scheduler sync failed", exc_info=True)
     return PipelineUrlRedirect(f"/pipelines/{pipeline_id}/generate")

--- a/src/web/runtime_shims.py
+++ b/src/web/runtime_shims.py
@@ -147,18 +147,22 @@ class SnapshotSchedulerManager:
         return None
 
     def update_interval(self, minutes: int) -> None:
-        # /settings/save-scheduler and /scheduler/jobs/*/set-interval call
-        # this synchronously after persisting the setting. The worker
-        # re-reads the interval on its own load cycle, so the web-side
-        # call is a no-op here.
+        # No-op: this snapshot shim cannot touch the live worker scheduler.
+        # Web routes must NOT rely on this to apply an interval change — the
+        # worker has no periodic re-sync, so a mutation only reaches the running
+        # scheduler when the route enqueues a `scheduler.reconcile` command
+        # (see src/web/scheduler/commands.py). Kept only to satisfy the
+        # WebScheduler interface. (#1247)
         return None
 
     async def sync_search_query_jobs(self) -> None:
-        # Search-query mutation routes call this when the scheduler is
-        # running (snapshot says is_running=True). The worker will pick
-        # up the DB change on its next sync cycle.
+        # No-op: see update_interval above. Search-query mutation routes enqueue
+        # `scheduler.reconcile` instead of calling this; the worker re-registers
+        # sq_<id> jobs when it handles that command. Kept for interface parity. (#1236)
         return None
 
     async def sync_pipeline_jobs(self) -> None:
-        # Pipeline mutation routes call this too; same rationale as above.
+        # No-op: same as sync_search_query_jobs. Pipeline mutation routes enqueue
+        # `scheduler.reconcile`; the worker re-registers content_generate_<id>
+        # jobs on reconcile. Kept for interface parity. (#1236)
         return None

--- a/src/web/scheduler/commands.py
+++ b/src/web/scheduler/commands.py
@@ -1,0 +1,30 @@
+"""Shared helper for enqueuing scheduler control commands from web routes.
+
+In web-mode ``deps.get_scheduler`` returns ``SnapshotSchedulerManager`` — a
+read-only shim whose ``sync_*``/``update_interval`` methods are no-ops (the live
+``SchedulerManager`` lives in the separate worker container). The only way a web
+mutation reaches the running scheduler is by enqueuing a ``scheduler.reconcile``
+telegram command, which the worker's ``_handle_scheduler_reconcile`` picks up and
+which re-registers search-query/pipeline jobs and re-reads the collect interval.
+
+``scheduler/handlers.py`` already does this for its own routes; this helper lets
+the search-query, pipeline, and settings domains do the same without importing
+across handler modules. ``TelegramCommandService.enqueue`` deduplicates on
+``(command_type, payload)``, so repeated reconcile requests collapse into one
+pending command instead of piling up a backlog.
+"""
+
+from __future__ import annotations
+
+from fastapi import Request
+
+from src.web import deps
+
+
+async def enqueue_scheduler_reconcile(request: Request, *, requested_by: str) -> int:
+    """Enqueue a ``scheduler.reconcile`` command; return its command id."""
+    return await deps.telegram_command_service(request).enqueue(
+        "scheduler.reconcile",
+        payload={},
+        requested_by=requested_by,
+    )

--- a/src/web/search_queries/handlers.py
+++ b/src/web/search_queries/handlers.py
@@ -6,14 +6,18 @@ from fastapi import Request
 from pydantic import ValidationError
 
 from src.web import deps
+from src.web.scheduler.commands import enqueue_scheduler_reconcile
 from src.web.search_queries.forms import SearchQueryForm
 from src.web.search_queries.responses import SearchQueryRedirect, SearchQueryTemplate
 
 
 async def _sync_scheduler(request: Request) -> None:
-    scheduler = deps.get_scheduler(request)
-    if scheduler.is_running:
-        await scheduler.sync_search_query_jobs()
+    # Web-mode scheduler is a read-only snapshot shim; the only way a search-query
+    # mutation reaches the live worker scheduler is via a reconcile command, which
+    # re-registers the sq_<id> jobs. Enqueue unconditionally: the worker's reconcile
+    # handler consults scheduler_autostart itself, and the snapshot is_running flag
+    # is a stale read that must not gate this (#1236).
+    await enqueue_scheduler_reconcile(request, requested_by="web:search_query.sync")
 
 
 async def search_queries_page(request: Request) -> SearchQueryTemplate:

--- a/src/web/settings/handlers.py
+++ b/src/web/settings/handlers.py
@@ -58,6 +58,7 @@ from src.telegram.resolve_guard import (
 )
 from src.utils.datetime import parse_datetime
 from src.web import deps
+from src.web.scheduler.commands import enqueue_scheduler_reconcile
 from src.web.settings.forms import (
     CREDENTIALS_MASK,
     AgentSettingsForm,
@@ -658,9 +659,11 @@ async def handle_save_scheduler_settings(
     db = deps.get_db(request)
     await db.repos.settings.set_setting("collect_interval_minutes", str(form.interval_minutes))
     await db.repos.settings.set_setting(REACTION_MIN_INTERVAL_SETTING, str(form.reaction_min_interval_sec))
-    scheduler = getattr(request.app.state, "scheduler", None)
-    if scheduler:
-        scheduler.update_interval(form.interval_minutes)
+    # Web-mode scheduler is a read-only snapshot shim, so calling update_interval() on it
+    # is a no-op. Enqueue a reconcile — exactly like the /scheduler set-interval route — so
+    # the live worker scheduler re-reads collect_interval_minutes and rebuilds its
+    # IntervalTrigger instead of keeping the old cadence until restart (#1247).
+    await enqueue_scheduler_reconcile(request, requested_by="web:settings.save_scheduler")
     return SettingsFlash(msg="scheduler_saved")
 
 

--- a/tests/routes/test_search_queries_routes.py
+++ b/tests/routes/test_search_queries_routes.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -138,46 +138,38 @@ async def test_run_search_query(route_client):
 
 
 @pytest.mark.anyio
-async def test_scheduler_synced_after_add(route_client):
-    """Test scheduler syncs after add when running."""
-    route_client._transport_app.state.scheduler._running = True
+async def test_scheduler_synced_after_add(route_client, db):
+    """Adding a search query enqueues a scheduler.reconcile command (#1236).
 
-    with patch(
-        "src.web.search_queries.handlers.deps.get_scheduler"
-    ) as mock_get_scheduler:
-        mock_scheduler = MagicMock()
-        mock_scheduler.is_running = True
-        mock_scheduler.sync_search_query_jobs = AsyncMock()
-        mock_get_scheduler.return_value = mock_scheduler
-
-        resp = await route_client.post(
-            "/search-queries/add",
-            data={"query": "sync test", "interval_minutes": "60"},
-            follow_redirects=False,
-        )
-        assert resp.status_code == 303
-        mock_scheduler.sync_search_query_jobs.assert_called_once()
+    The old in-process sync_search_query_jobs() call was a no-op behind the web
+    container; the mutation now reaches the live worker scheduler via a reconcile
+    command instead.
+    """
+    resp = await route_client.post(
+        "/search-queries/add",
+        data={"query": "sync test", "interval_minutes": "60"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    reconciles = await db.repos.telegram_commands.list_commands(command_type="scheduler.reconcile")
+    assert len(reconciles) == 1
 
 
 @pytest.mark.anyio
-async def test_scheduler_synced_after_toggle(route_client):
-    """Test scheduler syncs after toggle when running."""
+async def test_scheduler_synced_after_toggle(route_client, db):
+    """Toggling a search query enqueues a scheduler.reconcile command (#1236)."""
     await route_client.post(
         "/search-queries/add",
         data={"query": "sync toggle", "interval_minutes": "60"},
     )
+    # The add already enqueued one reconcile; toggling must enqueue another distinct
+    # command (dedup only collapses identical PENDING ones, so drain first).
+    await db.execute_write("DELETE FROM telegram_commands", ())
 
-    with patch(
-        "src.web.search_queries.handlers.deps.get_scheduler"
-    ) as mock_get_scheduler:
-        mock_scheduler = MagicMock()
-        mock_scheduler.is_running = True
-        mock_scheduler.sync_search_query_jobs = AsyncMock()
-        mock_get_scheduler.return_value = mock_scheduler
-
-        resp = await route_client.post("/search-queries/1/toggle", follow_redirects=False)
-        assert resp.status_code == 303
-        mock_scheduler.sync_search_query_jobs.assert_called_once()
+    resp = await route_client.post("/search-queries/1/toggle", follow_redirects=False)
+    assert resp.status_code == 303
+    reconciles = await db.repos.telegram_commands.list_commands(command_type="scheduler.reconcile")
+    assert len(reconciles) == 1
 
 
 @pytest.mark.anyio

--- a/tests/routes/test_settings_routes_provider_notifications.py
+++ b/tests/routes/test_settings_routes_provider_notifications.py
@@ -104,16 +104,17 @@ async def test_settings_page_notification_bot_error(route_client, db):
         assert resp.status_code == 200
 
 
-# ── save_scheduler: line 560-566 (interval update via scheduler) ───────
+# ── save_scheduler: persists interval + enqueues reconcile (#1247) ─────
 
 
 @pytest.mark.anyio
 async def test_save_scheduler_updates_running_scheduler(route_client, db):
-    """Test save scheduler updates interval on running scheduler (lines 567-569)."""
-    mock_scheduler = MagicMock()
-    mock_scheduler.update_interval = MagicMock()
-    route_client._transport_app.state.scheduler = mock_scheduler
+    """Saving the collect interval persists it and enqueues scheduler.reconcile (#1247).
 
+    The old in-process scheduler.update_interval() call was a no-op behind the web
+    container; the change now reaches the live worker scheduler via a reconcile
+    command, matching the /scheduler set-interval route.
+    """
     resp = await route_client.post(
         "/settings/save-scheduler",
         data={"collect_interval_minutes": "45"},
@@ -121,7 +122,9 @@ async def test_save_scheduler_updates_running_scheduler(route_client, db):
     )
     assert resp.status_code == 303
     assert "msg=scheduler_saved" in resp.headers["location"]
-    mock_scheduler.update_interval.assert_called_once_with(45)
+    assert await db.get_setting("collect_interval_minutes") == "45"
+    reconciles = await db.repos.telegram_commands.list_commands(command_type="scheduler.reconcile")
+    assert len(reconciles) == 1
 
 
 @pytest.mark.anyio

--- a/tests/test_web_scheduler_reconcile_enqueue.py
+++ b/tests/test_web_scheduler_reconcile_enqueue.py
@@ -1,0 +1,167 @@
+"""Web mutations must enqueue a ``scheduler.reconcile`` command (#1236, #1247).
+
+In web-mode ``app.state.scheduler`` is the read-only ``SnapshotSchedulerManager``
+shim whose ``sync_search_query_jobs``/``sync_pipeline_jobs``/``update_interval`` are
+no-ops. The only way a UI mutation reaches the live worker scheduler is by enqueuing
+a ``scheduler.reconcile`` telegram command (handled by the worker's
+``_handle_scheduler_reconcile``, which re-registers sq_/pipeline jobs and re-reads
+the collect interval). These tests pin that the mutation routes do enqueue it — the
+regression that #1236/#1247 fixed silently dropped the sync.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.models import Account, Channel, SearchQuery
+from src.services.pipeline_service import PipelineService, PipelineTargetRef
+from src.web.runtime_shims import SnapshotSchedulerManager
+from tests.helpers import build_web_app, make_auth_client, make_test_config
+
+
+@pytest.fixture
+async def web_client(tmp_path, real_pool_harness_factory):
+    """Authenticated web client running in web-mode (snapshot scheduler shim).
+
+    Yields ``(client, db)`` so tests can drive routes and read back the
+    ``telegram_commands`` table. The scheduler is forced to the shim so the test
+    proves the reconcile command is enqueued even when the in-process
+    ``sync_*``/``update_interval`` calls are no-ops.
+    """
+    config = make_test_config(tmp_path)
+    harness = real_pool_harness_factory()
+    app, db = await build_web_app(config, harness)
+    # Force web-mode scheduler: behind the web container in production the scheduler
+    # is always the snapshot shim, not the live SchedulerManager (#444).
+    app.state.scheduler = SnapshotSchedulerManager(db, config.scheduler.collect_interval_minutes)
+
+    await db.add_account(Account(phone="+100", session_string="sess"))
+    await db.add_channel(Channel(channel_id=1001, title="Source A"))
+    await db.repos.dialog_cache.replace_dialogs(
+        "+100",
+        [{"channel_id": 77, "title": "Target A", "username": "targeta", "channel_type": "channel"}],
+    )
+
+    async with make_auth_client(app) as client:
+        yield client, db
+
+    await app.state.collection_queue.shutdown()
+    await db.close()
+
+
+async def _reconcile_count(db) -> int:
+    commands = await db.repos.telegram_commands.list_commands(command_type="scheduler.reconcile")
+    return len(commands)
+
+
+async def _seed_pipeline(db) -> int:
+    return await PipelineService(db).add(
+        name="Seed pipeline",
+        prompt_template="Summarize {source_messages}",
+        source_channel_ids=[1001],
+        target_refs=[PipelineTargetRef(phone="+100", dialog_id=77)],
+    )
+
+
+# ---------------------------------------------------------------------------
+# #1236 — search-query mutations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_add_search_query_enqueues_reconcile(web_client):
+    client, db = web_client
+    assert await _reconcile_count(db) == 0
+
+    resp = await client.post("/search-queries/add", data={"query": "crypto", "interval_minutes": "30"})
+    assert resp.status_code == 200
+    assert await _reconcile_count(db) == 1
+
+
+@pytest.mark.anyio
+async def test_toggle_search_query_enqueues_reconcile(web_client):
+    client, db = web_client
+    sq_id = await db.repos.search_queries.add(SearchQuery(query="seed", interval_minutes=60))
+    assert await _reconcile_count(db) == 0
+
+    resp = await client.post(f"/search-queries/{sq_id}/toggle")
+    assert resp.status_code == 200
+    assert await _reconcile_count(db) == 1
+
+
+@pytest.mark.anyio
+async def test_delete_search_query_enqueues_reconcile(web_client):
+    client, db = web_client
+    sq_id = await db.repos.search_queries.add(SearchQuery(query="seed", interval_minutes=60))
+
+    resp = await client.post(f"/search-queries/{sq_id}/delete")
+    assert resp.status_code == 200
+    assert await _reconcile_count(db) == 1
+
+
+# ---------------------------------------------------------------------------
+# #1236 — pipeline mutations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_add_pipeline_enqueues_reconcile(web_client):
+    client, db = web_client
+    assert await _reconcile_count(db) == 0
+
+    resp = await client.post(
+        "/pipelines/add",
+        data={
+            "name": "News",
+            "prompt_template": "Summarize {source_messages}",
+            "source_channel_ids": ["1001"],
+            "target_refs": ["+100|77"],
+            "publish_mode": "moderated",
+            "generation_backend": "chain",
+            "generate_interval_minutes": "60",
+        },
+    )
+    assert resp.status_code == 200
+    assert await _reconcile_count(db) == 1
+
+
+@pytest.mark.anyio
+async def test_toggle_pipeline_enqueues_reconcile(web_client):
+    client, db = web_client
+    pid = await _seed_pipeline(db)
+    assert await _reconcile_count(db) == 0
+
+    resp = await client.post(f"/pipelines/{pid}/toggle")
+    assert resp.status_code == 200
+    assert await _reconcile_count(db) == 1
+
+
+@pytest.mark.anyio
+async def test_delete_pipeline_enqueues_reconcile(web_client):
+    client, db = web_client
+    pid = await _seed_pipeline(db)
+
+    resp = await client.post(f"/pipelines/{pid}/delete")
+    assert resp.status_code == 200
+    assert await _reconcile_count(db) == 1
+
+
+# ---------------------------------------------------------------------------
+# #1247 — collect_interval saved from the Settings page
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_save_scheduler_settings_enqueues_reconcile(web_client):
+    client, db = web_client
+    assert await _reconcile_count(db) == 0
+
+    resp = await client.post(
+        "/settings/save-scheduler",
+        data={"collect_interval_minutes": "15", "reaction_min_interval_sec": "10"},
+    )
+    assert resp.status_code == 200
+    # The interval was persisted...
+    assert await db.repos.settings.get_setting("collect_interval_minutes") == "15"
+    # ...and a reconcile was enqueued so the worker rebuilds its IntervalTrigger.
+    assert await _reconcile_count(db) == 1


### PR DESCRIPTION
## Проблема (эпик #1234, находки #1 и #10)

Один класс бага — no-op шим планировщика в веб-режиме. В `serve` веб-контейнер использует `SnapshotSchedulerManager`, а живой `SchedulerManager` крутится в отдельном воркер-контейнере, у которого **нет периодического ре-синка**.

- **#1236**: `sync_search_query_jobs`/`sync_pipeline_jobs` на шиме — no-op. Добавление/правка/включение search-query или pipeline в UI не регистрировало APScheduler-задачу до рестарта воркера → новый запрос молча не собирался, включённый pipeline молча не генерировал.
- **#1247**: сохранение `collect_interval` на Settings звало `scheduler.update_interval()` (тот же no-op шим) → работающий `IntervalTrigger` держал старую периодичность до рестарта.

## Фикс

Веб-мутации search-query/pipeline и сохранение `collect_interval` теперь ставят команду `scheduler.reconcile` — ровно как 4 маршрута в `src/web/scheduler/handlers.py` (эталон). Воркерный `_handle_scheduler_reconcile` перечитывает `scheduler_autostart`, ре-регистрирует sq_/pipeline-задачи (через `start()`) и перечитывает `collect_interval_minutes`. `TelegramCommandService.enqueue` дедуплицирует по `(type, payload)` — повторные reconcile схлопываются в одну PENDING-команду.

- Новый хелпер `src/web/scheduler/commands.py::enqueue_scheduler_reconcile`.
- search-query синк теперь **безусловный** (убран устаревший гейт по снапшотному `is_running` — воркер сам смотрит `scheduler_autostart`).
- Исправлены ложные комментарии «worker подхватит на следующем цикле» в шиме.

## Тесты

- Новый `tests/test_web_scheduler_reconcile_enqueue.py`: в веб-режиме (шим-планировщик) прогоняет add/toggle/delete search-query, add/toggle/delete pipeline и save-scheduler → проверяет, что в `telegram_commands` появилась `scheduler.reconcile`.
- Обновлены 2 существующих route-теста, которые ассертили старый no-op вызов, — теперь проверяют контракт reconcile.

`ruff check` чист, `lint-imports` зелёный, 433+ затронутых теста проходят (в т.ч. под `-n auto`).

## Соседний gap (вне scope, для сведения)

Agent-tool `save_scheduler_settings` (`src/agent/tools/settings.py:121`) тоже зовёт `scheduler_manager.update_interval()` — тот же класс. Не тронут: обе issue явно ограничены web-путями. Стоит завести отдельную задачу.

Closes #1236, Closes #1247

🤖 Generated with [Claude Code](https://claude.com/claude-code)