### PR TITLE
refactor: dedupe service/collector helper twins (#1135)

### DIFF
--- a/src/services/channel_analytics_service.py
+++ b/src/services/channel_analytics_service.py
@@ -310,12 +310,19 @@ class ChannelAnalyticsService:
             return stats[0].subscriber_count
         return None
 
-    async def _calc_err(self, channel_id: int, last_n: int = 20) -> float | None:
+    async def _engagement_rate(
+        self,
+        channel_id: int,
+        rows: list[dict],
+    ) -> float | None:
+        """ERR (Engagement Rate by Reach), in percent, for a set of message rows.
+
+        Shared body of `_calc_err` / `_calc_err24`: ``sum(engagement) /
+        (rows * subscribers) * 100``. ``None`` when the channel has no
+        subscribers or the message window is empty.
+        """
         sub_count = await self._get_subscriber_count(channel_id)
-        if not sub_count:
-            return None
-        rows = await self._db.repos.messages.get_err_data(channel_id, last_n)
-        if not rows:
+        if not sub_count or not rows:
             return None
         total_engagement = sum(
             (r.get("views") or 0)
@@ -326,18 +333,10 @@ class ChannelAnalyticsService:
         )
         return round(total_engagement / (len(rows) * sub_count) * 100, 2)
 
+    async def _calc_err(self, channel_id: int, last_n: int = 20) -> float | None:
+        rows = await self._db.repos.messages.get_err_data(channel_id, last_n)
+        return await self._engagement_rate(channel_id, rows)
+
     async def _calc_err24(self, channel_id: int) -> float | None:
-        sub_count = await self._get_subscriber_count(channel_id)
-        if not sub_count:
-            return None
         rows = await self._db.repos.messages.get_err24_data(channel_id)
-        if not rows:
-            return None
-        total_engagement = sum(
-            (r.get("views") or 0)
-            + (r.get("forwards") or 0)
-            + (r.get("reply_count") or 0)
-            + r.get("total_reactions", 0)
-            for r in rows
-        )
-        return round(total_engagement / (len(rows) * sub_count) * 100, 2)
+        return await self._engagement_rate(channel_id, rows)

--- a/src/services/photo_task_service.py
+++ b/src/services/photo_task_service.py
@@ -50,6 +50,52 @@ class PhotoTaskService:
             return PhotoSendMode.SEPARATE
         return send_mode
 
+    async def _create_send_batch_item(
+        self,
+        *,
+        phone: str,
+        target: PhotoTarget,
+        files: list[str],
+        send_mode: PhotoSendMode,
+        caption: str | None,
+        status: PhotoBatchStatus,
+        schedule_at: datetime | None = None,
+    ) -> tuple[int, int]:
+        """Create the PhotoBatch + its first PhotoBatchItem for an ad-hoc send.
+
+        Shared by :meth:`send_now` (status=RUNNING, stamps ``started_at``) and
+        :meth:`schedule_send` (status=SCHEDULED, stamps ``schedule_at``). Returns
+        ``(batch_id, item_id)``.
+        """
+        batch_id = await self._bundle.create_batch(
+            PhotoBatch(
+                phone=phone,
+                target_dialog_id=target.dialog_id,
+                target_title=target.title,
+                target_type=target.target_type,
+                send_mode=send_mode,
+                caption=caption,
+                status=status,
+            )
+        )
+        item_kwargs: dict = {
+            "batch_id": batch_id,
+            "phone": phone,
+            "target_dialog_id": target.dialog_id,
+            "target_title": target.title,
+            "target_type": target.target_type,
+            "file_paths": files,
+            "send_mode": send_mode,
+            "caption": caption,
+            "status": status,
+        }
+        if status == PhotoBatchStatus.RUNNING:
+            item_kwargs["started_at"] = datetime.now(timezone.utc)
+        elif schedule_at is not None:
+            item_kwargs["schedule_at"] = schedule_at
+        item_id = await self._bundle.create_item(PhotoBatchItem(**item_kwargs))
+        return batch_id, item_id
+
     async def send_now(
         self,
         *,
@@ -61,30 +107,13 @@ class PhotoTaskService:
     ) -> PhotoBatchItem:
         files = self.validate_files(file_paths)
         send_mode = self.normalize_mode(mode, len(files))
-        batch_id = await self._bundle.create_batch(
-            PhotoBatch(
-                phone=phone,
-                target_dialog_id=target.dialog_id,
-                target_title=target.title,
-                target_type=target.target_type,
-                send_mode=send_mode,
-                caption=caption,
-                status=PhotoBatchStatus.RUNNING,
-            )
-        )
-        item_id = await self._bundle.create_item(
-            PhotoBatchItem(
-                batch_id=batch_id,
-                phone=phone,
-                target_dialog_id=target.dialog_id,
-                target_title=target.title,
-                target_type=target.target_type,
-                file_paths=files,
-                send_mode=send_mode,
-                caption=caption,
-                status=PhotoBatchStatus.RUNNING,
-                started_at=datetime.now(timezone.utc),
-            )
+        batch_id, item_id = await self._create_send_batch_item(
+            phone=phone,
+            target=target,
+            files=files,
+            send_mode=send_mode,
+            caption=caption,
+            status=PhotoBatchStatus.RUNNING,
         )
         # Accumulate ids of files already published live on Telegram. In SEPARATE
         # mode send_now publishes file-by-file immediately, so if a later file
@@ -181,30 +210,14 @@ class PhotoTaskService:
     ) -> PhotoBatchItem:
         files = self.validate_files(file_paths)
         send_mode = self.normalize_mode(mode, len(files))
-        batch_id = await self._bundle.create_batch(
-            PhotoBatch(
-                phone=phone,
-                target_dialog_id=target.dialog_id,
-                target_title=target.title,
-                target_type=target.target_type,
-                send_mode=send_mode,
-                caption=caption,
-                status=PhotoBatchStatus.SCHEDULED,
-            )
-        )
-        item_id = await self._bundle.create_item(
-            PhotoBatchItem(
-                batch_id=batch_id,
-                phone=phone,
-                target_dialog_id=target.dialog_id,
-                target_title=target.title,
-                target_type=target.target_type,
-                file_paths=files,
-                send_mode=send_mode,
-                caption=caption,
-                schedule_at=schedule_at,
-                status=PhotoBatchStatus.SCHEDULED,
-            )
+        batch_id, item_id = await self._create_send_batch_item(
+            phone=phone,
+            target=target,
+            files=files,
+            send_mode=send_mode,
+            caption=caption,
+            status=PhotoBatchStatus.SCHEDULED,
+            schedule_at=schedule_at,
         )
         # Accumulate server-scheduled message ids progressively. In SEPARATE mode
         # send_now schedules files one-by-one; if a later file fails, the earlier

--- a/src/services/pipeline_nodes/handlers.py
+++ b/src/services/pipeline_nodes/handlers.py
@@ -32,6 +32,26 @@ except ImportError:  # pragma: no cover — handlers import path used without te
 logger = logging.getLogger(__name__)
 
 
+def _build_source_messages(messages: list) -> str:
+    """Render the ``context_messages`` list into the ``[header] text`` block fed to LLM/agent nodes.
+
+    Shared by the LLM-generate and agent-loop handlers — identical rendering of
+    each message (``[channel_title|username] stripped_text (id:.. date:..)``),
+    blank-separated. Empty/whitespace texts are dropped.
+    """
+    from datetime import datetime
+
+    source_parts: list[str] = []
+    for m in messages:
+        text = (m.text or "").strip()
+        if not text:
+            continue
+        header = m.channel_title or m.channel_username or ""
+        when = m.date.isoformat() if isinstance(m.date, datetime) else str(m.date)
+        source_parts.append(f"[{header}] {text} (id:{m.message_id} date:{when})")
+    return "\n\n".join(source_parts)
+
+
 def _current_node_id(services: dict, default: str = "?") -> str:
     """Return the node id for the currently-executing handler.
 
@@ -186,8 +206,6 @@ class LlmGenerateHandler(BaseNodeHandler):
         if provider_callable is None:
             raise RuntimeError("LlmGenerateHandler: no provider_callable in services")
 
-        from datetime import datetime
-
         from src.agent.prompt_template import render_prompt_template
 
         prompt_template = node_config.get("prompt_template") or context.get_global("prompt_template", "")
@@ -197,15 +215,7 @@ class LlmGenerateHandler(BaseNodeHandler):
 
         # Build source messages string from context
         messages = context.get_global("context_messages", [])
-        source_parts = []
-        for m in messages:
-            text = (m.text or "").strip()
-            if not text:
-                continue
-            header = m.channel_title or m.channel_username or ""
-            when = m.date.isoformat() if isinstance(m.date, datetime) else str(m.date)
-            source_parts.append(f"[{header}] {text} (id:{m.message_id} date:{when})")
-        source_messages = "\n\n".join(source_parts)
+        source_messages = _build_source_messages(messages)
 
         rendered = render_prompt_template(
             prompt_template,
@@ -842,8 +852,6 @@ class AgentLoopHandler(BaseNodeHandler):
         if provider_callable is None:
             raise RuntimeError("AgentLoopHandler: no provider_callable in services")
 
-        from datetime import datetime
-
         system_prompt = node_config.get("system_prompt", "Ты полезный ассистент.")
         model = node_config.get("model") or services.get("default_model") or ""
         max_tokens = int(node_config.get("max_tokens", 2000))
@@ -870,18 +878,11 @@ class AgentLoopHandler(BaseNodeHandler):
         full_system = system_prompt + tool_desc + self._REACT_SUFFIX
 
         # Build source messages string from context
-        messages = context.get_global("context_messages", [])
-        source_parts = []
-        for m in messages:
-            text = (m.text or "").strip()
-            if not text:
-                continue
-            header = m.channel_title or m.channel_username or ""
-            when = m.date.isoformat() if isinstance(m.date, datetime) else str(m.date)
-            source_parts.append(f"[{header}] {text} (id:{m.message_id} date:{when})")
-        source_messages = "\n\n".join(source_parts)
+        source_messages = _build_source_messages(context.get_global("context_messages", []))
 
-        user_message = f"Сообщения для анализа:\n\n{source_messages}" if source_parts else "Нет сообщений для анализа."
+        user_message = (
+            f"Сообщения для анализа:\n\n{source_messages}" if source_messages else "Нет сообщений для анализа."
+        )
 
         conversation = [
             {"role": "system", "content": full_system},

--- a/src/services/telegram_actions.py
+++ b/src/services/telegram_actions.py
@@ -619,6 +619,40 @@ class TelegramActionService:
             await client.kick_participant(entity, user)
             return TelegramActionResult(phone=acquired_phone)
 
+    async def _fetch_message_with_flood_wait(
+        self,
+        client,
+        acquired_phone: str,
+        entity,
+        message_id: int,
+        *,
+        operation_prefix: str,
+    ):
+        """Resolve a single message by id under ``run_with_flood_wait``, or raise.
+
+        Shared body of :meth:`download_media` / :meth:`download_media_sized`:
+        fetch the one message via ``iter_messages(ids=...)`` under the flood-wait
+        wrapper, then raise :class:`TelegramActionMessageNotFoundError` when the
+        id no longer exists. Returns the resolved message object.
+        """
+        message = None
+
+        async def _lookup_message() -> None:
+            nonlocal message
+            async for current_message in client.iter_messages(entity, ids=int(message_id)):
+                message = current_message
+                break
+
+        await run_with_flood_wait(
+            _lookup_message(),
+            operation=f"{operation_prefix}_lookup",
+            phone=acquired_phone,
+            pool=self._pool,
+        )
+        if message is None:
+            raise TelegramActionMessageNotFoundError("message_not_found")
+        return message
+
     async def download_media(
         self,
         *,
@@ -631,22 +665,9 @@ class TelegramActionService:
         output_resolved = await asyncio.to_thread(_ensure_resolved_dir, output_dir)
         async with self._client(phone=phone, native=True) as (client, acquired_phone):
             entity = await self._resolve_entity(client, phone=acquired_phone, identifier=chat_id)
-            message = None
-
-            async def _lookup_message() -> None:
-                nonlocal message
-                async for current_message in client.iter_messages(entity, ids=int(message_id)):
-                    message = current_message
-                    break
-
-            await run_with_flood_wait(
-                _lookup_message(),
-                operation=f"{operation_prefix}_lookup",
-                phone=acquired_phone,
-                pool=self._pool,
+            message = await self._fetch_message_with_flood_wait(
+                client, acquired_phone, entity, message_id, operation_prefix=operation_prefix
             )
-            if message is None:
-                raise TelegramActionMessageNotFoundError("message_not_found")
             path = await run_with_flood_wait(
                 client.download_media(message, file=str(output_resolved)),
                 operation=operation_prefix,
@@ -679,22 +700,9 @@ class TelegramActionService:
         root_resolved = await asyncio.to_thread(_ensure_resolved_dir, output_dir)
         async with self._client(phone=phone, native=True) as (client, acquired_phone):
             entity = await self._resolve_entity(client, phone=acquired_phone, identifier=chat_id)
-            message = None
-
-            async def _lookup_message() -> None:
-                nonlocal message
-                async for current_message in client.iter_messages(entity, ids=int(message_id)):
-                    message = current_message
-                    break
-
-            await run_with_flood_wait(
-                _lookup_message(),
-                operation=f"{operation_prefix}_lookup",
-                phone=acquired_phone,
-                pool=self._pool,
+            message = await self._fetch_message_with_flood_wait(
+                client, acquired_phone, entity, message_id, operation_prefix=operation_prefix
             )
-            if message is None:
-                raise TelegramActionMessageNotFoundError("message_not_found")
             if getattr(message, "media", None) is None:
                 raise TelegramActionNoMediaError("no_media")
 

--- a/src/telegram/collector_mixins/stats.py
+++ b/src/telegram/collector_mixins/stats.py
@@ -42,51 +42,68 @@ class StatsMixin:
     def is_stats_running(self: "Collector") -> bool:
         return self._stats_running or self._stats_all_running
 
-    def stats_worker_count(self: "Collector") -> int:
-        configured = max(1, int(getattr(self._config, "stats_worker_count", 3) or 1))
+    def _configured_worker_count(
+        self: "Collector", attr: str, default: int
+    ) -> int:
+        """Configured worker count for an attr, clamped to connected clients.
+
+        Shared by :meth:`stats_worker_count` / :meth:`stats_all_worker_count`:
+        ``max(1, min(configured, connected))`` when clients are connected, else
+        the configured value.
+        """
+        configured = max(1, int(getattr(self._config, attr, default) or 1))
         connected = len(getattr(self._pool, "clients", {}) or {})
         if connected <= 0:
             return configured
         return max(1, min(configured, connected))
+
+    def stats_worker_count(self: "Collector") -> int:
+        return self._configured_worker_count("stats_worker_count", 3)
 
     def stats_all_worker_count(self: "Collector") -> int:
-        configured = max(1, int(getattr(self._config, "stats_all_worker_count", 1) or 1))
-        connected = len(getattr(self._pool, "clients", {}) or {})
-        if connected <= 0:
-            return configured
-        return max(1, min(configured, connected))
+        return self._configured_worker_count("stats_all_worker_count", 1)
+
+    async def _available_worker_count(
+        self: "Collector", *, attr: str, default: int, fallback: int, log_label: str
+    ) -> int:
+        """Live-available worker count for an attr, falling back to the configured value.
+
+        Shared by :meth:`available_stats_worker_count` /
+        :meth:`available_stats_all_worker_count`: read
+        ``available_stats_client_count`` from the pool (sync or async), and when
+        positive return ``max(1, min(configured, available))`` (or ``1`` when
+        the pool reports none), else the configured ``fallback``.
+        """
+        configured = max(1, int(getattr(self._config, attr, default) or 1))
+        counter = getattr(self._pool, "available_stats_client_count", None)
+        if callable(counter):
+            try:
+                count = counter()
+                if asyncio.iscoroutine(count):
+                    count = await count
+                available = int(count)
+                if available > 0:
+                    return max(1, min(configured, available))
+                return 1
+            except Exception:
+                logger.debug("Failed to read available %s client count", log_label, exc_info=True)
+        return fallback
 
     async def available_stats_worker_count(self: "Collector") -> int:
-        configured = max(1, int(getattr(self._config, "stats_worker_count", 3) or 1))
-        counter = getattr(self._pool, "available_stats_client_count", None)
-        if callable(counter):
-            try:
-                count = counter()
-                if asyncio.iscoroutine(count):
-                    count = await count
-                available = int(count)
-                if available > 0:
-                    return max(1, min(configured, available))
-                return 1
-            except Exception:
-                logger.debug("Failed to read available stats client count", exc_info=True)
-        return self.stats_worker_count()
+        return await self._available_worker_count(
+            attr="stats_worker_count",
+            default=3,
+            fallback=self.stats_worker_count(),
+            log_label="stats",
+        )
 
     async def available_stats_all_worker_count(self: "Collector") -> int:
-        configured = max(1, int(getattr(self._config, "stats_all_worker_count", 1) or 1))
-        counter = getattr(self._pool, "available_stats_client_count", None)
-        if callable(counter):
-            try:
-                count = counter()
-                if asyncio.iscoroutine(count):
-                    count = await count
-                available = int(count)
-                if available > 0:
-                    return max(1, min(configured, available))
-                return 1
-            except Exception:
-                logger.debug("Failed to read available stats-all client count", exc_info=True)
-        return self.stats_all_worker_count()
+        return await self._available_worker_count(
+            attr="stats_all_worker_count",
+            default=1,
+            fallback=self.stats_all_worker_count(),
+            log_label="stats-all",
+        )
 
     def set_stats_all_running(self: "Collector", running: bool) -> None:
         self._stats_all_running = running


### PR DESCRIPTION
Part of #1135 (axis 5 of #1130). Five genuine (non-parity) clones across `services/` and `telegram/`.

## Clones & extraction

| Clone | Extracted helper | Notes |
|---|---|---|
| `channel_analytics_service._calc_err` ↔ `_calc_err24` | `_engagement_rate(channel_id, rows)` | Engagement formula `sum / (rows*subs) * 100`. Each caller keeps its own data fetch (`get_err_data` vs `get_err24_data`). |
| `pipeline_nodes/handlers` source block (LlmGenerate + AgentLoop) | module-level `_build_source_messages(messages)` | Identical `[header] text (id:.. date:..)` rendering, blank-joined; blank texts dropped. The AgentLoop `user_message` truthiness guard is preserved (joined string empty ⟺ parts list empty). |
| `telegram_actions.download_media` ↔ `download_media_sized` lookup | `_fetch_message_with_flood_wait(...)` | Resolve-entity + `iter_messages(ids=)` under flood-wait + `MessageNotFoundError` raise. |
| `photo_task_service.send_now` ↔ `schedule_send` batch+item ctor | `_create_send_batch_item(..., status, schedule_at)` → `(batch_id, item_id)` | Parameterized by status + `started_at` vs `schedule_at`. |
| `collector_mixins/stats` `stats_*worker_count` + `available_stats_*worker_count` (2 pairs) | `_configured_worker_count`, `_available_worker_count` | Twins differed only by config attr / default / log label. |

## Verification
- ruff clean on all five files.
- 1359 targeted tests pass (`analytics/err/pipeline_node/telegram_action/download_media/photo_task/collector_stats/worker_count/source_messages`).

## jscpd
- Removed: the five clones above.
- `Total: 0.67%` (49 clones) — flat vs. the PR-2 state. The remaining `services/telegram_actions.py:575↔594` and `collector_mixins/cancellation↔stats` hits are parity-style Telegram-error-handling blocks and the shared TYPE_CHECKING `Collector` Protocol (see #1135 parity notes), intentionally untouched.

Part of #1135 / #1130. Not for merge — review requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)