### PR TITLE
chore(mypy): type database layer (src/ 42 -> 29)

### DIFF
--- a/src/database/connection.py
+++ b/src/database/connection.py
@@ -5,6 +5,7 @@ import os
 import time
 from dataclasses import dataclass
 from pathlib import Path
+from typing import cast
 
 import aiosqlite
 
@@ -177,4 +178,5 @@ class DBConnection:
 
     async def execute_fetchall(self, sql: str, params: tuple = ()) -> list:
         assert self.db is not None
-        return await self.db.execute_fetchall(sql, params)
+        # aiosqlite stubs declare Iterable[Row]; at runtime this is a list.
+        return cast(list, await self.db.execute_fetchall(sql, params))

--- a/src/database/facade.py
+++ b/src/database/facade.py
@@ -273,20 +273,22 @@ class Database:
         Not reentrant — nesting would deadlock asyncio.Lock.
         """
         assert self._db is not None
+        # Local binding keeps the narrowed (non-optional) type visible inside the lambda.
+        db = self._db
         async with self._write_lock:
             await self._with_busy_retry(
                 "transaction begin",
-                lambda: begin_immediate(self._db),
+                lambda: begin_immediate(db),
             )
             committed = False
             try:
-                yield self._db
-                await self._db.execute("COMMIT")
+                yield db
+                await db.execute("COMMIT")
                 committed = True
             finally:
                 if not committed:
                     try:
-                        await self._db.execute("ROLLBACK")
+                        await db.execute("ROLLBACK")
                     except aiosqlite.OperationalError:
                         pass
 
@@ -578,7 +580,7 @@ class Database:
         if existing:
             return existing["id"]
         try:
-            cur = await self.execute_write(
+            write_cur = await self.execute_write(
                 """
                 INSERT INTO channel_rename_events
                     (channel_id, old_title, new_title, old_username, new_username)
@@ -586,7 +588,7 @@ class Database:
                 """,
                 (channel_id, old_title, new_title, old_username, new_username),
             )
-            return cur.lastrowid or 0
+            return write_cur.lastrowid or 0
         except sqlite3.IntegrityError:
             # Concurrent INSERT won the race; re-select the existing row
             cur = await self._read(

--- a/src/database/migrations.py
+++ b/src/database/migrations.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Mapping, Sequence
 from pathlib import Path
+from typing import cast
 
 import aiosqlite
 
@@ -242,7 +243,8 @@ async def _dedupe_primary_accounts(db: aiosqlite.Connection) -> None:
     if "is_primary" not in await table_columns(db, "accounts"):
         return
     cur = await db.execute("SELECT id FROM accounts WHERE is_primary = 1 ORDER BY id ASC")
-    rows = await cur.fetchall()
+    # aiosqlite stubs declare fetchall() as Iterable[Row]; at runtime it is a list.
+    rows = cast("list[aiosqlite.Row]", await cur.fetchall())
     if len(rows) <= 1:
         return
     keep_id = rows[0][0]

--- a/src/database/pool.py
+++ b/src/database/pool.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Sequence
 from contextlib import asynccontextmanager
-from typing import Any, AsyncIterator, Protocol
+from typing import Any, AsyncIterator, Protocol, cast
 
 import aiosqlite
 
@@ -167,13 +167,14 @@ class ReadPoolProxy:
         _reject_writes(sql)
         async with self._pool.acquire_read() as conn:
             cur = await conn.execute(sql, params)
-            # fetchall() returns a fresh owned list, so BufferedCursor can take it directly.
-            return BufferedCursor(await cur.fetchall())
+            # fetchall() returns a fresh owned list (stubs say Iterable[Row]), so
+            # BufferedCursor can take it directly.
+            return BufferedCursor(cast("list[Any]", await cur.fetchall()))
 
     async def execute_fetchall(self, sql: str, params: Sequence[Any] = ()) -> list[Any]:
         _reject_writes(sql)
         async with self._pool.acquire_read() as conn:
-            return await conn.execute_fetchall(sql, params)
+            return cast("list[Any]", await conn.execute_fetchall(sql, params))
 
     async def create_function(self, name: str, narg: int, func: Any, **kwargs: Any) -> None:
         """Register a UDF on every read connection (filter queries call this lazily)."""

--- a/src/database/repositories/collection_tasks.py
+++ b/src/database/repositories/collection_tasks.py
@@ -69,7 +69,7 @@ class CollectionTasksRepository:
     ) -> (
         dict[str, Any] | StatsAllTaskPayload | SqStatsTaskPayload | FilterAnalyzeTaskPayload
         | PipelineRunTaskPayload | ContentGenerateTaskPayload | ContentPublishTaskPayload
-        | TranslateBatchTaskPayload | None
+        | TranslateBatchTaskPayload | ExportTaskPayload | None
     ):
         if not raw:
             return None
@@ -109,6 +109,7 @@ class CollectionTasksRepository:
             | ContentGenerateTaskPayload
             | ContentPublishTaskPayload
             | TranslateBatchTaskPayload
+            | ExportTaskPayload
             | None
         ),
     ) -> str | None:

--- a/src/database/repositories/filters.py
+++ b/src/database/repositories/filters.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import aiosqlite
 
@@ -370,7 +370,8 @@ class FilterRepository:
         params: tuple = (),
     ) -> list[aiosqlite.Row]:
         cur = await conn.execute(sql, params)
-        return await cur.fetchall()
+        # aiosqlite stubs declare fetchall() as Iterable[Row]; at runtime it is a list.
+        return cast("list[aiosqlite.Row]", await cur.fetchall())
 
     async def fetch_maps_parallel(
         self,

--- a/src/database/repositories/messages.py
+++ b/src/database/repositories/messages.py
@@ -145,7 +145,7 @@ class MessagesRepository:
     async def get_embedding_dimensions(self) -> int | None:
         """Размерность векторов индекса эмбеддингов (из настроек), либо ``None`` если индекс ещё не создан."""
         raw_value = await self._get_setting(_EMBEDDING_DIMENSIONS_SETTING)
-        if raw_value in (None, ""):
+        if raw_value is None or raw_value == "":
             return None
         try:
             return int(raw_value)
@@ -1217,6 +1217,7 @@ class MessagesRepository:
             union_parts = []
             all_params: list = []
             for sq in chunk:
+                assert sq.id is not None  # ``valid`` filtered out None ids above
                 fts_query = self._build_fts_match(sq.query, sq.is_fts)
                 extra_conds, extra_params = self._build_extra_conditions(sq)
                 where_parts = [


### PR DESCRIPTION
Part of #1133 (mypy debt reduction axis). Independent sibling of #1275 (telegram utils) — disjoint files.

## mypy delta

`python -m mypy src/` on this branch: **42 errors -> 29 errors** (−13). No new errors in untouched files (verified against per-file baseline).

| File | Errors before | After |
|---|---|---|
| src/database/facade.py | 3 | 0 |
| src/database/migrations.py | 2 | 0 |
| src/database/pool.py | 2 | 0 |
| src/database/repositories/collection_tasks.py | 2 | 0 |
| src/database/repositories/messages.py | 2 | 0 |
| src/database/connection.py | 1 | 0 |
| src/database/repositories/filters.py | 1 | 0 |

## Changes (typing-only, no runtime behavior change)

- **migrations / connection / pool / repositories.filters**: `cast()` around `fetchall()` / `execute_fetchall()` results — aiosqlite stubs declare `Iterable[Row]` while the runtime value is a list; `cast` is a runtime no-op (no copy).
- **facade.transaction()**: bind the asserted connection to a local `db` so the narrowed non-optional type is visible inside the busy-retry lambda (mypy does not propagate attribute narrowing into closures).
- **facade.record_rename_event**: separate `write_cur` variable — the read path returns `BufferedCursor`, the write path `aiosqlite.Cursor` (which owns `lastrowid`).
- **repositories.collection_tasks**: add `ExportTaskPayload` to `_deserialize_payload` return union and `_serialize_payload` param union — both code paths already handle it at runtime (the `task_kind == EXPORT` parse branch and the `isinstance` tuple); this only aligns annotations with existing code. The interop payloads (#960 `DmReplyTaskPayload` etc.) stay excluded per the design note in models.py.
- **repositories.messages**: `is None or == ""` narrowing before `int()` (semantically identical to the tuple-membership check); `assert sq.id is not None` inside the chunk loop — `valid` pre-filters None ids two lines above.

## Verification

- `ruff check src/ tests/ conftest.py` — clean
- `python -m mypy src/` — 29 errors (was 42), untouched files unchanged
- `pytest tests/repositories/ tests/test_database.py tests/test_database_pool.py tests/test_database_write_lock.py tests/test_migrations.py tests/test_migrations_schema_paths.py` — **496 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ExCZyXkbUpTkRRrQrFA2