### PR TITLE
refactor: replace 2 DB-busy retry loops with tenacity (#1132)

### DIFF
--- a/scripts/reinvented_baseline.json
+++ b/scripts/reinvented_baseline.json
@@ -2,24 +2,16 @@
   "_comment": "Baseline-снимок scripts/detect_reinvented.py (#1108). Фиксирует текущие находки-велосипеды, чтобы прогоны диффили и подсвечивали НОВЫЕ. Пересоздать: python scripts/detect_reinvented.py --update-baseline.",
   "findings": [
     {
-      "file": "src/agent/manager.py",
-      "line": 429,
+      "file": "src/agent/backends/_stream.py",
+      "line": 463,
       "kind": "handrolled-retry-loop",
       "what": "самописный retry/backoff-цикл в _await_with_countdown()",
       "replacement": "tenacity.retry / aiolimiter (для rate-limit)",
       "confidence": "med"
     },
     {
-      "file": "src/database/facade.py",
-      "line": 236,
-      "kind": "handrolled-retry-loop",
-      "what": "самописный retry/backoff-цикл в _with_busy_retry()",
-      "replacement": "tenacity.retry / aiolimiter (для rate-limit)",
-      "confidence": "med"
-    },
-    {
       "file": "src/services/task_handlers/stats.py",
-      "line": 173,
+      "line": 174,
       "kind": "handrolled-retry-loop",
       "what": "самописный retry/backoff-цикл в handle_stats_all()",
       "replacement": "tenacity.retry / aiolimiter (для rate-limit)",
@@ -27,39 +19,31 @@
     },
     {
       "file": "src/services/telegram_command_dispatcher.py",
-      "line": 144,
+      "line": 152,
       "kind": "handrolled-retry-loop",
       "what": "самописный retry/backoff-цикл в _run_loop()",
-      "replacement": "tenacity.retry / aiolimiter (для rate-limit)",
-      "confidence": "med"
-    },
-    {
-      "file": "src/services/telegram_command_dispatcher.py",
-      "line": 343,
-      "kind": "handrolled-retry-loop",
-      "what": "самописный retry/backoff-цикл в _update_command_safely()",
       "replacement": "tenacity.retry / aiolimiter (для rate-limit)",
       "confidence": "med"
     },
     {
       "file": "src/services/unified_dispatcher.py",
-      "line": 178,
+      "line": 182,
       "kind": "handrolled-retry-loop",
       "what": "самописный retry/backoff-цикл в _run_loop()",
       "replacement": "tenacity.retry / aiolimiter (для rate-limit)",
       "confidence": "med"
     },
     {
-      "file": "src/telegram/collector.py",
-      "line": 674,
+      "file": "src/telegram/collector_mixins/collection.py",
+      "line": 322,
       "kind": "handrolled-retry-loop",
       "what": "самописный retry/backoff-цикл в collect_all_channels()",
       "replacement": "tenacity.retry / aiolimiter (для rate-limit)",
       "confidence": "med"
     },
     {
-      "file": "src/telegram/collector.py",
-      "line": 2281,
+      "file": "src/telegram/collector_mixins/stats.py",
+      "line": 475,
       "kind": "handrolled-retry-loop",
       "what": "самописный retry/backoff-цикл в collect_all_stats()",
       "replacement": "tenacity.retry / aiolimiter (для rate-limit)",
@@ -91,15 +75,23 @@
     },
     {
       "file": "src/web/bootstrap.py",
-      "line": 74,
+      "line": 76,
       "kind": "handrolled-retry-loop",
       "what": "самописный retry/backoff-цикл в _retry_telegram_pool_until_connected()",
       "replacement": "tenacity.retry / aiolimiter (для rate-limit)",
       "confidence": "med"
     },
     {
+      "file": "src/web/scheduler/context.py",
+      "line": 236,
+      "kind": "manual-counter",
+      "what": "самописный частотный счётчик в _dedupe_recent_unavailability_events()",
+      "replacement": "collections.Counter",
+      "confidence": "med"
+    },
+    {
       "file": "src/web/search/handlers.py",
-      "line": 84,
+      "line": 86,
       "kind": "handrolled-retry-loop",
       "what": "самописный retry/backoff-цикл в _telegram_search_via_worker()",
       "replacement": "tenacity.retry / aiolimiter (для rate-limit)",

--- a/src/database/facade.py
+++ b/src/database/facade.py
@@ -9,6 +9,8 @@ from datetime import datetime
 from typing import Any
 
 import aiosqlite
+from tenacity import AsyncRetrying, RetryCallState, RetryError, retry_if_exception, stop_after_attempt
+from tenacity.wait import wait_chain, wait_fixed
 
 from src.database.bundles import DatabaseRepositories
 from src.database.connection import ConnectionTuning, DBConnection
@@ -68,6 +70,26 @@ class DatabaseBusyError(RuntimeError):
 def _is_sqlite_busy_error(exc: BaseException) -> bool:
     message = str(exc).lower()
     return any(part in message for part in _SQLITE_BUSY_MESSAGES)
+
+
+def _is_retryable_busy_error(exc: BaseException) -> bool:
+    return isinstance(exc, sqlite3.OperationalError) and _is_sqlite_busy_error(exc)
+
+
+def _wrap_async(
+    action: Callable[[], Awaitable[aiosqlite.Cursor | None]],
+) -> Callable[[], Awaitable[aiosqlite.Cursor | None]]:
+    """Обернуть action в async-fn для tenacity.AsyncRetrying.
+
+    tenacity await'ит результат ``fn()``, но ``action`` — синхронный ``Callable``,
+    возвращающий coroutine; без обёртки coroutine остался бы не-await'нутым и ни
+    одна DDL/DML внутри не выполнилась бы (#1132).
+    """
+
+    async def _runner() -> aiosqlite.Cursor | None:
+        return await action()
+
+    return _runner
 
 
 class Database:
@@ -232,33 +254,43 @@ class Database:
         operation: str,
         action: Callable[[], Awaitable[aiosqlite.Cursor | None]],
     ) -> aiosqlite.Cursor | None:
+        # tenacity вместо ручного цикла (#1132); лестница задержек — ровно
+        # self._busy_retry_delays_sec (wait_chain), попыток len(delays)+1.
         delays = self._busy_retry_delays_sec
-        for attempt in range(len(delays) + 1):
-            try:
-                return await action()
-            except sqlite3.OperationalError as exc:
-                if not _is_sqlite_busy_error(exc):
-                    raise
-                if attempt >= len(delays):
-                    logger.warning(
-                        "Database stayed locked during %s after %d attempts",
-                        operation,
-                        attempt + 1,
-                    )
-                    raise DatabaseBusyError(
-                        "Database is busy. Retry the request in a few seconds."
-                    ) from exc
-                delay = delays[attempt]
-                logger.warning(
-                    "Database locked during %s; retrying in %.2fs (%d/%d)",
-                    operation,
-                    delay,
-                    attempt + 1,
-                    len(delays) + 1,
-                )
-                if delay > 0:
-                    await asyncio.sleep(delay)
-        return None
+
+        def _log_retry(retry_state: RetryCallState) -> None:
+            next_action = retry_state.next_action
+            logger.warning(
+                "Database locked during %s; retrying in %.2fs (%d/%d)",
+                operation,
+                next_action.sleep if next_action is not None else 0.0,
+                retry_state.attempt_number,
+                len(delays) + 1,
+            )
+
+        retryer = AsyncRetrying(
+            retry=retry_if_exception(_is_retryable_busy_error),
+            stop=stop_after_attempt(len(delays) + 1),
+            wait=wait_chain(*(wait_fixed(delay) for delay in delays)),
+            sleep=asyncio.sleep,
+            before_sleep=_log_retry,
+        )
+        try:
+            # Оборачиваем action в async-fn: tenacity AsyncRetrying await'ит
+            # результат fn(), а action — это синхронный Callable, возвращающий
+            # coroutine (lambda: begin_immediate(...)). Без обёртки coroutine
+            # остаётся не-await'нутым и BEGIN не выполняется (#1132).
+            return await retryer(_wrap_async(action))
+        except RetryError as retry_error:
+            last_exc = retry_error.last_attempt.exception()
+            logger.warning(
+                "Database stayed locked during %s after %d attempts",
+                operation,
+                len(delays) + 1,
+            )
+            raise DatabaseBusyError(
+                "Database is busy. Retry the request in a few seconds."
+            ) from last_exc
 
     @asynccontextmanager
     async def transaction(self) -> AsyncIterator[aiosqlite.Connection]:

--- a/src/services/telegram_command_dispatcher.py
+++ b/src/services/telegram_command_dispatcher.py
@@ -7,6 +7,9 @@ from datetime import timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from tenacity import AsyncRetrying, RetryCallState, retry_if_exception_type
+from tenacity.wait import wait_exponential
+
 from src.config import AppConfig
 from src.database import Database, DatabaseBusyError
 from src.live_runtime_pause import LiveRuntimePauseGate
@@ -345,34 +348,54 @@ class TelegramCommandDispatcher(
         **kwargs: Any,
     ) -> None:
         assert command_id is not None
-        delay = COMMAND_STATUS_UPDATE_BUSY_RETRY_INITIAL_SEC
-        while True:
-            try:
-                await self._db.repos.telegram_commands.update_command(
-                    command_id,
-                    status=status,
-                    **kwargs,
-                )
+
+        async def _update() -> None:
+            await self._db.repos.telegram_commands.update_command(
+                command_id,
+                status=status,
+                **kwargs,
+            )
+
+        def _log_busy(retry_state: RetryCallState) -> None:
+            outcome = retry_state.outcome
+            logger.warning(
+                "telegram_command_dispatcher: DB busy while marking command %s %s: %s",
+                command_id,
+                log_action,
+                outcome.exception() if outcome is not None else None,
+            )
+
+        try:
+            if not retry_busy:
+                await _update()
                 return
-            except DatabaseBusyError as exc:
-                logger.warning(
-                    "telegram_command_dispatcher: DB busy while marking command %s %s: %s",
-                    command_id,
-                    log_action,
-                    exc,
-                )
-                if not retry_busy:
-                    return
-                await asyncio.sleep(delay)
-                delay = min(delay * 2, COMMAND_STATUS_UPDATE_BUSY_RETRY_MAX_SEC)
-            except Exception as exc:
-                logger.warning(
-                    "telegram_command_dispatcher: failed to mark command %s %s: %s",
-                    command_id,
-                    log_action,
-                    exc,
-                )
-                return
+            # tenacity вместо ручного цикла (#1132): бесконечный retry на busy с
+            # экспоненциальной лестницей INITIAL, 2×, 4×… и потолком MAX — как раньше.
+            retryer = AsyncRetrying(
+                retry=retry_if_exception_type(DatabaseBusyError),
+                wait=wait_exponential(
+                    multiplier=COMMAND_STATUS_UPDATE_BUSY_RETRY_INITIAL_SEC,
+                    max=COMMAND_STATUS_UPDATE_BUSY_RETRY_MAX_SEC,
+                ),
+                sleep=asyncio.sleep,
+                before_sleep=_log_busy,
+            )
+            await retryer(_update)
+        except DatabaseBusyError as exc:
+            # Достижимо только при retry_busy=False: retryer повторяет busy бесконечно.
+            logger.warning(
+                "telegram_command_dispatcher: DB busy while marking command %s %s: %s",
+                command_id,
+                log_action,
+                exc,
+            )
+        except Exception as exc:
+            logger.warning(
+                "telegram_command_dispatcher: failed to mark command %s %s: %s",
+                command_id,
+                log_action,
+                exc,
+            )
 
     async def _dispatch(self, command_type: str, payload: dict[str, Any]) -> dict[str, Any]:
         handler_name = f"_handle_{command_type.replace('.', '_')}"

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -216,6 +216,106 @@ async def test_agent_message_write_raises_database_busy_after_retries(db, monkey
     assert await db.get_agent_messages(thread_id) == []
 
 
+# --- характеризующие тесты _with_busy_retry (#1132: ручной цикл → tenacity) ---
+# Фиксируют точный контракт retry до/после замены реализации: лестницу задержек,
+# число попыток, сквозной проброс не-busy ошибок и цепочку исключений.
+
+
+@pytest.mark.anyio
+async def test_busy_retry_sleeps_exact_configured_ladder(db, monkeypatch):
+    """При исчерпании попыток спим ровно _busy_retry_delays_sec, по порядку.
+
+    Никакой экспоненты/джиттера: лестница фиксированная, попыток len(delays)+1.
+    """
+    calls = 0
+
+    async def always_locked():
+        nonlocal calls
+        calls += 1
+        raise sqlite3.OperationalError("database is locked")
+
+    slept: list[float] = []
+
+    async def fake_sleep(delay):
+        slept.append(delay)
+
+    db._busy_retry_delays_sec = (0.05, 0.2, 0.7)
+    monkeypatch.setattr("asyncio.sleep", fake_sleep)
+
+    with pytest.raises(DatabaseBusyError, match="Database is busy"):
+        await db._with_busy_retry("test op", always_locked)
+
+    assert calls == 4
+    assert slept == [0.05, 0.2, 0.7]
+
+
+@pytest.mark.anyio
+async def test_busy_retry_returns_action_result_after_transient_busy(db, monkeypatch):
+    """Успех после transient-busy: результат action возвращается, спали ровно delays[0]."""
+    sentinel = object()
+    calls = 0
+
+    async def flaky():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise sqlite3.OperationalError("database table is locked")
+        return sentinel
+
+    slept: list[float] = []
+
+    async def fake_sleep(delay):
+        slept.append(delay)
+
+    db._busy_retry_delays_sec = (0.05, 0.2)
+    monkeypatch.setattr("asyncio.sleep", fake_sleep)
+
+    assert await db._with_busy_retry("test op", flaky) is sentinel
+    assert calls == 2
+    assert slept == [0.05]
+
+
+@pytest.mark.anyio
+async def test_busy_retry_reraises_non_busy_operational_error_immediately(db, monkeypatch):
+    """Не-busy OperationalError пробрасывается сразу: без повторов и без sleep."""
+    calls = 0
+
+    async def broken():
+        nonlocal calls
+        calls += 1
+        raise sqlite3.OperationalError("no such table: nope")
+
+    async def fail_sleep(delay):  # pragma: no cover - защита от ложного retry
+        raise AssertionError("non-busy error must not be retried")
+
+    monkeypatch.setattr("asyncio.sleep", fail_sleep)
+
+    with pytest.raises(sqlite3.OperationalError, match="no such table"):
+        await db._with_busy_retry("test op", broken)
+
+    assert calls == 1
+
+
+@pytest.mark.anyio
+async def test_busy_retry_chains_last_busy_error_as_cause(db, monkeypatch):
+    """DatabaseBusyError связан цепочкой (__cause__) с последней busy-ошибкой."""
+    last_error = sqlite3.OperationalError("database is locked")
+
+    async def always_locked():
+        raise last_error
+
+    async def fake_sleep(delay):
+        return None
+
+    db._busy_retry_delays_sec = (0,)
+    monkeypatch.setattr("asyncio.sleep", fake_sleep)
+
+    with pytest.raises(DatabaseBusyError) as exc_info:
+        await db._with_busy_retry("test op", always_locked)
+
+    assert exc_info.value.__cause__ is last_error
+
+
 @pytest.mark.anyio
 async def test_account_session_encrypted_at_rest(tmp_path):
     db_path = str(tmp_path / "encrypted.db")

--- a/tests/test_telegram_command_dispatcher.py
+++ b/tests/test_telegram_command_dispatcher.py
@@ -1537,6 +1537,74 @@ async def test_run_loop_cancelled_reraises_when_update_busy():
     db.repos.telegram_commands.update_command.assert_awaited_once()
 
 
+# --- характеризующие тесты _update_command_safely (#1132: ручной цикл → tenacity) ---
+# Фиксируют точный контракт retry до/после замены реализации: экспоненциальную
+# лестницу задержек с потолком, retry_busy=False и заглатывание прочих ошибок.
+
+
+def _busy_error():
+    from src.database import DatabaseBusyError
+
+    return DatabaseBusyError("Database is busy. Retry the request in a few seconds.")
+
+
+async def test_update_command_safely_busy_backoff_doubles_and_caps():
+    """Лестница задержек: INITIAL, 2×, 4×… с потолком MAX; попыток — до успеха."""
+    db = _mock_db()
+    d = _dispatcher(db=db, pool=_mock_pool())
+    failures = 6
+    db.repos.telegram_commands.update_command = AsyncMock(
+        side_effect=[_busy_error()] * failures + [None]
+    )
+
+    with patch.object(mod.asyncio, "sleep", new_callable=AsyncMock) as mock_sleep:
+        await d._update_command_safely(
+            7, status=TelegramCommandStatus.SUCCEEDED, log_action="succeeded"
+        )
+
+    expected = []
+    delay = mod.COMMAND_STATUS_UPDATE_BUSY_RETRY_INITIAL_SEC
+    for _ in range(failures):
+        expected.append(delay)
+        delay = min(delay * 2, mod.COMMAND_STATUS_UPDATE_BUSY_RETRY_MAX_SEC)
+
+    assert [c.args[0] for c in mock_sleep.await_args_list] == expected
+    assert db.repos.telegram_commands.update_command.await_count == failures + 1
+
+
+async def test_update_command_safely_busy_without_retry_is_single_shot():
+    """retry_busy=False: одна попытка, без sleep, busy заглатывается."""
+    db = _mock_db()
+    d = _dispatcher(db=db, pool=_mock_pool())
+    db.repos.telegram_commands.update_command = AsyncMock(side_effect=_busy_error())
+
+    with patch.object(mod.asyncio, "sleep", new_callable=AsyncMock) as mock_sleep:
+        await d._update_command_safely(
+            7,
+            status=TelegramCommandStatus.FAILED,
+            log_action="failed",
+            retry_busy=False,
+        )
+
+    db.repos.telegram_commands.update_command.assert_awaited_once()
+    mock_sleep.assert_not_awaited()
+
+
+async def test_update_command_safely_swallows_generic_error_without_retry():
+    """Не-busy ошибка: одна попытка, без sleep, наружу не пробрасывается."""
+    db = _mock_db()
+    d = _dispatcher(db=db, pool=_mock_pool())
+    db.repos.telegram_commands.update_command = AsyncMock(side_effect=RuntimeError("boom"))
+
+    with patch.object(mod.asyncio, "sleep", new_callable=AsyncMock) as mock_sleep:
+        await d._update_command_safely(
+            7, status=TelegramCommandStatus.SUCCEEDED, log_action="succeeded"
+        )
+
+    db.repos.telegram_commands.update_command.assert_awaited_once()
+    mock_sleep.assert_not_awaited()
+
+
 # ============================================================
 # Additional tests for handler edge paths
 # ============================================================


### PR DESCRIPTION
Part of #1132 (axis 2/7 of #1130). Registry: #782 — retry batch, DB-busy group. Follows up #1198 (Counter/base64 safe subset), which explicitly deferred all retry findings for per-case owner review.

## What

Replaces the **two genuine hand-rolled retry loops** among the 14 detector findings with `tenacity.AsyncRetrying` (already a direct dependency; same style as `error_recovery_service.py` / `production_limits_service.py`). The other 12 findings are poll/pacing/work-distribution loops — adjudication table below, no code changes.

### 1. `Database._with_busy_retry` (`src/database/facade.py`)

SQLite-busy retry on the shared write path. Behaviour preserved exactly:

- fixed delay ladder from `self._busy_retry_delays_sec` via `wait_chain(*(wait_fixed(d) ...))` — no jitter, no exponent;
- attempts = `len(delays) + 1` via `stop_after_attempt`;
- non-busy `OperationalError` re-raised immediately (`retry_if_exception(_is_retryable_busy_error)`);
- same per-retry and final warning logs; final failure raises `DatabaseBusyError` chained (`from`) to the last busy error.

### 2. `TelegramCommandDispatcher._update_command_safely` (`src/services/telegram_command_dispatcher.py`)

Unbounded exponential backoff on `DatabaseBusyError`. Behaviour preserved exactly:

- ladder `INITIAL, 2×, 4×, …` capped at `MAX` via `wait_exponential(multiplier=INITIAL, max=MAX)` — bit-identical float sequence (doubling is exact in binary);
- `retry_busy=False` → single attempt, busy swallowed with the same log line;
- non-busy exceptions swallowed with the same log line (status updates must never kill the run loop);
- `sleep=asyncio.sleep` keeps the existing test seam — suite patches of `mod.asyncio.sleep` still observe the retry sleeps;
- `CancelledError` still propagates (tenacity re-raises `BaseException`s, `except Exception` doesn't catch them) — `test_run_loop_cancelled_reraises_when_update_busy` stays green.

## tenacity trap discovered (for the #782 registry)

`AsyncRetrying` awaits the **result of** `fn()`, so `fn` must be an async callable. `_with_busy_retry` receives a **sync** `Callable` returning a coroutine (`lambda: begin_immediate(...)`). Without the `_wrap_async` adapter the coroutine was never awaited → `BEGIN IMMEDIATE` never ran → `transaction()` hit `cannot COMMIT - no transaction is active`, leaking out as `PytestUnraisableExceptionWarning` (which is an **error** under the project's `filterwarnings = ["error"]`, so it silently broke every DB write and red the whole suite). The adapter is one line (`async def _runner(): return await action()`); the dispatcher path is unaffected because its `_update` is already `async def`. Worth a line in #782 so future retry→tenacity conversions don't repeat it.

## Retry/lifecycle check (#958 trap)

Both loops are **local SQLite** retries — no network, no billing. `SQLITE_BUSY` means the statement did **not** execute, so a retry cannot double-apply a write. tenacity adds no hidden extra retry layer here (no SDK involved); attempt counts and delay sequences are pinned by tests.

## TDD / behavioural equivalence

7 characterisation tests were added **first** and verified green on the old implementation, then the swap landed with the tests untouched:

- `test_database.py`: exact sleep ladder on exhaustion; result returned after transient busy (slept exactly `delays[0]`); non-busy `OperationalError` raise-through with zero sleeps; `DatabaseBusyError.__cause__` is the last busy error.
- `test_telegram_command_dispatcher.py`: exponential ladder doubles and caps (computed from module constants); `retry_busy=False` single-shot without sleep; generic error swallowed without retry.

## Detector / baseline

- Findings for both converted functions are gone; `--fail-on-new` green.
- Baseline refreshed (13 → 12 entries): −2 fixed; pure path renames folded in (`agent/manager.py` → `agent/backends/_stream.py`, `telegram/collector.py` → `telegram/collector_mixins/*` — same findings, files moved by earlier refactors); +1 genuinely new finding recorded (`web/scheduler/context.py:236`, see table).

## Adjudication of the remaining 12 findings (proposal — owner decides, #782)

| Finding | Class | Proposal |
|---|---|---|
| `agent/backends/_stream.py:463` `_await_with_countdown` | deadline-extension ticker for streaming UX — no operation is ever re-attempted | keep (false positive) |
| `services/task_handlers/stats.py` `handle_stats_all` | worker-pool batch loop with flood-defer; retries delegated | keep (FP, same class as pool_dialogs #1114) |
| `telegram_command_dispatcher.py` `_run_loop` | infinite service poll loop (claim → dispatch); sleeps are idle pacing | keep |
| `unified_dispatcher.py` `_run_loop` | same | keep |
| `collector_mixins/collection.py` `collect_all_channels` | iterates *different* channels with inter-channel stagger; errors break/continue, never re-attempt | keep (FP) |
| `collector_mixins/stats.py` `collect_all_stats` | worker-pool with defer | keep (FP) |
| `pool_dialogs.py` `warm_all_dialogs`, `leave_channels` | already adjudicated FP — #1114, AST guards in #1149/#1176 | keep (guarded) |
| `pool_dialogs.py` `delete_dialogs` | same pattern as `leave_channels`: retry delegated to `run_with_flood_wait_retry`, loop iterates different dialogs | keep (FP) |
| `web/bootstrap.py` `_retry_telegram_pool_until_connected` | condition-driven reconnect loop with cooperative-shutdown checks between waits; tenacity is exception-driven — conversion would bury the shutdown logic | keep |
| `web/search/handlers.py` `_telegram_search_via_worker` | poll-until-deadline for a DB command status, not a failure retry | keep (FP) |
| `web/scheduler/context.py:236` `_dedupe_recent_unavailability_events` (NEW, counter) | group-by with **two** aggregates (count + max timestamp); `collections.Counter` covers only the count and would split a single-pass aggregation into two structures | propose keep |

Registry row (#782 journal):

| Дата | Находка (файл) | Стандартная замена | Решение | PR/issue |
|------|----------------|--------------------|---------|----------|
| 2026-07-10 | `database/facade.py` `_with_busy_retry`; `telegram_command_dispatcher.py` `_update_command_safely` (DB-busy retry) | tenacity.AsyncRetrying | заменено (этот PR) | this PR |
| 2026-07-10 | остальные 12 retry/counter-находок | — | предложение «оставить» (таблица выше), финальное слово за владельцем | this PR |

Not merging — owner reviews (retry→library is in the dual-review category per the task brief).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
