### PR TITLE
fix(agent): route save_scheduler_settings through scheduler.reconcile (#1266)

### DIFF
--- a/src/agent/tools/settings.py
+++ b/src/agent/tools/settings.py
@@ -9,6 +9,7 @@ from claude_agent_sdk import tool
 
 from src.agent.tools._categories import ToolCategory, ToolMeta
 from src.agent.tools._registry import _text_response, require_confirmation
+from src.services.telegram_command_service import TelegramCommandService
 
 # Permission metadata for this module's tools (#245). Single source of
 # truth: permissions.py derives TOOL_CATEGORIES / MODULE_GROUPS /
@@ -27,7 +28,10 @@ TOOL_GROUPS: list[tuple[str, dict[str, ToolMeta]]] = [
 ]
 
 def register(db, client_pool, embedding_service, **kwargs):
-    scheduler_manager = kwargs.get("scheduler_manager")
+    # scheduler_manager (a read-only snapshot shim in web-mode) is no longer used here:
+    # save_scheduler_settings enqueues a scheduler.reconcile command for the worker instead
+    # of calling the no-op shim (#1266). register() still accepts **kwargs for parity with
+    # the other tool modules.
     tools = []
 
     @tool("get_settings", "Get current system settings (scheduler, agent, filters, etc.)", {})
@@ -117,8 +121,18 @@ def register(db, client_pool, embedding_service, **kwargs):
             interval = int(args.get("collect_interval_minutes", 60))
             interval = max(1, min(1440, interval))
             await db.set_setting("collect_interval_minutes", str(interval))
-            if scheduler_manager is not None:
-                scheduler_manager.update_interval(interval)
+            # In web-mode ``scheduler_manager`` is the read-only ``SnapshotSchedulerManager``
+            # shim whose ``update_interval`` is a no-op — the live ``SchedulerManager`` runs in
+            # the separate worker container. Enqueue a ``scheduler.reconcile`` command so the
+            # worker re-reads ``collect_interval_minutes`` and rebuilds its IntervalTrigger,
+            # exactly like the web settings route does (#1266, matching #1236/#1247 via #1257).
+            # ``enqueue`` deduplicates on (type, payload), so repeated reconciles collapse into
+            # one pending command.
+            await TelegramCommandService(db).enqueue(
+                "scheduler.reconcile",
+                payload={},
+                requested_by="agent:save_scheduler_settings",
+            )
             return _text_response(f"Интервал сбора установлен: {interval} мин.")
         except Exception as e:
             return _text_response(f"Ошибка сохранения настроек планировщика: {e}")

--- a/tests/test_agent_tools_settings.py
+++ b/tests/test_agent_tools_settings.py
@@ -1,7 +1,7 @@
 """Tests for agent tools: settings.py."""
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -140,6 +140,22 @@ class TestSaveFilterSettingsTool:
         mock_db.set_setting.assert_any_call("low_uniqueness_threshold", "0.3")
 
 
+def _mock_command_service(mock_db):
+    """Stub ``db.repos.telegram_commands`` so ``TelegramCommandService.enqueue`` works.
+
+    ``save_scheduler_settings`` constructs ``TelegramCommandService(db)`` and calls
+    ``enqueue`` — which reaches into ``db.repos.telegram_commands``. Wire the two repo
+    methods enqueue touches (dedup lookup + insert) so the tool runs against the mock_db.
+    Returns the ``telegram_commands`` repo mock for assertions.
+    """
+    repo = MagicMock()
+    repo.find_active_by_type = AsyncMock(return_value=None)
+    repo.create_command = AsyncMock(return_value=7)
+    mock_db.repos = MagicMock()
+    mock_db.repos.telegram_commands = repo
+    return repo
+
+
 class TestSaveSchedulerSettingsTool:
     @pytest.mark.anyio
     async def test_requires_confirm(self, mock_db):
@@ -150,6 +166,7 @@ class TestSaveSchedulerSettingsTool:
     @pytest.mark.anyio
     async def test_saves_interval(self, mock_db):
         mock_db.set_setting = AsyncMock()
+        _mock_command_service(mock_db)
         handlers = _get_tool_handlers(mock_db)
         result = await handlers["save_scheduler_settings"](
             {"collect_interval_minutes": 30, "confirm": True}
@@ -160,6 +177,7 @@ class TestSaveSchedulerSettingsTool:
     @pytest.mark.anyio
     async def test_clamps_interval_to_range(self, mock_db):
         mock_db.set_setting = AsyncMock()
+        _mock_command_service(mock_db)
         handlers = _get_tool_handlers(mock_db)
         # Test lower bound
         result = await handlers["save_scheduler_settings"](
@@ -172,6 +190,87 @@ class TestSaveSchedulerSettingsTool:
             {"collect_interval_minutes": 2000, "confirm": True}
         )
         assert "1440 мин" in _text(result)
+
+    # --- #1266: web-mode scheduler mutation must reach the worker via a command ---
+
+    @pytest.mark.anyio
+    async def test_enqueues_scheduler_reconcile(self, mock_db):
+        """The tool must enqueue a ``scheduler.reconcile`` command, not poke a no-op shim.
+
+        In web-mode the injected scheduler_manager is the read-only snapshot shim; the
+        live SchedulerManager lives in the worker. The only way a chat-driven interval
+        change reaches it is a ``scheduler.reconcile`` telegram command. Regression guard
+        for #1266 — mutation-red: without the enqueue, ``create_command`` is never awaited.
+        """
+        mock_db.set_setting = AsyncMock()
+        repo = _mock_command_service(mock_db)
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["save_scheduler_settings"](
+            {"collect_interval_minutes": 30, "confirm": True}
+        )
+        assert "30 мин" in _text(result)
+        # dedup lookup + insert are both against command_type "scheduler.reconcile"
+        repo.find_active_by_type.assert_awaited_once()
+        assert repo.find_active_by_type.await_args.args[0] == "scheduler.reconcile"
+        repo.create_command.assert_awaited_once()
+        created = repo.create_command.await_args.args[0]
+        assert created.command_type == "scheduler.reconcile"
+        assert created.payload == {}
+
+    @pytest.mark.anyio
+    async def test_interval_saved_before_reconcile(self, mock_db):
+        """The interval must be persisted before the reconcile is enqueued.
+
+        The worker's ``_handle_scheduler_reconcile`` re-reads ``collect_interval_minutes``
+        from the DB, so the write must land first or the reconcile would rebuild the
+        trigger from the stale value.
+        """
+        calls: list[str] = []
+        mock_db.set_setting = AsyncMock(side_effect=lambda *a, **k: calls.append("set_setting"))
+        repo = _mock_command_service(mock_db)
+        repo.create_command = AsyncMock(side_effect=lambda *a, **k: calls.append("enqueue") or 7)
+        handlers = _get_tool_handlers(mock_db)
+        await handlers["save_scheduler_settings"]({"collect_interval_minutes": 45, "confirm": True})
+        assert calls == ["set_setting", "enqueue"]
+
+    @pytest.mark.anyio
+    async def test_no_confirm_does_not_enqueue(self, mock_db):
+        """The confirm gate must fire before any DB write or enqueue."""
+        mock_db.set_setting = AsyncMock()
+        repo = _mock_command_service(mock_db)
+        handlers = _get_tool_handlers(mock_db)
+        result = await handlers["save_scheduler_settings"]({"collect_interval_minutes": 30})
+        assert "confirm=true" in _text(result).lower()
+        mock_db.set_setting.assert_not_awaited()
+        repo.create_command.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_enqueues_reconcile_row_in_real_db(self, db):
+        """Integration guard: a real ``scheduler.reconcile`` row lands in telegram_commands.
+
+        Mirrors the web-route contract from #1257 (``tests/test_web_scheduler_reconcile_enqueue.py``)
+        but drives the agent tool against a real in-memory Database instead of the web app.
+        """
+        handlers = _get_tool_handlers(db)
+        result = await handlers["save_scheduler_settings"](
+            {"collect_interval_minutes": 90, "confirm": True}
+        )
+        assert "90 мин" in _text(result)
+        assert await db.get_setting("collect_interval_minutes") == "90"
+        commands = await db.repos.telegram_commands.list_commands(command_type="scheduler.reconcile")
+        assert len(commands) == 1
+        assert commands[0].payload == {}
+
+    @pytest.mark.anyio
+    async def test_repeated_saves_dedup_into_one_reconcile(self, db):
+        """``enqueue`` deduplicates on (type, payload), so repeated saves collapse to one row."""
+        handlers = _get_tool_handlers(db)
+        await handlers["save_scheduler_settings"]({"collect_interval_minutes": 30, "confirm": True})
+        await handlers["save_scheduler_settings"]({"collect_interval_minutes": 45, "confirm": True})
+        commands = await db.repos.telegram_commands.list_commands(command_type="scheduler.reconcile")
+        assert len(commands) == 1
+        # Latest interval still persisted even though the reconcile command was reused.
+        assert await db.get_setting("collect_interval_minutes") == "45"
 
 
 class TestGetSystemInfoTool:


### PR DESCRIPTION
## Summary

`save_scheduler_settings` (agent chat tool, `src/agent/tools/settings.py`) persisted `collect_interval_minutes` and then called `scheduler_manager.update_interval(interval)` **only when `scheduler_manager is not None`**. In **web-mode** (agent chat in the UI under the default `serve`) the scheduler is the read-only `SnapshotSchedulerManager` shim (or `None`), whose `update_interval` is a no-op — the live `SchedulerManager` runs in the separate worker container.

Effect: an operator changing the collect interval via agent chat got a success message and the setting was written, but the running worker `IntervalTrigger` kept its old cadence until the worker restarted. Same symptom as #1247, reached via the agent-tool route instead of the Settings page.

## Fix

After persisting the interval, the tool now enqueues a `scheduler.reconcile` telegram command via `TelegramCommandService`, exactly like the four routes in `src/web/scheduler/handlers.py` and the web settings route in #1257. The worker's `_handle_scheduler_reconcile` re-reads `collect_interval_minutes` and rebuilds its trigger. `enqueue` deduplicates on `(type, payload)`, so repeated reconciles collapse into one pending command.

The now-unused `scheduler_manager` kwarg is dropped from this module's `register()` body; `register()` still accepts `**kwargs` for parity with the other tool modules.

## Reference / relationship

- Epic **#1234** (scheduler no-op-shim bug class).
- **#1257** (`fix(web): route scheduler mutations through reconcile command`, for #1236/#1247) is the reference for the web-route pattern. Note its `enqueue_scheduler_reconcile` helper (`src/web/scheduler/commands.py`) **is not yet on main**, so this PR uses the underlying `TelegramCommandService.enqueue` primitive directly — the same contract as `enqueue_scheduler_command` already on `main`. No dependency on the unmerged branch.

## Out of scope

The issue also suggests auditing search-query / pipeline agent write-tools for the same gap. Kept the diff to `settings.py` (+ its test) per the task scope; that audit is a separate follow-up.

## Tests

Regression guards in `tests/test_agent_tools_settings.py`, **proven mutation-red** (reverting the enqueue makes 4 guards fail):

- unit (mock repo): `scheduler.reconcile` enqueued with empty payload; interval persisted before enqueue; confirm gate blocks any write/enqueue.
- integration (real in-memory DB): a `scheduler.reconcile` row lands in `telegram_commands`; repeated saves dedup to one row — mirroring #1257's `tests/test_web_scheduler_reconcile_enqueue.py`.

`ruff check src/ tests/ conftest.py` clean; `lint-imports` contract KEPT; 49 tests in the two target files + 215 in permission/settings-path suites pass.

Closes #1266

🤖 Generated with [Claude Code](https://claude.com/claude-code)