### PR TITLE
fix: daily cost cap exceeded by concurrent calls — atomic check-and-reserve (#1250)

### DIFF
--- a/src/services/image_generation_service.py
+++ b/src/services/image_generation_service.py
@@ -118,6 +118,7 @@ class ImageGenerationService:
                     retryable=True,
                 )
                 return None
+        result: str | None = None
         try:
             result = await adapter(text, model_id)
         except TimeoutError as exc:
@@ -125,7 +126,6 @@ class ImageGenerationService:
             self._last_failure = ImageGenerationFailure(
                 kind="timeout", provider=provider_name, model=model, message=str(exc),
             )
-            return None
         except Exception as exc:
             # OSError is an expected I/O failure — log calmly without a traceback;
             # anything else is unexpected and warrants the full stack.
@@ -136,10 +136,18 @@ class ImageGenerationService:
             self._last_failure = ImageGenerationFailure(
                 kind="error", provider=provider_name, model=model, message=str(exc),
             )
+        finally:
+            # Settle the budget reserved by acquire() exactly once (#1250): a paid
+            # generation books its cost; a failed/empty one (including cancellation,
+            # which skips the except clauses above) returns the reservation so the
+            # budget isn't held until the day rolls over.
+            if limits is not None:
+                if result:
+                    await limits.record_cost(is_image=True)
+                else:
+                    await limits.release_cost(is_image=True)
+        if result is None:
             return None
-        # The paid generation succeeded → record its cost against the daily cap.
-        if limits is not None and result:
-            await limits.record_cost(is_image=True)
         s3 = getattr(self, "_s3", None)
         if result and s3 is not None:
             if result.startswith("http"):

--- a/src/services/production_limits_service.py
+++ b/src/services/production_limits_service.py
@@ -163,6 +163,13 @@ class CostTracker:
     def __init__(self, config: CostConfig | None = None, db: "Database | None" = None):
         self._config = config or CostConfig()
         self._daily_cost = 0.0
+        # Estimated cost claimed by in-flight paid calls: added by reserve_cost
+        # BEFORE the provider call and removed by record_cost/release_cost after
+        # it, so concurrent callers can't all pass the cap check against the same
+        # pre-spend total (#1250). In-memory only — reservations guard concurrency
+        # within this process; cross-instance protection stays at the recorded
+        # spend level (#814).
+        self._reserved = 0.0
         self._day_start = time.time()
         self._lock = asyncio.Lock()
         # When a DB is provided, the daily cost is persisted to the settings table and
@@ -313,12 +320,24 @@ class CostTracker:
             return self._config.cost_per_image
         return (tokens / 1000) * self._config.cost_per_1k_tokens
 
+    async def _refresh_daily_cost(self, now: float) -> None:
+        """Bring ``self._daily_cost`` up to date. Must be called under self._lock."""
+        if self._db is not None:
+            # Re-read the authoritative total so a sibling instance's spend is
+            # seen before we approve another call against the shared cap (#814).
+            self._daily_cost = await self._read_persisted_cost(now)
+            self._loaded = True
+            return
+        await self._ensure_loaded()
+        if self._maybe_reset_day(now):
+            await self._persist()
+
     async def check_cost_cap(
         self,
         tokens: int = 0,
         is_image: bool = False,
     ) -> tuple[bool, float]:
-        """Check if request is within cost cap.
+        """Check if request is within cost cap (read-only, reserves nothing).
 
         Args:
             tokens: Number of tokens
@@ -328,28 +347,61 @@ class CostTracker:
             Tuple of (allowed, estimated_cost)
         """
         async with self._lock:
-            now = time.time()
-            if self._db is not None:
-                # Re-read the authoritative total so a sibling instance's spend is
-                # seen before we approve another call against the shared cap (#814).
-                self._daily_cost = await self._read_persisted_cost(now)
-                self._loaded = True
-            else:
-                await self._ensure_loaded()
-                if self._maybe_reset_day(now):
-                    await self._persist()
-
+            await self._refresh_daily_cost(time.time())
             estimated = await self.estimate_cost(tokens, is_image)
-
-            if self._daily_cost + estimated > self._config.daily_cost_cap:
+            if self._daily_cost + self._reserved + estimated > self._config.daily_cost_cap:
                 return False, estimated
-
             return True, estimated
 
-    async def record_cost(self, tokens: int = 0, is_image: bool = False) -> float:
-        """Record cost for a request after it actually executes."""
+    async def reserve_cost(
+        self,
+        tokens: int = 0,
+        is_image: bool = False,
+    ) -> tuple[bool, float]:
+        """Atomically check the cap AND reserve the estimated cost (#1250).
+
+        Claims budget under the same lock as the check, BEFORE the paid provider
+        call runs, so N concurrent callers can't all be approved against the same
+        pre-spend total while none of them has recorded anything yet. Every
+        successful reservation MUST be settled with exactly one of ``record_cost``
+        (call succeeded — books the actual spend) or ``release_cost`` (call failed
+        or never ran — returns the budget); otherwise the reserved budget stays
+        claimed until the day rolls over.
+
+        Returns:
+            Tuple of (reserved, estimated_cost)
+        """
+        async with self._lock:
+            await self._refresh_daily_cost(time.time())
+            estimated = await self.estimate_cost(tokens, is_image)
+            if self._daily_cost + self._reserved + estimated > self._config.daily_cost_cap:
+                return False, estimated
+            self._reserved += estimated
+            return True, estimated
+
+    async def release_cost(self, tokens: int = 0, is_image: bool = False) -> float:
+        """Release a reservation whose paid call failed or never ran (#1250).
+
+        Recomputes the same deterministic estimate as ``reserve_cost``, so for the
+        same arguments the released amount always matches the reservation. Clamped
+        at zero so an unpaired release cannot corrupt the ledger.
+        """
         async with self._lock:
             estimated = await self.estimate_cost(tokens, is_image)
+            self._reserved = max(0.0, self._reserved - estimated)
+            return estimated
+
+    async def record_cost(self, tokens: int = 0, is_image: bool = False) -> float:
+        """Record cost for a request after it actually executes.
+
+        Settles the matching ``reserve_cost`` reservation: the reservation (same
+        deterministic estimate for the same arguments) is dropped and the actual
+        cost is booked in its place. Also safe without a prior reservation — the
+        release is clamped at zero and only the spend is recorded.
+        """
+        async with self._lock:
+            estimated = await self.estimate_cost(tokens, is_image)
+            self._reserved = max(0.0, self._reserved - estimated)
             if self._db is None:
                 self._maybe_reset_day(time.time())
                 self._daily_cost += estimated
@@ -363,9 +415,13 @@ class CostTracker:
         """Get current daily cost."""
         return self._daily_cost
 
+    def get_reserved_cost(self) -> float:
+        """Get the estimated cost currently reserved by in-flight calls (#1250)."""
+        return self._reserved
+
     def get_remaining_budget(self) -> float:
-        """Get remaining daily budget."""
-        return max(0.0, self._config.daily_cost_cap - self._daily_cost)
+        """Get remaining daily budget, net of outstanding reservations."""
+        return max(0.0, self._config.daily_cost_cap - self._daily_cost - self._reserved)
 
 
 class ProductionLimitsService:
@@ -420,11 +476,17 @@ class ProductionLimitsService:
             is_image: Whether this is an image generation
             max_wait: Maximum wait time in seconds
 
+        On success the estimated cost is reserved against the daily cap, so the
+        caller MUST settle with exactly one of ``record_cost`` (paid call
+        succeeded) or ``release_cost`` (paid call failed or never ran) — otherwise
+        the reserved budget stays claimed until the day rolls over (#1250).
+
         Returns:
             Tuple of (allowed, error_message)
         """
-        # Check cost cap first
-        cost_allowed, estimated_cost = await self._cost_tracker.check_cost_cap(
+        # Atomically check the cost cap and reserve the estimated cost, so N
+        # concurrent calls can't all pass against the same pre-spend total (#1250).
+        cost_allowed, estimated_cost = await self._cost_tracker.reserve_cost(
             tokens, is_image
         )
         if not cost_allowed:
@@ -435,6 +497,8 @@ class ProductionLimitsService:
             tokens, is_image, max_wait
         )
         if not rate_allowed:
+            # The paid call won't run — return the reserved budget.
+            await self._cost_tracker.release_cost(tokens, is_image)
             return False, "Rate limit timeout"
 
         return True, None
@@ -443,10 +507,19 @@ class ProductionLimitsService:
         """Record the actual cost of a completed call against the daily cap.
 
         Pair with ``acquire`` for call sites that don't use ``execute_with_retry``
-        (e.g. image generation): ``acquire`` reserves the rate slot and checks the
-        cap, ``record_cost`` books the spend once the paid call has succeeded.
+        (e.g. image generation): ``acquire`` reserves the estimated cost and the
+        rate slot, ``record_cost`` settles the reservation into booked spend once
+        the paid call has succeeded.
         """
         return await self._cost_tracker.record_cost(tokens, is_image)
+
+    async def release_cost(self, tokens: int = 0, is_image: bool = False) -> float:
+        """Release the cost reservation taken by ``acquire`` (#1250).
+
+        Call when the paid call failed or never ran, so the reserved budget does
+        not stay claimed (blocking other callers) until the day rolls over.
+        """
+        return await self._cost_tracker.release_cost(tokens, is_image)
 
     async def execute_with_retry(
         self,
@@ -504,7 +577,14 @@ class ProductionLimitsService:
                 if not allowed:
                     raise _AcquireLimitError(error or "Rate limit exceeded")
 
-                result = await func()
+                try:
+                    result = await func()
+                except BaseException:
+                    # The paid call failed — release the budget reserved by
+                    # acquire(), so neither the retry below nor other callers are
+                    # blocked by a reservation with no real spend behind it (#1250).
+                    await self._cost_tracker.release_cost(tokens, is_image)
+                    raise
                 await self._cost_tracker.record_cost(tokens, is_image)
                 return result
 
@@ -516,6 +596,7 @@ class ProductionLimitsService:
             "rate_limits": self._rate_limiter.get_usage(),
             "cost": {
                 "daily_cost": self._cost_tracker.get_daily_cost(),
+                "reserved": self._cost_tracker.get_reserved_cost(),
                 "remaining_budget": self._cost_tracker.get_remaining_budget(),
                 "daily_cap": self._cost_tracker._config.daily_cost_cap,
             },

--- a/tests/test_image_generation_service.py
+++ b/tests/test_image_generation_service.py
@@ -1116,3 +1116,102 @@ async def test_generate_invokes_adapter_once_with_limits_configured():
     result = await svc.generate("together:flux", "a cat")
     assert result == "http://img/result.png"
     assert calls["n"] == 1
+
+
+# ── #1250: atomic check-and-reserve on the daily cost cap ──
+
+
+def _make_limits(cost_config):
+    from src.services.production_limits_service import (
+        ProductionLimitsService,
+        RateLimitConfig,
+    )
+
+    db = MagicMock()
+    db.get_setting = AsyncMock(return_value=None)
+    return ProductionLimitsService(db, RateLimitConfig(), cost_config)
+
+
+def _make_limited_service(adapter, limits):
+    svc = ImageGenerationService.__new__(ImageGenerationService)
+    svc._adapters = {"together": adapter}
+    svc._s3 = None
+    svc._last_failure = None
+    svc._limits = limits
+    return svc
+
+
+@pytest.mark.anyio
+async def test_concurrent_generations_do_not_exceed_cost_cap():
+    """Regression guard for #1250: with budget left for exactly one image, N
+    concurrent generations must produce exactly one paid call — the estimated
+    cost is reserved atomically with the cap check, BEFORE the paid adapter runs.
+
+    On the pre-#1250 check-then-record flow every generation passed the check
+    against the same pre-spend total while the paid calls were still in flight,
+    so all N adapters ran and the cap was exceeded by (N-1) x cost."""
+    from src.services.production_limits_service import CostConfig
+
+    limits = _make_limits(CostConfig(cost_per_image=1.0, daily_cost_cap=1.0))
+
+    release = asyncio.Event()
+    calls = {"n": 0}
+
+    async def slow_paid_adapter(text, model_id):
+        calls["n"] += 1
+        # Park in flight so record_cost lags the cap check, like a real 10-60s call.
+        await release.wait()
+        return "http://img/result.png"
+
+    svc = _make_limited_service(slow_paid_adapter, limits)
+
+    tasks = [asyncio.create_task(svc.generate("together:flux", "a cat")) for _ in range(5)]
+
+    async def all_past_cap_check():
+        # Every task is either finished (blocked by the cap) or parked inside the
+        # paid adapter — i.e. all five made it past the cost-cap check.
+        while sum(t.done() for t in tasks) + calls["n"] < len(tasks):
+            await asyncio.sleep(0.01)
+
+    await asyncio.wait_for(all_past_cap_check(), timeout=5.0)
+    release.set()
+    results = await asyncio.gather(*tasks)
+
+    assert calls["n"] == 1  # only the budgeted paid call went out
+    assert sum(1 for r in results if r) == 1
+    assert limits._cost_tracker.get_daily_cost() == pytest.approx(1.0)  # cap intact
+    assert limits._cost_tracker.get_reserved_cost() == pytest.approx(0.0)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "failure",
+    ["raises_oserror", "raises_timeout", "returns_none"],
+)
+async def test_failed_generation_releases_reserved_budget(failure):
+    """When the paid call fails (error, timeout, or empty result), the budget
+    reserved by acquire() must be released — otherwise it stays claimed all day
+    and blocks later generations (#1250)."""
+    from src.services.production_limits_service import CostConfig
+
+    limits = _make_limits(CostConfig(cost_per_image=1.0, daily_cost_cap=1.0))
+
+    async def failing_adapter(text, model_id):
+        if failure == "raises_oserror":
+            raise OSError("provider down")
+        if failure == "raises_timeout":
+            raise TimeoutError("too slow")
+        return None
+
+    svc = _make_limited_service(failing_adapter, limits)
+    assert await svc.generate("together:flux", "a cat") is None
+    assert limits._cost_tracker.get_reserved_cost() == pytest.approx(0.0)
+    assert limits._cost_tracker.get_daily_cost() == pytest.approx(0.0)
+
+    # The budget is still available: a follow-up generation succeeds.
+    async def ok_adapter(text, model_id):
+        return "http://img/ok.png"
+
+    svc._adapters = {"together": ok_adapter}
+    assert await svc.generate("together:flux", "a cat") == "http://img/ok.png"
+    assert limits._cost_tracker.get_daily_cost() == pytest.approx(1.0)

--- a/tests/test_production_limits_service.py
+++ b/tests/test_production_limits_service.py
@@ -532,6 +532,156 @@ async def test_cost_cap_blocks_using_other_instances_spend(db):
     assert allowed is False
 
 
+# === #1250: atomic check-and-reserve ===
+
+
+@pytest.mark.anyio
+async def test_reserve_cost_concurrent_admits_exactly_one():
+    """With budget left for exactly one image, N concurrent reservations admit
+    exactly one — the check and the claim happen atomically under one lock (#1250)."""
+    tracker = CostTracker(CostConfig(cost_per_image=1.0, daily_cost_cap=1.0))
+
+    results = await asyncio.gather(*(tracker.reserve_cost(is_image=True) for _ in range(5)))
+
+    admitted = [ok for ok, _ in results]
+    assert admitted.count(True) == 1
+    assert tracker.get_reserved_cost() == pytest.approx(1.0)
+
+
+@pytest.mark.anyio
+async def test_release_cost_returns_reserved_budget():
+    """release_cost frees a reservation whose paid call never happened, so the
+    budget becomes available again instead of being held all day (#1250)."""
+    tracker = CostTracker(CostConfig(cost_per_image=1.0, daily_cost_cap=1.0))
+
+    ok, _ = await tracker.reserve_cost(is_image=True)
+    assert ok is True
+    ok, _ = await tracker.reserve_cost(is_image=True)
+    assert ok is False  # budget fully reserved
+
+    await tracker.release_cost(is_image=True)
+
+    ok, _ = await tracker.reserve_cost(is_image=True)
+    assert ok is True  # released budget is reusable
+    assert tracker.get_reserved_cost() == pytest.approx(1.0)
+
+
+@pytest.mark.anyio
+async def test_record_cost_settles_reservation_without_double_count():
+    """record_cost converts the reservation into booked spend: the reserve is
+    dropped, the actual cost is recorded once, and the cap stays enforced."""
+    tracker = CostTracker(CostConfig(cost_per_image=1.0, daily_cost_cap=1.0))
+
+    ok, _ = await tracker.reserve_cost(is_image=True)
+    assert ok is True
+    await tracker.record_cost(is_image=True)
+
+    assert tracker.get_reserved_cost() == pytest.approx(0.0)
+    assert tracker.get_daily_cost() == pytest.approx(1.0)
+    assert tracker.get_remaining_budget() == pytest.approx(0.0)
+    ok, _ = await tracker.reserve_cost(is_image=True)
+    assert ok is False  # cap consumed by the recorded spend, not double-counted
+
+
+@pytest.mark.anyio
+async def test_check_cost_cap_sees_outstanding_reservations():
+    """The read-only check counts in-flight reservations, not just recorded spend."""
+    tracker = CostTracker(CostConfig(cost_per_image=1.0, daily_cost_cap=1.0))
+
+    ok, _ = await tracker.reserve_cost(is_image=True)
+    assert ok is True
+
+    allowed, _ = await tracker.check_cost_cap(is_image=True)
+    assert allowed is False
+    assert tracker.get_daily_cost() == 0.0  # nothing recorded yet
+
+
+@pytest.mark.anyio
+async def test_concurrent_acquire_admits_only_budgeted_calls():
+    """Regression guard for #1250: N concurrent acquires with budget for exactly
+    one image admit exactly one. On the pre-#1250 check-then-record flow every
+    acquire passed against the same pre-spend total and all N paid calls went out."""
+    service = ProductionLimitsService(
+        db=SimpleNamespace(),
+        rate_config=RateLimitConfig(requests_per_minute=100, tokens_per_minute=100000),
+        cost_config=CostConfig(cost_per_image=1.0, daily_cost_cap=1.0),
+    )
+
+    results = await asyncio.gather(*(service.acquire(is_image=True, max_wait=0.01) for _ in range(5)))
+
+    admitted = [ok for ok, _ in results]
+    assert admitted.count(True) == 1
+    blocked_errors = [error for ok, error in results if not ok]
+    assert all("Daily cost cap exceeded" in error for error in blocked_errors)
+
+
+@pytest.mark.anyio
+async def test_acquire_rate_timeout_releases_cost_reservation():
+    """When acquire reserves budget but then times out on the rate limiter, the
+    reservation is released — the paid call never ran (#1250)."""
+    service = ProductionLimitsService(
+        db=SimpleNamespace(),
+        rate_config=RateLimitConfig(requests_per_minute=0),
+        cost_config=CostConfig(cost_per_image=1.0, daily_cost_cap=1.0),
+    )
+
+    allowed, error = await service.acquire(is_image=True, max_wait=0.01)
+
+    assert allowed is False
+    assert error == "Rate limit timeout"
+    assert service._cost_tracker.get_reserved_cost() == pytest.approx(0.0)
+
+
+@pytest.mark.anyio
+async def test_execute_with_retry_releases_reservation_on_failed_attempt():
+    """A failed attempt must release its reservation before the retry re-acquires;
+    with budget for exactly one call a leaked reservation would block the retry
+    (and every later caller) even though no money was spent (#1250)."""
+    service = ProductionLimitsService(
+        db=SimpleNamespace(),
+        rate_config=RateLimitConfig(requests_per_minute=100, tokens_per_minute=100000),
+        cost_config=CostConfig(cost_per_1k_tokens=1.0, daily_cost_cap=1.0),
+    )
+    call_count = 0
+
+    async def flaky():
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RuntimeError("transient")
+        return "recovered"
+
+    with patch("src.services.production_limits_service.asyncio.sleep", new_callable=AsyncMock):
+        result = await service.execute_with_retry(func=flaky, tokens=1000, max_retries=2, base_delay=0.01)
+
+    assert result == "recovered"
+    assert call_count == 2
+    assert service._cost_tracker.get_reserved_cost() == pytest.approx(0.0)
+    assert service._cost_tracker.get_daily_cost() == pytest.approx(1.0)  # only the paid attempt
+
+
+@pytest.mark.anyio
+async def test_execute_with_retry_exhausted_leaves_no_reservation():
+    """When every attempt fails, no budget stays reserved after the raise (#1250)."""
+    service = ProductionLimitsService(
+        db=SimpleNamespace(),
+        rate_config=RateLimitConfig(requests_per_minute=100, tokens_per_minute=100000),
+        cost_config=CostConfig(cost_per_1k_tokens=1.0, daily_cost_cap=1.0),
+    )
+
+    with patch("src.services.production_limits_service.asyncio.sleep", new_callable=AsyncMock):
+        with pytest.raises(RuntimeError, match="always fails"):
+            await service.execute_with_retry(
+                func=AsyncMock(side_effect=RuntimeError("always fails")),
+                tokens=1000,
+                max_retries=2,
+                base_delay=0.01,
+            )
+
+    assert service._cost_tracker.get_reserved_cost() == pytest.approx(0.0)
+    assert service._cost_tracker.get_daily_cost() == pytest.approx(0.0)
+
+
 def test_from_config_disabled_returns_none():
     from src.config import AppConfig
 


### PR DESCRIPTION
Closes #1250. Found in the #1234 code review (finding #13); restores the hard daily-cap guarantee from #814.

## Problem

The daily cost cap was **check-then-record**: `CostTracker._lock` serialized only the *check*, while the spend was booked by `record_cost` only *after* the paid provider call finished (10–60s later). With budget left for exactly one image, N concurrent generations (pipeline + agent-tool + web) all passed `check_cost_cap` against the same pre-spend total → all N paid calls went out → `record_cost` booked everything after the fact → the cap was exceeded by (N−1)×cost.

## Fix: atomic check-and-reserve

`CostTracker` now claims the **estimated** cost under the same lock as the cap check, before the paid call runs, and settles it afterwards:

- **`reserve_cost(tokens, is_image)`** — refreshes the authoritative daily total (#814 cross-instance read preserved), checks `daily + reserved + estimated > cap`, and on success adds the estimate to the in-flight reservation ledger — all under one `_lock` acquisition.
- **`record_cost(...)`** — settles: drops the matching reservation (same deterministic estimate for the same arguments) and books the actual spend in its place. Still safe without a prior reservation (release clamped at zero).
- **`release_cost(...)`** — returns the budget when the paid call failed or never ran, so a failed call can't hold the budget until the day rolls over.
- `check_cost_cap` stays a read-only check but now counts outstanding reservations; `get_remaining_budget()` is net of reservations; `get_stats()` exposes `cost.reserved`.

Callers follow the *reserve → try paid call → settle exactly once* pattern:

- `ProductionLimitsService.acquire()` reserves (and **releases on rate-limit timeout**, where the paid call never runs).
- `execute_with_retry()` releases on a failed attempt (including `CancelledError`) before the retry re-acquires — no reservation pile-up, and no new retry added around the paid call itself.
- `ImageGenerationService.generate()` settles in a `finally` block: success → `record_cost`; error / timeout / empty result / cancellation → `release_cost`.

Reservations are in-memory (per process — which is where the race lives: web + embedded worker share one process by default). Cross-instance protection remains at the recorded-spend level exactly as in #814.

## Tests (mutation-verified)

Red proven on the pre-fix code by stashing the src changes:

- `test_concurrent_generations_do_not_exceed_cost_cap` — 5 concurrent `generate()` calls with budget for one image, adapters parked in-flight on an event: **fails `assert 5 == 1` on the old code** (all 5 paid calls went out), passes with the fix (1 paid call, cap intact).
- `test_concurrent_acquire_admits_only_budgeted_calls` — service-level: exactly one of 5 concurrent acquires is admitted.
- `test_failed_generation_releases_reserved_budget[oserror|timeout|returns_none]` — a failed paid call releases the reservation and a follow-up generation still fits the budget.
- `test_acquire_rate_timeout_releases_cost_reservation`, `test_execute_with_retry_releases_reservation_on_failed_attempt`, `test_execute_with_retry_exhausted_leaves_no_reservation`, plus `reserve/release/settle` unit tests on `CostTracker` (no double-count on settle).

## Verification

- `ruff check src/ tests/ conftest.py` — clean
- `tests/test_production_limits_service.py` + `tests/test_image_generation_service.py` — 110 passed (incl. 12 new)
- `tests/test_regression_services_coverage.py` — 82 passed; dependent image suites (agent tools / routes / CLI) — 98 passed; `pytest -m smoke` — green
- mypy on both changed files: no new errors vs origin/main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019R5KeKC8yEV89hWy6ndCWa