### PR TITLE
refactor(agent): drop two verified-dead symbols (vulture, #1136)

### DIFF
--- a/src/agent/provider_registry.py
+++ b/src/agent/provider_registry.py
@@ -14,11 +14,6 @@ ZAI_LEGACY_ANTHROPIC_BASE_URLS = {
     "https://api.z.ai/api/anthropic",
     "https://api.z.ai/api/anthropic/v1",
 }
-ZAI_BASE_URL_REQUIRED_HINT = (
-    "Z.AI Base URL is optional. Empty value defaults to "
-    "https://api.z.ai/api/coding/paas/v4 for the GLM Coding Plan; use "
-    "https://api.z.ai/api/paas/v4 only for pay-per-token PaaS access."
-)
 
 
 def is_zai_legacy_anthropic_base_url(base_url: str = "") -> bool:

--- a/src/agent/tools/_registry.py
+++ b/src/agent/tools/_registry.py
@@ -208,15 +208,6 @@ def arg_csv_ints(
     return result
 
 
-def require_args(args: dict[str, Any], *names: str) -> dict[str, str]:
-    values = {name: arg_str(args, name) for name in names}
-    missing = [name for name, value in values.items() if not value]
-    if missing:
-        joined = ", ".join(missing)
-        raise ToolInputError(f"{joined} обязательны.")
-    return values
-
-
 def normalize_phone(phone: object) -> str:
     """Ensure phone starts with '+' — models sometimes omit it."""
     if phone is None:


### PR DESCRIPTION
Part of #1136 (vulture axis of epic #1130). Two symbols deleted; each verified dead across all five surfaces (FastAPI/Web/CLI/agent/TUI) before removal. Per #1136, "dead by graph" ≠ "unneeded" — so every candidate below passed a full grep + git-history check before deletion.

## Deletions

### 1. `src/agent/tools/_registry.py` — `require_args()` (8 lines)
- **Repo-wide grep** (`src/ tests/ scripts/ docs/ conftest.py`, across `.py/.txt/.md/.rst`): exactly **1 hit — the definition**. No string references, no `__all__` export, no wildcard import of `_registry` (the repo has zero `import \*` statements), no `getattr` dispatch by that name.
- **git history**: born in #534 (refactor sharing tool-context helpers) **already without a caller or test** — `git show 0fdae381 | grep -c require_args` → 1 (definition only). Dead since birth.
- **Five surfaces**: it's a private helper inside the agent-tool registry; tools are reached via the registry, never via this function.

### 2. `src/agent/provider_registry.py` — `ZAI_BASE_URL_REQUIRED_HINT` constant (5 lines)
- **Repo-wide grep**: **1 hit — the definition**. The hint text ("Z.AI Base URL is optional…") is not duplicated anywhere else.
- **git history**: born *used* in #528 (Z.AI Coding Plan support: assigned to `_init_error`, returned from a check, and raised in a `RuntimeError`). The last consumer was removed in #535 (canonicalize provider metadata) — `git grep ZAI_BASE_URL_REQUIRED_HINT f49ce429` → definition only. Orphaned leftover of that refactor.
- Sibling `ZAI_*` constants (`ZAI_GENERAL_BASE_URL`, `ZAI_CODING_BASE_URL`, `ZAI_DEFAULT_BASE_URL`, `ZAI_LEGACY_ANTHROPIC_BASE_URLS`) remain — they are used.

## Verification (no regression guard possible — code is gone, so proof = green suite + this note)
- `ruff check src/agent/tools/_registry.py src/agent/provider_registry.py` — clean.
- `python -c "import src.agent.tools._registry, src.agent.provider_registry"` — OK.
- Full suite (`pytest tests/ -m "not aiosqlite_serial" -n auto` then `-m aiosqlite_serial`) — green (the only unrelated failures are pre-existing on `origin/main`: `tests/test_quality_scoring_service.py` and the xdist-flaky `tests/routes/test_debug_routes.py::test_debug_timing_page`; both deselected and reproduced on clean main).

## Not deleted in this PR (doubtful → left for owner decision)
- `src/agent/tools/_photo_loader_runtime.py::resolve_photo_target_id` — 0 production callers (last call migrated to `resolve_photo_target` in #842), but its docstring explicitly calls it a *"Backward-compatible shim"*. Intentional compat surface → **not** deleted without explicit owner "yes".

Part of #1136 / #1130.