### PR TITLE
chore(mypy): type services/runtime/misc (src/ 42 -> 27)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,6 +174,8 @@ module = [
     "langdetect",
     "openpyxl",
     "openpyxl.*",
+    "regex",
+    "regex.*",
     "sklearn.*",
     "telethon",
     "telethon.*",

--- a/src/agent/tools/_registry.py
+++ b/src/agent/tools/_registry.py
@@ -268,7 +268,9 @@ def connected_phones_from_pool(client_pool: object | None) -> set[str]:
     if isinstance(instance_attrs, dict) and "connected_phones" in instance_attrs:
         connected_phones = instance_attrs["connected_phones"]
     elif callable(getattr(type(client_pool), "connected_phones", None)):
-        connected_phones = client_pool.connected_phones
+        # type(client_pool).connected_phones is callable (a property/method); access it,
+        # giving mypy a typed handle without weakening the duck-typed signature.
+        connected_phones = cast(Any, client_pool).connected_phones
 
     if callable(connected_phones):
         try:
@@ -279,7 +281,7 @@ def connected_phones_from_pool(client_pool: object | None) -> set[str]:
             return {str(phone) for phone in phones}
 
     try:
-        clients = client_pool.clients
+        clients = getattr(client_pool, "clients", {})
     except Exception:
         clients = {}
     if isinstance(clients, dict):
@@ -330,7 +332,7 @@ def _pool_reports_connections(client_pool: object | None) -> bool:
     if callable(getattr(type(client_pool), "connected_phones", None)):
         return True
     try:
-        return isinstance(client_pool.clients, dict)
+        return isinstance(getattr(client_pool, "clients", None), dict)
     except Exception:
         return False
 

--- a/src/config.py
+++ b/src/config.py
@@ -191,7 +191,7 @@ class AppConfig(BaseModel):
     web: WebConfig = WebConfig()
     scheduler: SchedulerConfig = SchedulerConfig()
     notifications: NotificationsConfig = NotificationsConfig()
-    database: DatabaseConfig = DatabaseConfig()
+    database: DatabaseConfig = DatabaseConfig()  # type: ignore[call-arg]  # Field(gt=0) defaults are mis-seen as required
     llm: LLMConfig = LLMConfig()
     agent: AgentConfig = AgentConfig()
     security: SecurityConfig = SecurityConfig()

--- a/src/models.py
+++ b/src/models.py
@@ -667,12 +667,14 @@ class PipelineGraph(BaseModel):
         )
 
     @classmethod
-    def from_json(cls, data: str | dict) -> "PipelineGraph":
+    def from_json(cls, data: str | dict[str, Any]) -> "PipelineGraph":
         """Собрать граф из JSON-строки или уже разобранного dict (валидирует узлы
         и рёбра через их модели)."""
         import json
         if isinstance(data, str):
             data = json.loads(data)
+        # json.loads returns Any; the str branch is gone, so narrow to the parsed dict.
+        assert isinstance(data, dict)
         nodes = [PipelineNode.model_validate(n) for n in data.get("nodes", [])]
         edges = [PipelineEdge.model_validate(e) for e in data.get("edges", [])]
         return cls(nodes=nodes, edges=edges)

--- a/src/runtime/worker.py
+++ b/src/runtime/worker.py
@@ -6,6 +6,7 @@ import signal
 from dataclasses import asdict
 from datetime import datetime, timezone
 from inspect import isawaitable
+from typing import Any
 
 from src.config import AppConfig
 from src.database import DatabaseBusyError
@@ -251,7 +252,7 @@ async def _publish_collection_queue_status_snapshot(container, now: datetime) ->
 
 async def _notification_target_status_payload(container, stop_event: asyncio.Event | None) -> dict:
     target_status = await container.notification_target_service.describe_target()
-    bot_payload = {"configured": False}
+    bot_payload: dict[str, Any] = {"configured": False}
     if target_status.state == "available":
         try:
             bot = await NotificationService(

--- a/src/scheduler/service.py
+++ b/src/scheduler/service.py
@@ -549,8 +549,8 @@ class SchedulerManager:
                 logger.exception("Error fetching search queries for potential jobs")
         if self._pipeline_bundle:
             try:
-                all_active = await self._pipeline_bundle.get_all(active_only=True)
-                for p in all_active:
+                active_pipelines = await self._pipeline_bundle.get_all(active_only=True)
+                for p in active_pipelines:
                     if p.id is not None and p.is_active:
                         # Only content_generate_ is a periodic job now (#835/2). Do NOT advertise
                         # pipeline_run_ as a togglable potential job: sync_pipeline_jobs always

--- a/src/search/numpy_semantic.py
+++ b/src/search/numpy_semantic.py
@@ -6,7 +6,8 @@ from typing import TYPE_CHECKING
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    pass
+    import numpy as np
+    from sklearn.neighbors import NearestNeighbors
 
 
 class NumpySemanticIndex:
@@ -19,8 +20,8 @@ class NumpySemanticIndex:
 
     def __init__(self) -> None:
         self._ids: list[int] = []
-        self._matrix = None  # numpy ndarray, shape (N, dims), lazy import
-        self._index = None  # sklearn.neighbors.NearestNeighbors, lazy import
+        self._matrix: np.ndarray | None = None  # shape (N, dims), lazy import
+        self._index: NearestNeighbors | None = None  # lazy import
 
     def load(self, embeddings: list[tuple[int, list[float]]]) -> None:
         """Load pre-computed embeddings.  ``embeddings`` is a list of (message_id, vector)."""


### PR DESCRIPTION
Part of #1133 (mypy debt reduction axis). Independent sibling of #1275 (telegram utils) and #1277 (database) — disjoint files.

## mypy delta

`python -m mypy src/` on this branch: **42 errors -> 27 errors** (−15). No new errors in untouched files (verified against per-file baseline). The remaining 27 are the PR1 (#1275) and PR2 (#1277) files, which this branch does not touch.

| File | Errors before | After |
|---|---|---|
| src/agent/tools/_registry.py | 3 | 0 |
| src/config.py | 2 | 0 |
| src/models.py | 2 | 0 |
| src/search/numpy_semantic.py | 2 | 0 |
| src/scheduler/service.py | 2 | 0 |
| src/runtime/worker.py | 3 | 0 |
| src/services/notification_matcher.py | 1 | 0 |

## Changes (typing-only, no runtime behavior change)

- **pyproject mypy overrides**: add `regex` / `regex.*` to the `ignore_missing_imports` module list (third-party, ships no stubs) — clears the `import-untyped` in `notification_matcher`. Same pattern as the existing `sklearn.*` / `yaml` entries.
- **numpy_semantic**: `TYPE_CHECKING`-import `numpy as np` and `NearestNeighbors`, annotate the lazy `_matrix: np.ndarray | None` / `_index: NearestNeighbors | None` fields (the imports stay runtime-lazy).
- **scheduler/service**: rename the loop-bound `all_active` to `active_pipelines` in the pipeline branch — the previous reuse of the same name (typed `list[SearchQuery]` from the search-query branch above) caused a cross-branch assignment error.
- **runtime/worker**: annotate `bot_payload: dict[str, Any]` — it was inferred as bool-only from the initial `{"configured": False}` then widened with str/int/None values.
- **models.PipelineGraph.from_json**: narrow the param to `str | dict[str, Any]` and `assert isinstance(data, dict)` after `json.loads` so the `.get("nodes")` / `.get("edges")` calls type-check (json.loads returns `Any`).
- **config**: targeted `# type: ignore[call-arg]` on `DatabaseConfig()` — the pydantic mypy plugin mis-reports the `Field(gt=0)` / `Field(ge=0)` defaults as required (the defaults are valid and present).
- **agent/tools/_registry**: the three pool helper functions (`connected_phones_from_pool`, `_pool_reports_connections`, etc.) are intentionally duck-typed over `object | None` with `getattr` + try/except. Replaced the few direct `.clients` / `.connected_phones` attribute accesses (which mypy rejects on `object`) with `getattr(...)` and one `cast(Any, ...)` where the attribute is guarded by `callable(type(...).attr)`.

## Verification

- `ruff check src/ tests/ conftest.py` — clean
- `python -m mypy src/` — 27 errors (was 42), untouched files unchanged; all 7 PR3 files at 0
- `pytest tests/test_notification_matcher.py tests/test_agent_tools_registry.py tests/test_pipeline_graph.py tests/test_jobs_read_model.py` — **143 passed**
- `pytest tests/test_cli_dialogs_notifications_scheduler.py -k "scheduler or potential_job or job"` — **46 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3ExCZyXkbUpTkRRrQrFA2