### PR TITLE
fix: CircuitBreaker opens against a healthy provider (cumulative vs consecutive failures)

### DIFF
--- a/src/services/error_recovery_service.py
+++ b/src/services/error_recovery_service.py
@@ -144,12 +144,20 @@ class CircuitBreaker:
             return True, self._state.state
 
     async def record_success(self) -> None:
-        """Record a successful execution."""
+        """Record a successful execution.
+
+        In the closed state a success resets ``failure_count`` so the breaker
+        counts CONSECUTIVE failures, not cumulative ones — transient errors
+        that are each recovered by a retry must never add up to the threshold
+        over the breaker's lifetime (issue #1251).
+        """
         async with self._lock:
             if self._state.state == "half_open":
                 self._state.failure_count = 0
                 self._state.half_open_calls = 0
                 self._state.state = "closed"
+            elif self._state.state == "closed":
+                self._state.failure_count = 0
 
     async def record_failure(self) -> None:
         """Record a failed execution."""

--- a/tests/test_error_recovery_service.py
+++ b/tests/test_error_recovery_service.py
@@ -279,6 +279,28 @@ async def test_circuit_breaker_opens_after_threshold():
 
 
 @pytest.mark.anyio
+async def test_recovered_failures_do_not_open_circuit():
+    """Failures each followed by a success must not open the breaker (#1251).
+
+    The breaker counts CONSECUTIVE failures: a success in the closed state
+    resets the counter, so transient errors that are each recovered by a
+    retry never accumulate up to the threshold over the service's lifetime.
+    """
+    breaker = CircuitBreaker(
+        CircuitBreakerConfig(failure_threshold=5, recovery_timeout=60.0)
+    )
+
+    for _ in range(5):
+        await breaker.record_failure()
+        await breaker.record_success()
+
+    allowed, state = await breaker.can_execute()
+    assert allowed is True
+    assert state == "closed"
+    assert breaker.get_state()["failure_count"] == 0
+
+
+@pytest.mark.anyio
 async def test_retry_policy_with_jitter():
     """Test retry policy calculates delay with jitter."""
     policy = RetryPolicy(max_retries=3, base_delay=1.0, jitter=True)


### PR DESCRIPTION
## Summary

From code review #1234 (finding #14), issue #1251.

`CircuitBreaker.record_success` reset `failure_count` only in the `half_open` state. In the `closed` state every `record_failure` incremented the counter and a subsequent success never reset it, so the breaker counted **cumulative** failures over its whole lifetime instead of **consecutive** ones. Five transient errors — each successfully recovered by a retry — spread over the lifetime of a process-wide `ErrorRecoveryService` were enough to open the circuit against a perfectly healthy provider, producing "Circuit breaker is open" errors in 60-second windows. The code comment promises the breaker "trips after 5 consecutive provider failures".

## Fix

`record_success` in the `closed` state now also resets `failure_count` to 0, so only an unbroken run of failures can reach the threshold. The `half_open` branch is untouched (it keeps its own reset of `failure_count`, `half_open_calls`, and the transition to `closed`); a success while `open` still changes nothing.

## Tests

- New regression guard `test_recovered_failures_do_not_open_circuit`: 5 failures, each followed by a success, must NOT open the breaker. Mutation-verified: on the pre-fix code the test fails (breaker opens, `can_execute` returns `False`); with the fix it passes.
- Existing `test_circuit_breaker_opens_after_threshold` (threshold reached with no intervening successes → opens) still passes, as do the half_open transition tests.
- Full `tests/test_error_recovery_service.py`: 31 passed. All other test files referencing CircuitBreaker/error_recovery (integration, generation, notifier, debug routes/CLI): 229 passed.
- `ruff check src/ tests/ conftest.py` clean.

Closes #1251

Related: #1234

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AztVXwNWL7dQAciRMc1pig