### PR TITLE
chore(mypy): type telegram & shared utils (src/ 42 -> 30)

### DIFF
--- a/src/search/telegram_search.py
+++ b/src/search/telegram_search.py
@@ -552,6 +552,9 @@ class TelegramSearch:
                         )
                         username = ch_record.username if ch_record else None
                         if username:
+                            # _acquire_search_client yields an error result when the
+                            # pool is missing, so a live client implies a live pool.
+                            assert self._pool is not None
                             try:
                                 entity = await self._pool.run_live_username_resolve(
                                     lambda: session.resolve_entity(username),

--- a/src/settings_utils.py
+++ b/src/settings_utils.py
@@ -14,7 +14,8 @@ def parse_int_setting(
     if raw_value in (None, ""):
         return default
     try:
-        return int(raw_value)
+        # int() raising TypeError on unsupported objects is the handled path below.
+        return int(raw_value)  # type: ignore[call-overload]
     except (TypeError, ValueError):
         logger.warning("Invalid %s in settings DB (%r), using %d", setting_name, raw_value, default)
         return default
@@ -30,7 +31,8 @@ def parse_float_setting(
     if raw_value in (None, ""):
         return default
     try:
-        value = float(raw_value)
+        # float() raising TypeError on unsupported objects is the handled path below.
+        value = float(raw_value)  # type: ignore[arg-type]
         # float("nan")/float("inf") parse without raising; reject them so callers
         # that int()-coerce or clamp the result don't crash or propagate NaN.
         if not math.isfinite(value):

--- a/src/telegram/collector_mixins/cancellation.py
+++ b/src/telegram/collector_mixins/cancellation.py
@@ -32,6 +32,11 @@ logger = logging.getLogger("src.telegram.collector")
 
 
 class CancellationMixin:
+    # Declared here so the runtime Collector's __init__ annotation (which widens the
+    # second element to ``str | int | None`` and allows ``None``) matches the type
+    # mypy would otherwise infer from the assignments in this mixin.
+    _last_unavailability_log: tuple[str, str | int | None, datetime | None] | None
+
     def _get_resolve_username_backoff_remaining_sec(self: "Collector", phone: str | None = None) -> int:
         # The pool owns the single source of truth for the resolve backoff
         # (#785). With ``phone`` — that account's window; without — the
@@ -168,7 +173,9 @@ class CancellationMixin:
         retry_after_sec = getattr(availability, "retry_after_sec", None)
         if getattr(availability, "state", None) != "all_flooded":
             return False
-        if not is_transient_flood_wait_seconds(retry_after_sec):
+        # Explicit None check narrows for the int() below; is_transient_flood_wait_seconds
+        # already returns False for None, so behavior is unchanged.
+        if retry_after_sec is None or not is_transient_flood_wait_seconds(retry_after_sec):
             return False
         await sleep_for_flood_wait_seconds(
             int(retry_after_sec),

--- a/src/telegram/flood_wait.py
+++ b/src/telegram/flood_wait.py
@@ -34,7 +34,7 @@ class HandledFloodWaitError(RuntimeError):
         self.info = info
 
 
-def coerce_flood_wait_seconds(value: object) -> int:
+def coerce_flood_wait_seconds(value: int | float | str | None) -> int:
     return max(1, int(value or 0))
 
 

--- a/src/telegram/identity.py
+++ b/src/telegram/identity.py
@@ -34,7 +34,8 @@ def _int_value(value: object) -> int | None:
     if value is None or isinstance(value, Mock) or isinstance(value, bool):
         return None
     try:
-        return int(value)
+        # int() raising TypeError on unsupported objects is the handled path below.
+        return int(value)  # type: ignore[call-overload]
     except (TypeError, ValueError):
         return None
 

--- a/src/telegram/resolve_guard.py
+++ b/src/telegram/resolve_guard.py
@@ -4,6 +4,7 @@ import json
 import logging
 from collections.abc import Awaitable, Callable, Iterable
 from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING, cast
 
 from src.telegram.flood_wait import HandledFloodWaitError, run_with_flood_wait
 from src.telegram.rate_limiter import (
@@ -11,6 +12,16 @@ from src.telegram.rate_limiter import (
     ResolveRateLimiter,
     UsernameResolveRateLimitedError,
 )
+
+if TYPE_CHECKING:
+    from typing import Protocol
+
+    class _SettingsStore(Protocol):
+        """Structural view of the ``db`` argument: only the settings get/set pair."""
+
+        async def get_setting(self, key: str) -> str | None: ...
+        async def set_setting(self, key: str, value: str) -> None: ...
+
 
 logger = logging.getLogger(__name__)
 
@@ -245,8 +256,11 @@ class ResolveGuardMixin:
         backoff is conservatively applied to every known phone, re-persisted
         in the per-phone format, and the legacy key is cleared.
         """
+        # ``db`` stays ``object`` (pool_lifecycle mirrors this signature); the cast
+        # only gives mypy the settings get/set pair actually used here.
+        store = cast("_SettingsStore", db)
         try:
-            value = await db.get_setting(RESOLVE_BACKOFF_BY_PHONE_SETTING)
+            value = await store.get_setting(RESOLVE_BACKOFF_BY_PHONE_SETTING)
         except Exception:
             return
         if value:
@@ -262,7 +276,7 @@ class ResolveGuardMixin:
                 return
         # Legacy single-deadline migration (pre-#790).
         try:
-            legacy_value = await db.get_setting(RESOLVE_BACKOFF_LEGACY_SETTING)
+            legacy_value = await store.get_setting(RESOLVE_BACKOFF_LEGACY_SETTING)
         except Exception:
             return
         if not legacy_value:
@@ -277,11 +291,11 @@ class ResolveGuardMixin:
         for phone in phone_list:
             self._restore_resolve_backoff_entry(phone, until)
         try:
-            await db.set_setting(
+            await store.set_setting(
                 RESOLVE_BACKOFF_BY_PHONE_SETTING,
                 json.dumps({phone: until.isoformat() for phone in phone_list}),
             )
-            await db.set_setting(RESOLVE_BACKOFF_LEGACY_SETTING, "")
+            await store.set_setting(RESOLVE_BACKOFF_LEGACY_SETTING, "")
         except Exception:
             logger.debug("Failed to migrate legacy resolve backoff", exc_info=True)
 

--- a/src/utils/datetime.py
+++ b/src/utils/datetime.py
@@ -1,6 +1,15 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import overload
+
+
+@overload
+def normalize_utc(value: datetime) -> datetime: ...
+@overload
+def normalize_utc(value: None) -> None: ...
+@overload
+def normalize_utc(value: datetime | None) -> datetime | None: ...
 
 
 def normalize_utc(value: datetime | None) -> datetime | None:


### PR DESCRIPTION
Part of #1133 (mypy debt reduction axis).

## mypy delta

`python -m mypy src/`: **42 errors -> 30 errors** (−12). No new errors in untouched files (verified against per-file baseline).

| File | Errors before | After |
|---|---|---|
| src/settings_utils.py | 2 | 0 |
| src/telegram/resolve_guard.py | 4 | 0 |
| src/telegram/identity.py | 1 | 0 |
| src/telegram/flood_wait.py | 1 | 0 |
| src/telegram/collector.py + collector_mixins/cancellation.py | 2 | 0 |
| src/search/telegram_search.py | 1 | 0 |
| src/utils/datetime.py | 1 | 0 |

## Changes (typing-only, no runtime behavior change)

- **settings_utils / identity**: targeted `# type: ignore[call-overload|arg-type]` on `int()`/`float()` coerce-and-catch sites — `TypeError` is the handled path in the existing `except`; same pattern as `runtime_diagnostics.py:70`.
- **flood_wait**: `coerce_flood_wait_seconds` param narrowed `object` -> `int | float | str | None`; both callers pass `getattr(exc, "seconds", 0)`.
- **resolve_guard**: TYPE_CHECKING `_SettingsStore` Protocol + `cast` inside `restore_resolve_username_backoff`; the `db: object` signature is kept intact because the pool_lifecycle stub mirrors it verbatim (changing it there is out of scope — #1270 zone).
- **cancellation mixin**: explicit class-level `_last_unavailability_log` declaration matching the runtime `Collector.__init__` annotation; explicit `is None` narrowing before `int(retry_after_sec)` (the helper already returned False for None — identical behavior).
- **telegram_search**: `assert self._pool is not None` before `run_live_username_resolve` — `_acquire_search_client` yields an error result when the pool is missing, so a live client implies a live pool.
- **utils/datetime**: `@overload` set on `normalize_utc` so `parse_required_utc_datetime` returns non-optional `datetime`.

## Verification

- `ruff check src/ tests/ conftest.py` — clean
- `python -m mypy src/` — 30 errors (was 42), untouched files unchanged
- `pytest tests/test_settings_utils.py tests/test_flood_wait.py tests/test_utils_datetime.py tests/test_client_pool_resolve_guard.py tests/test_collector.py tests/test_collector_internals.py tests/test_search.py` — **203 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ExCZyXkbUpTkRRrQrFA2