### PR TITLE
fix(provider): read LangChain .text as a property, not a method (#1263)

### DIFF
--- a/src/services/provider_service.py
+++ b/src/services/provider_service.py
@@ -330,6 +330,15 @@ class RuntimeProviderRegistry:
         if isinstance(response, str):
             return response
         text_attr = getattr(response, "text", None)
+        # LangChain >=0.3 exposes ``.text`` as a property. In langchain-core the
+        # value is a ``TextAccessor`` that *is* a ``str`` but is still callable for
+        # backwards compat — calling it emits a LangChainDeprecationWarning
+        # ("Use .text as a property instead"), which trips ``filterwarnings=error``.
+        # Prefer the property contract: if ``.text`` already reads as a string, use
+        # it directly and never invoke it as a method.
+        if isinstance(text_attr, str):
+            return str(text_attr)
+        # Legacy fallback: very old LangChain where ``.text`` is a plain method.
         if callable(text_attr):
             try:
                 text = text_attr()

--- a/tests/test_quality_scoring_service.py
+++ b/tests/test_quality_scoring_service.py
@@ -308,3 +308,46 @@ async def test_score_content_fallback_without_config_uses_default(mock_db):
     service = QualityScoringService(mock_db)
     score = await service.score_content("text")
     assert score.overall == 0.5
+
+
+# === _response_text LangChain .text property regression (issue #1263) ===
+
+
+def test_response_text_reads_langchain_message_text_property():
+    """``.text`` on a LangChain message is a property, not a method (issue #1263).
+
+    langchain-core exposes ``AIMessage.text`` as a ``TextAccessor`` that *is* a
+    ``str`` yet stays callable for backwards compat; calling it emits a
+    ``LangChainDeprecationWarning`` which trips ``filterwarnings=["error"]``.
+    ``_response_text`` must read it as a property and never invoke it.
+    """
+    import warnings
+
+    from langchain_core.messages import AIMessage
+
+    from src.services.provider_service import RuntimeProviderRegistry
+
+    message = AIMessage(content="generated body")
+
+    # Sanity: the accessor really is both str-like and (deprecated) callable, so
+    # this test guards against a regression to the method-call code path.
+    assert isinstance(message.text, str)
+    assert callable(message.text)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        text = RuntimeProviderRegistry._response_text(message)
+
+    assert text == "generated body"
+
+
+def test_response_text_legacy_callable_fallback():
+    """Very old LangChain exposed ``.text`` as a plain method — still supported."""
+
+    class _LegacyMessage:
+        def text(self) -> str:
+            return "legacy body"
+
+    from src.services.provider_service import RuntimeProviderRegistry
+
+    assert RuntimeProviderRegistry._response_text(_LegacyMessage()) == "legacy body"


### PR DESCRIPTION
## Что и зачем

Предсуществующий баг (виден и на `main`), который **красит job `tests` под `-n auto`** и мешает мержу: `tests/test_quality_scoring_service.py` падал с `assert 0.0 == 0.5`.

### Корень
`src/services/provider_service.py` в `_response_text()` вызывал `.text()` **как метод**:
```python
text_attr = getattr(response, "text", None)
if callable(text_attr):
    text = text_attr()   # ← deprecated call
```
В langchain-core (1.4.x) `AIMessage.text` — это `TextAccessor`: он *является* `str`, но остаётся `callable` для обратной совместимости. Поэтому код шёл по `callable`-ветке и **вызывал** `text_attr()`, что эмитит `LangChainDeprecationWarning: Calling .text() as a method is deprecated. Use .text as a property instead`. Под проектным `filterwarnings=["error"]` это hard failure, плюс извлечение текста ломалось → scoring возвращал `0.0`.

### Фикс
Приоритет — property-контракт: если `.text` уже читается как `str`, вернуть его напрямую и **никогда** не вызывать как метод. Legacy callable-путь оставлен как fallback для очень старого LangChain, где `.text` был чистым методом.

### Регресс-тесты
- `test_response_text_reads_langchain_message_text_property` — property-путь не варнит под `filterwarnings=error` (мутационно проверено: **без** фикса тест падает ровно на `LangChainDeprecationWarning`).
- `test_response_text_legacy_callable_fallback` — legacy method-путь всё ещё поддержан.

## Верификация
- `tests/test_quality_scoring_service.py` изолированно: **26 passed, 0 warnings** (в чистом CI-подобном окружении).
- Полный `pytest tests/ -n auto -q -m "not aiosqlite_serial"`: **9131 passed, 143 skipped, 0 failed, 0 warnings** (3:13).
- `ruff check` чисто.

> NB: leaf-флейк `test_real_telegram_policy.py` — отдельный CI-блокер, чинится в PR #1259, не входит в этот дифф.

Closes #1263

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013istHFPjoy23fZGkVNErEr