### PR TITLE
fix(codex): surface failed turn instead of empty "success" response

### DIFF
--- a/src/agent/codex_backend.py
+++ b/src/agent/codex_backend.py
@@ -115,9 +115,10 @@ class CodexSdkBackend:
 
         full_text_parts: list[str] = []
         usage: dict | None = None
+        turn_error: str | None = None
 
         async def _drain() -> dict | None:
-            nonlocal usage
+            nonlocal usage, turn_error
             async with AsyncCodex() as codex:
                 thread = await codex.thread_start(
                     base_instructions=system_prompt or None,
@@ -153,7 +154,12 @@ class CodexSdkBackend:
                         usage = _usage_from_payload(payload) or usage
                     elif method == NOTE_TURN_COMPLETED:
                         # Terminal event — stop draining rather than waiting for
-                        # the async iterator to close on its own.
+                        # the async iterator to close on its own. But a failed
+                        # turn (auth expiry, model error, MCP-server crash) is
+                        # delivered *inside* turn/completed as Turn.status=failed
+                        # + Turn.error — record it so the caller surfaces an
+                        # error frame instead of a "successful" empty response.
+                        turn_error = _turn_error_message(payload)
                         break
             return usage
 
@@ -173,6 +179,15 @@ class CodexSdkBackend:
             await queue.put(f"data: {error_payload}\n\n")
             return
 
+        # A failed turn is not a success: surface the error frame the drain
+        # loop captured from turn/completed (status=failed) instead of a done
+        # payload whose full_text would otherwise be an empty "" answer.
+        if turn_error is not None:
+            logger.error("Codex turn failed: %s", turn_error)
+            error_payload = safe_json_dumps({"error": turn_error}, ensure_ascii=False)
+            await queue.put(f"data: {error_payload}\n\n")
+            return
+
         full_text = "".join(full_text_parts)
         done_payload = safe_json_dumps(
             {
@@ -185,6 +200,29 @@ class CodexSdkBackend:
             ensure_ascii=False,
         )
         await queue.put(f"data: {done_payload}\n\n")
+
+
+def _turn_error_message(payload) -> str | None:
+    """Error message when a ``turn/completed`` reports a failed turn, else None.
+
+    Shape (openai_codex ``TurnCompletedNotification``): ``payload.turn`` is a
+    ``Turn`` whose ``status`` is a ``TurnStatus`` enum (``failed`` when the turn
+    crashed — auth expiry, model error, MCP-server crash) and whose ``error`` is
+    a ``TurnError`` (``.message``) populated only on failure. ``status`` is
+    compared via its ``.value`` so a real enum and a plain-string fake both work;
+    any status other than ``failed`` (completed / interrupted / inProgress) is a
+    non-failure and returns None.
+    """
+    turn = getattr(payload, "turn", None)
+    if turn is None:
+        return None
+    status = getattr(turn, "status", None)
+    status_value = getattr(status, "value", status)
+    if status_value != "failed":
+        return None
+    error = getattr(turn, "error", None)
+    message = getattr(error, "message", None)
+    return str(message) if message else "Codex turn failed"
 
 
 def _mcp_tool_item(payload):

--- a/tests/test_codex_backend.py
+++ b/tests/test_codex_backend.py
@@ -19,7 +19,16 @@ pytestmark = pytest.mark.anyio
 
 
 def _install_fake_codex(
-    monkeypatch, *, deltas, usage=None, tool=None, tool_error=False, noise_item=False, hang=False
+    monkeypatch,
+    *,
+    deltas,
+    usage=None,
+    tool=None,
+    tool_error=False,
+    noise_item=False,
+    hang=False,
+    turn_status="completed",
+    turn_error_message=None,
 ):
     """Install a fake ``openai_codex`` whose turn streams *deltas* then *usage*.
 
@@ -37,6 +46,10 @@ def _install_fake_codex(
     - ``noise_item=True`` also emits a non-MCP ``item/started`` (a reasoning item
       with no ``tool``/``server``), which the backend must ignore — the real SDK
       emits ``item/*`` for many item types, not just tool calls.
+    - ``turn_status`` / ``turn_error_message`` set the ``turn/completed`` payload's
+      ``turn.status`` and ``turn.error.message`` — ``turn_status="failed"`` with a
+      message models a crashed turn (``Turn.status=failed`` + ``Turn.error``) the
+      backend must surface as an error frame, not a "successful" empty response.
     """
     captured: dict = {}
 
@@ -71,7 +84,15 @@ def _install_fake_codex(
                     "thread/tokenUsage/updated",
                     SimpleNamespace(token_usage=SimpleNamespace(last=usage)),
                 )
-            yield _note("turn/completed", SimpleNamespace())
+            # turn/completed carries the Turn: status ("completed"/"failed"/...)
+            # and error (TurnError-shaped, .message) — only populated on failure.
+            turn_err = (
+                SimpleNamespace(message=turn_error_message)
+                if turn_error_message is not None
+                else None
+            )
+            turn = SimpleNamespace(status=turn_status, error=turn_err)
+            yield _note("turn/completed", SimpleNamespace(turn=turn))
 
     class FakeThread:
         async def turn(self, text):
@@ -270,6 +291,79 @@ async def test_chat_stream_ignores_non_mcp_items(monkeypatch):
     assert not [e for e in events if e.get("type") in ("tool_start", "tool_end")]
     # text still flows and the turn completes normally
     assert [e["text"] for e in events if "text" in e] == ["hi"]
+
+
+async def test_chat_stream_failed_turn_emits_error_not_empty_done(monkeypatch):
+    """A failed turn (turn/completed status=failed) surfaces the error, not a fake success.
+
+    Regression for #1252: the SDK delivers turn failures (auth expiry, model
+    error, MCP-server crash) *inside* turn/completed as ``Turn.status=failed`` +
+    ``Turn.error``. The backend used to ``break`` unconditionally and emit
+    ``{'done': True, 'full_text': ''}`` — a "successful" empty answer with no
+    error indication. It must instead emit an error frame and no done frame.
+    """
+    _install_fake_codex(
+        monkeypatch,
+        deltas=[],
+        turn_status="failed",
+        turn_error_message="authentication expired",
+    )
+    backend = _make_backend()
+    queue: asyncio.Queue = asyncio.Queue()
+
+    await backend.chat_stream(
+        thread_id=1, prompt="x", system_prompt="", stats={}, model="gpt-5.4", queue=queue
+    )
+
+    events = await _drain(queue)
+    errors = [e for e in events if "error" in e]
+    assert errors, events
+    assert "authentication expired" in errors[0]["error"]
+    # A failed turn must NOT be reported as a successful (empty) done frame.
+    assert not any(e.get("done") for e in events)
+
+
+async def test_chat_stream_failed_turn_without_message_still_errors(monkeypatch):
+    """A failed turn with no Turn.error still yields an error frame, not empty success.
+
+    ``Turn.error`` is only *populated* on failure but is still ``| None``; a
+    failed status with a missing message must fall back to a generic error rather
+    than slip through as an empty done frame.
+    """
+    _install_fake_codex(
+        monkeypatch, deltas=[], turn_status="failed", turn_error_message=None
+    )
+    backend = _make_backend()
+    queue: asyncio.Queue = asyncio.Queue()
+
+    await backend.chat_stream(
+        thread_id=1, prompt="x", system_prompt="", stats={}, model="gpt-5.4", queue=queue
+    )
+
+    events = await _drain(queue)
+    assert [e for e in events if "error" in e], events
+    assert not any(e.get("done") for e in events)
+
+
+async def test_chat_stream_non_failed_status_still_completes(monkeypatch):
+    """A non-failed terminal status (e.g. completed) still emits a normal done frame.
+
+    Guards the failure check from over-triggering: only ``status=failed`` is an
+    error; ``completed`` (and other non-failure statuses) must still stream the
+    done payload with the collected text.
+    """
+    _install_fake_codex(monkeypatch, deltas=["ok"], turn_status="completed")
+    backend = _make_backend()
+    queue: asyncio.Queue = asyncio.Queue()
+
+    await backend.chat_stream(
+        thread_id=1, prompt="x", system_prompt="", stats={}, model="gpt-5.4", queue=queue
+    )
+
+    events = await _drain(queue)
+    assert not [e for e in events if "error" in e], events
+    done = next(e for e in events if e.get("done"))
+    assert done["full_text"] == "ok"
 
 
 def test_notification_methods_match_sdk_registry():


### PR DESCRIPTION
## Problem

The Codex agent backend treated `turn/completed` as an unconditional success (a bare `break`) and always emitted `{done: True, full_text: ""}`. But the openai_codex SDK delivers turn **failures** — expired auth, model error, MCP-server crash — *inside* `turn/completed` as `Turn.status=failed` + `Turn.error`. A crashed turn was therefore streamed to the user as a "successful" empty response with no error indication, and persisted as a normal turn.

Found in the #1234 code review (finding #15). Opt-in dev-mode-override backend, fully isolated.

## Fix

The drain loop now inspects `payload.turn.status` on `turn/completed` via a new `_turn_error_message` helper:

- On `status=failed`, it emits an **error frame** (`Turn.error`'s `message`, or a generic fallback when `error` is `None`) and returns before the done payload — symmetric with the existing `total_timeout` error path.
- Non-failed statuses (`completed` / `interrupted` / `inProgress`) still stream the normal done frame.

`status` is compared via its `.value` so both a real `TurnStatus` enum and a plain-string fake resolve identically.

## Tests

`tests/test_codex_backend.py`:
- `test_chat_stream_failed_turn_emits_error_not_empty_done` — failed turn → error frame carrying the message, no done frame.
- `test_chat_stream_failed_turn_without_message_still_errors` — failed turn with `Turn.error = None` → generic error, still no empty success.
- `test_chat_stream_non_failed_status_still_completes` — guards the check from over-triggering: a `completed` turn still emits a done frame with the collected text.

Mutating the fix back to a bare `break` turns the two failure tests red (verified). The `test_notification_methods_match_sdk_registry` SDK guard is untouched.

## Checklist
- `ruff check src/ tests/ conftest.py` clean
- `pytest tests/test_codex_backend.py` → 12 passed
- No mypy regression in `codex_backend.py` (0 errors in the file)
- Only `src/agent/codex_backend.py` (+ its tests) touched

Closes #1252
Refs #1234

🤖 Generated with [Claude Code](https://claude.com/claude-code)