### PR TITLE
fix: pipeline add --json-file drops targets and stays inactive (#1246)

### DIFF
--- a/src/cli/commands/pipeline.py
+++ b/src/cli/commands/pipeline.py
@@ -237,6 +237,9 @@ async def _pipeline_add_from_json(
             else []
         ),
         "generate_interval_minutes": args.interval,
+        # Activate unless --inactive was passed; import_json reads is_active from
+        # the payload, so the pipeline is created active in one write (#1246).
+        "is_active": not args.inactive,
         "pipeline_json": graph_data,
     }
     return await svc.import_json(data)

--- a/src/services/pipeline_service.py
+++ b/src/services/pipeline_service.py
@@ -52,6 +52,42 @@ class PipelineTargetRef:
     dialog_id: int
 
 
+def _coerce_target_ref(ref: Any) -> PipelineTargetRef | None:
+    """Normalise one exported target ref into a ``PipelineTargetRef``.
+
+    Exports and the CLI/agent surfaces disagree on shape: ``export_json`` emits
+    ``"phone|dialog_id"`` strings, while ``pipeline add --json-file`` builds
+    ``{"phone": ..., "dialog_id": ...}`` dicts. The old import path accepted only
+    the string form, so dict refs were silently dropped and the imported
+    pipeline ended up with zero targets (#1246). Accept both; return ``None`` for
+    anything unparseable so the caller can skip it.
+    """
+    if isinstance(ref, PipelineTargetRef):
+        return ref
+    if isinstance(ref, str):
+        if "|" not in ref:
+            return None
+        phone, _, dialog_id = ref.partition("|")
+        phone = phone.strip()
+        dialog_id = dialog_id.strip()
+        if not phone or not dialog_id:
+            return None
+        try:
+            return PipelineTargetRef(phone=phone, dialog_id=int(dialog_id))
+        except ValueError:
+            return None
+    if isinstance(ref, dict):
+        phone = str(ref.get("phone", "")).strip()
+        raw_dialog = ref.get("dialog_id")
+        if not phone or raw_dialog is None:
+            return None
+        try:
+            return PipelineTargetRef(phone=phone, dialog_id=int(raw_dialog))
+        except (ValueError, TypeError):
+            return None
+    return None
+
+
 @dataclass(frozen=True)
 class PipelineRetrievalScope:
     query: str
@@ -544,9 +580,9 @@ class PipelineService:
         target_refs_raw = payload.get("target_refs", [])
         target_refs: list[PipelineTargetRef] = []
         for ref in target_refs_raw:
-            if isinstance(ref, str) and "|" in ref:
-                phone, _, dialog_id = ref.partition("|")
-                target_refs.append(PipelineTargetRef(phone=phone, dialog_id=int(dialog_id)))
+            coerced = _coerce_target_ref(ref)
+            if coerced is not None:
+                target_refs.append(coerced)
 
         pipeline_json: PipelineGraph | None = None
         if "pipeline_json" in payload:
@@ -563,7 +599,11 @@ class PipelineService:
             publish_mode=payload.get("publish_mode", PipelinePublishMode.MODERATED),
             generation_backend=payload.get("generation_backend", PipelineGenerationBackend.CHAIN),
             generate_interval_minutes=int(payload.get("generate_interval_minutes", 60)),
-            is_active=False,
+            # Honour an explicit is_active from the payload; default False so a
+            # plain export->import round-trip stays inactive (export_json never
+            # emits is_active). The CLI `--json-file` path passes is_active so a
+            # `pipeline add` without --inactive activates the pipeline (#1246).
+            is_active=bool(payload.get("is_active", False)),
             account_phone=payload.get("account_phone"),
         )
         self._inject_runtime_refs(pipeline_json, source_ids, target_refs)

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -1840,9 +1840,80 @@ def test_pipeline_add_json_file(tmp_path, cli_init_patch, capsys):
     verify_db = Database(db_path)
     asyncio.run(verify_db.initialize())
     pipelines = asyncio.run(verify_db.repos.content_pipelines.get_all())
+    # #1246: the --json-file path built target_refs as dicts but import_json only
+    # accepted "phone|dialog_id" strings, so targets were silently dropped; and
+    # is_active was hard-coded False, so a `pipeline add` without --inactive left
+    # the pipeline inactive. Guard both: targets must survive and be active.
+    targets = asyncio.run(verify_db.repos.content_pipelines.list_targets(pipelines[0].id))
     asyncio.run(verify_db.close())
     assert len(pipelines) == 1
     assert pipelines[0].pipeline_json is not None
+    assert len(targets) == 1
+    assert targets[0].phone == "+100"
+    assert targets[0].dialog_id == 77
+    assert pipelines[0].is_active is True
+
+
+def test_pipeline_add_json_file_inactive(tmp_path, cli_init_patch, capsys):
+    """--json-file with --inactive keeps the imported pipeline inactive (#1246)."""
+    import json
+
+    db_path = str(tmp_path / "cli_pipeline_add_json_inactive.db")
+    db = Database(db_path)
+    asyncio.run(db.initialize())
+    _add_pipeline_prereqs(db)
+
+    graph_data = {
+        "nodes": [
+            {"id": "s", "type": "source", "name": "src", "config": {}},
+            {"id": "f", "type": "fetch_messages", "name": "fetch", "config": {}},
+            {"id": "p", "type": "publish", "name": "pub", "config": {}},
+        ],
+        "edges": [
+            {"from_node": "s", "to_node": "f"},
+            {"from_node": "f", "to_node": "p"},
+        ],
+    }
+    json_path = str(tmp_path / "graph.json")
+    with open(json_path, "w") as f:
+        json.dump(graph_data, f)
+
+    with cli_init_patch(db, *_PIPELINE_INIT_DB_TARGETS):
+        from src.cli.commands.pipeline import run
+
+        run(
+            _ns(
+                pipeline_action="add",
+                name="JsonFileInactive",
+                prompt_template=None,
+                source=[1001],
+                target=["+100|77"],
+                llm_model=None,
+                image_model=None,
+                publish_mode="moderated",
+                generation_backend="chain",
+                interval=60,
+                inactive=True,
+                json_file=json_path,
+                node_specs=None,
+                edge=None,
+                node_configs=None,
+            )
+        )
+
+    asyncio.run(db.close())
+    out = capsys.readouterr().out
+    assert "Added pipeline id=" in out
+
+    verify_db = Database(db_path)
+    asyncio.run(verify_db.initialize())
+    pipelines = asyncio.run(verify_db.repos.content_pipelines.get_all())
+    targets = asyncio.run(verify_db.repos.content_pipelines.list_targets(pipelines[0].id))
+    asyncio.run(verify_db.close())
+    assert len(pipelines) == 1
+    # Targets still survive even when inactive (bug 1 is independent of --inactive).
+    assert len(targets) == 1
+    assert pipelines[0].is_active is False
 
 
 # ── Issue #463: runs/run-show semantic display ───────────────────────────────

--- a/tests/test_pipeline_service_edge_cases.py
+++ b/tests/test_pipeline_service_edge_cases.py
@@ -551,6 +551,76 @@ async def test_import_json_with_target_refs(svc, pipeline_id):
 
 
 @pytest.mark.anyio
+async def test_import_json_accepts_dict_target_refs(svc):
+    """#1246 bug 1: target_refs given as dicts (the shape `pipeline add --json-file`
+    builds) must be honoured, not silently dropped. The old string-only filter
+    left the imported pipeline with zero targets."""
+    data = {
+        "name": "DictTargets",
+        "prompt_template": "Summarize {source_messages}",
+        "source_ids": [1001],
+        "target_refs": [{"phone": "+100", "dialog_id": 77}],
+        "generate_interval_minutes": 30,
+    }
+    new_id = await svc.import_json(data)
+    targets = await svc.get_targets(new_id)
+    assert len(targets) == 1
+    assert targets[0].phone == "+100"
+    assert targets[0].dialog_id == 77
+
+
+@pytest.mark.anyio
+async def test_import_json_accepts_string_target_refs(svc):
+    """The legacy 'phone|dialog_id' string form (what export_json emits) still works."""
+    data = {
+        "name": "StringTargets",
+        "prompt_template": "Summarize {source_messages}",
+        "source_ids": [1001],
+        "target_refs": ["+100|77"],
+        "generate_interval_minutes": 30,
+    }
+    new_id = await svc.import_json(data)
+    targets = await svc.get_targets(new_id)
+    assert len(targets) == 1
+    assert targets[0].dialog_id == 77
+
+
+@pytest.mark.anyio
+async def test_import_json_honours_is_active_true(svc):
+    """#1246 bug 2: import_json hard-coded is_active=False, so a payload asking for
+    an active pipeline (the CLI passes is_active=not --inactive) was ignored and
+    the pipeline never ran. It must now honour an explicit is_active."""
+    data = {
+        "name": "ActiveImport",
+        "prompt_template": "Summarize {source_messages}",
+        "source_ids": [1001],
+        "target_refs": [{"phone": "+100", "dialog_id": 77}],
+        "generate_interval_minutes": 30,
+        "is_active": True,
+    }
+    new_id = await svc.import_json(data)
+    imported = await svc.get(new_id)
+    assert imported is not None
+    assert imported.is_active is True
+
+
+@pytest.mark.anyio
+async def test_import_json_is_active_defaults_false(svc):
+    """A payload without is_active (a plain export->import round-trip) stays inactive."""
+    data = {
+        "name": "DefaultInactive",
+        "prompt_template": "Summarize {source_messages}",
+        "source_ids": [1001],
+        "target_refs": [{"phone": "+100", "dialog_id": 77}],
+        "generate_interval_minutes": 30,
+    }
+    new_id = await svc.import_json(data)
+    imported = await svc.get(new_id)
+    assert imported is not None
+    assert imported.is_active is False
+
+
+@pytest.mark.anyio
 async def test_import_json_with_invalid_pipeline_graph(svc, pipeline_id):
     """Import with unparsable pipeline_json field -- should be ignored gracefully."""
     export = await svc.export_json(pipeline_id)


### PR DESCRIPTION
## Problem

`pipeline add NAME --json-file graph.json --target PHONE|DIALOG_ID` printed `Added pipeline id=N`, but the created pipeline had **zero targets** and was **inactive**, so generation never ran. Two independent bugs in `PipelineService.import_json` (`src/services/pipeline_service.py`):

### Bug 1 — targets silently dropped
The target-ref loop only accepted `"phone|dialog_id"` **strings**:

```python
if isinstance(ref, str) and "|" in ref:
```

But the CLI `--json-file` path builds `target_refs` as **dicts** (`{"phone": ..., "dialog_id": ...}`), so every ref was skipped and the pipeline ended up with no targets.

### Bug 2 — pipeline never activated
`is_active` was hard-coded to `False`, so the `--inactive` flag was accepted but ignored — a `pipeline add` without `--inactive` still produced an inactive pipeline.

## Fix

- New `_coerce_target_ref` helper normalises **both** the `"phone|dialog_id"` string form (what `export_json` emits) and the `{"phone", "dialog_id"}` dict form (what the CLI builds) into a `PipelineTargetRef`; unparseable refs are skipped.
- `import_json` now reads `is_active` from the payload, defaulting to `False` so a plain export→import round-trip stays inactive (`export_json` never emits `is_active`).
- `_pipeline_add_from_json` passes `is_active=not args.inactive`.

The fix lives in `import_json`, so **both** surfaces are covered: the CLI `--json-file` path and the agent `import_pipeline_json` tool (`src/agent/tools/pipeline_templates.py`), which share the same method.

## Tests (mutation-verified red without each fix)

- `test_pipeline_service_edge_cases.py`: dict target refs accepted, legacy string refs still accepted, `is_active` honoured when true, defaults false on round-trip.
- `test_pipeline_cli.py`: extended `test_pipeline_add_json_file` to assert targets survive and the pipeline is active; new `test_pipeline_add_json_file_inactive` for the `--inactive` path.

All 210 tests across the four pipeline test files pass; `ruff check src/ tests/ conftest.py` clean.

Refs #1234
Closes #1246

🤖 Generated with [Claude Code](https://claude.com/claude-code)