### PR TITLE
chore: vulture whitelist for verified false-positive ensure_ascii (#1136)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,6 +237,20 @@ exclude_lines = [
 [tool.bandit]
 exclude_dirs = ["tests"]
 
+# Dead-code scan whitelist (vulture, #1136). vulture auto-reads this section,
+# so it applies both to `python -m vulture src/` and to scripts/code_health.py.
+# Every name here is a VERIFIED false-positive — do not delete the code it
+# refers to; each entry must say why it is intentionally "unused".
+[tool.vulture]
+ignore_names = [
+    # src/utils/json.py safe_json_dumps(ensure_ascii=...): intentional
+    # call-site-compatibility parameter after the orjson migration (#956) —
+    # orjson is always UTF-8, the flag is accepted so existing
+    # `safe_json_dumps(obj, ensure_ascii=True)` calls don't break, but has
+    # no effect. Removing it would break call sites. See issue #1136.
+    "ensure_ascii",
+]
+
 # Doc-coverage (interrogate, #1072). scripts/doc_coverage.py and the advisory
 # CI step read this. `fail_under` is a SOFT baseline — a ratchet floor that
 # surfaces regressions without forcing a docstring-everything sprint. Raise it

--- a/tests/test_utils_json.py
+++ b/tests/test_utils_json.py
@@ -69,6 +69,17 @@ def test_kwargs_forwarded():
     assert result == '{"a":2,"b":1}'
 
 
+def test_ensure_ascii_accepted_for_call_site_compat():
+    # `ensure_ascii` is an intentional no-op kept for call-site compatibility
+    # after the orjson migration (#956): orjson is always UTF-8. Live call
+    # sites pass it (e.g. generation_runs repository), so the parameter must
+    # keep being accepted with either value. Vulture-whitelisted in
+    # pyproject.toml [tool.vulture] — do not remove (#1136).
+    payload = {"text": "привет"}
+    assert safe_json_dumps(payload, ensure_ascii=True) == safe_json_dumps(payload, ensure_ascii=False)
+    assert "привет" in safe_json_dumps(payload, ensure_ascii=True)
+
+
 def test_custom_default_does_not_receive_datetime():
     # With a custom default, datetime must be serialized natively by orjson, NOT
     # routed to the caller's default (which may not handle it) — review on #956.


### PR DESCRIPTION
Part of #1136 (vulture axis of epic #1130).

## Summary
- Adds `[tool.vulture]` to `pyproject.toml` (`ignore_names=["ensure_ascii"]`), bringing the high-confidence dead-code report to **0 findings** — via whitelist, NOT deletion, as #1136 requires.
- Adds a regression test (`tests/test_utils_json.py::test_ensure_ascii_accepted_for_call_site_compat`) locking the parameter in place.

## Why whitelist, not deletion
`safe_json_dumps(ensure_ascii=...)` is an intentional call-site-compatibility parameter after the orjson migration (#956): orjson always emits UTF-8, so the flag is a documented no-op. **Live call sites pass it today** — verified by grep:
- `src/database/repositories/generation_runs.py` — 5 calls with `ensure_ascii=False`
- `src/models.py:666` — `ensure_ascii=False`

Removing it would break those call sites. This matches #1136, which already classifies the finding as a false-positive and asks for a whitelist rather than deletion.

## Whitelist format (requesting owner sign-off)
vulture ≥2.1 auto-reads `[tool.vulture]` from `pyproject.toml`, so the whitelist applies both to bare `python -m vulture src/` and to `scripts/code_health.py` without changing either invocation.

Trade-off: `ignore_names` matches by name repo-wide, so any *future* unused `ensure_ascii` symbol would also be skipped. Accepted for this specific name; the section header comment requires each entry to carry a justification. Alternative considered and rejected: a separate whitelist `.py` file would require changing the `code_health.py` call and wouldn't cover bare vulture runs.

## Verification
- Repo-wide grep for `ensure_ascii` confirms live production call sites (above) → must not delete.
- **Before:** `python -m vulture src/ --min-confidence 80` → 1 finding (`src/utils/json.py:23`, 100%).
- **After:** 0 findings; `scripts/code_health.py` prints «Находок (high-confidence): 0».
- `ruff check src/ tests/ conftest.py` clean.
- `pytest tests/test_utils_json.py` — 14 passed.
- Full suite: the only failures (`tests/test_quality_scoring_service.py`, `tests/routes/test_debug_routes.py::test_debug_timing_page`) are **pre-existing** — reproduced on clean `origin/main` (quality_scoring fails on clean main; debug_timing is xdist-flaky, passes in isolation). Unrelated to this whitelist.

## Note: nothing else deleted in this PR
The wider 60%-confidence vulture sweep surfaces many more names, but per #1136 every candidate must be verified across all five surfaces (FastAPI/Web/CLI/agent/TUI) before deletion and most are framework false-positives (Typer commands, FastAPI routes/DI, Textual hooks, pydantic fields, dispatcher `_handle_*` via `getattr`). Those go in separate PRs; doubtful candidates are left untouched. This PR only resolves the single high-confidence verified false-positive that #1136 explicitly targets.

Part of #1136 / #1130.